### PR TITLE
DSS-404: Adds units to box-shadow tokens

### DIFF
--- a/libs/core/tokens/tokens.json
+++ b/libs/core/tokens/tokens.json
@@ -235,16 +235,16 @@
       "value": [
         {
           "x": "0",
-          "y": "1",
-          "blur": "2",
+          "y": "1px",
+          "blur": "2px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.06)",
           "type": "dropShadow"
         },
         {
           "x": "0",
-          "y": "1",
-          "blur": "3",
+          "y": "1px",
+          "blur": "3px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.1)",
           "type": "dropShadow"
@@ -256,8 +256,8 @@
       "value": [
         {
           "x": "0",
-          "y": "2",
-          "blur": "4",
+          "y": "2px",
+          "blur": "4px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.12)",
           "type": "dropShadow"
@@ -265,7 +265,7 @@
         {
           "x": "0",
           "y": "0",
-          "blur": "2",
+          "blur": "2px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.08)",
           "type": "dropShadow"
@@ -277,8 +277,8 @@
       "value": [
         {
           "x": "0",
-          "y": "8",
-          "blur": "14",
+          "y": "8px",
+          "blur": "14px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.16)",
           "type": "dropShadow"
@@ -286,7 +286,7 @@
         {
           "x": "0",
           "y": "0",
-          "blur": "4",
+          "blur": "4px",
           "spread": "0",
           "color": "rgba(0, 0, 0, 0.08)",
           "type": "dropShadow"
@@ -297,8 +297,8 @@
     "lg": {
       "value": {
         "x": "0",
-        "y": "8",
-        "blur": "40",
+        "y": "8px",
+        "blur": "40px",
         "spread": "0",
         "color": "rgba(0, 0, 0, 0.24)",
         "type": "dropShadow"
@@ -521,5 +521,20 @@
       "value": "60px",
       "type": "lineHeights"
     }
+  },
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": [
+      "color",
+      "box-shadow",
+      "border",
+      "font-family",
+      "font-weight",
+      "font-size",
+      "spacing",
+      "border-radius",
+      "letter-spacing",
+      "line-height"
+    ]
   }
 }

--- a/libs/core/tokens/tokens.json
+++ b/libs/core/tokens/tokens.json
@@ -521,20 +521,5 @@
       "value": "60px",
       "type": "lineHeights"
     }
-  },
-  "$themes": [],
-  "$metadata": {
-    "tokenSetOrder": [
-      "color",
-      "box-shadow",
-      "border",
-      "font-family",
-      "font-weight",
-      "font-size",
-      "spacing",
-      "border-radius",
-      "letter-spacing",
-      "line-height"
-    ]
   }
 }


### PR DESCRIPTION
# Description

Updates box-shadow tokens to include the px unit.

Fixes: [DSS-404](https://kajabi.atlassian.net/browse/DSS-404)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Sage versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-404]: https://kajabi.atlassian.net/browse/DSS-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ