### PR TITLE
chore: remove mdx extension from '*.stories.' regex

### DIFF
--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
   stories: [
     "../src/**/*.docs.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx|mdx)"
+    "../src/**/*.stories.@(js|jsx|ts|tsx)"
   ],
   addons: [
     {


### PR DESCRIPTION
# Description

This is a clean-up task to ensure all stories are in the proper format.

Documentation style text lives in `.docs.stories.mdx`
Code based stories live in `.stories.[js|jsx|ts|tsx]` 

Fixes #(issue)
[DSS-288](https://kajabi.atlassian.net/browse/DSS-288)

## Type of change
- [X]  No impact on functionality of code



[DSS-288]: https://kajabi.atlassian.net/browse/DSS-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ