### PR TITLE
chore: update development server configuration

### DIFF
--- a/libs/core/stencil.config.ts
+++ b/libs/core/stencil.config.ts
@@ -8,6 +8,10 @@ import { sass } from '@stencil/sass';
 export const config: Config = {
   namespace: 'pine-core',
   globalStyle: 'src/global/styles/app.scss',
+  devServer: {
+    openBrowser: false,
+    port: 7100
+  },
   outputTargets: [
     {
       type: 'dist',

--- a/libs/icons/stencil.config.ts
+++ b/libs/icons/stencil.config.ts
@@ -5,6 +5,10 @@ import { sass } from '@stencil/sass';
 
 export const config: Config = {
   namespace: 'pds-icons',
+  devServer: {
+    openBrowser: false,
+    port: 7200
+  },
   plugins: [sass()],
   outputTargets: [
     {


### PR DESCRIPTION
# Description
This PR handles a couple of nuisances with the Stencil Development servers.

* The port will change upon a restart. This will now make the port static
* Browser window opening upon start. This will no longer be the case
  *  Core: `http://localhost:7100`
  *  icons: `http://localhost:7200`