### PR TITLE
[DSS-431]: feat(copytext) - Copy Text

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -143,6 +143,7 @@ export namespace Components {
     interface PdsCopytext {
         /**
           * Determines whether `copytext` should have a border.
+          * @defaultValue true
          */
         "border": boolean;
         /**
@@ -151,10 +152,12 @@ export namespace Components {
         "componentId": string;
         /**
           * Determines whether `copytext` should expand to the full width of its container.
+          * @defaultValue false
          */
         "fullWidth": boolean;
         /**
           * Determines whether the `value` should truncate and display with an ellipsis.
+          * @defaultValue false
          */
         "truncate": boolean;
         /**
@@ -839,6 +842,7 @@ declare namespace LocalJSX {
     interface PdsCopytext {
         /**
           * Determines whether `copytext` should have a border.
+          * @defaultValue true
          */
         "border"?: boolean;
         /**
@@ -847,6 +851,7 @@ declare namespace LocalJSX {
         "componentId"?: string;
         /**
           * Determines whether `copytext` should expand to the full width of its container.
+          * @defaultValue false
          */
         "fullWidth"?: boolean;
         /**
@@ -855,6 +860,7 @@ declare namespace LocalJSX {
         "onPdsCopyTextClick"?: (event: PdsCopytextCustomEvent<any>) => void;
         /**
           * Determines whether the `value` should truncate and display with an ellipsis.
+          * @defaultValue false
          */
         "truncate"?: boolean;
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -141,8 +141,17 @@ export namespace Components {
         "variant": 'text' | 'tag' | 'dropdown';
     }
     interface PdsCopytext {
+        /**
+          * Determines whether copytext should have a border.
+         */
         "border": boolean;
+        /**
+          * Determines whether copytext should expand to the full width of its container.
+         */
         "fullWidth": boolean;
+        /**
+          * The string that is displayed and that is also copied to the clipboard upon interaction.
+         */
         "value": string;
     }
     interface PdsDivider {
@@ -816,8 +825,17 @@ declare namespace LocalJSX {
         "variant"?: 'text' | 'tag' | 'dropdown';
     }
     interface PdsCopytext {
+        /**
+          * Determines whether copytext should have a border.
+         */
         "border"?: boolean;
+        /**
+          * Determines whether copytext should expand to the full width of its container.
+         */
         "fullWidth"?: boolean;
+        /**
+          * The string that is displayed and that is also copied to the clipboard upon interaction.
+         */
         "value"?: string;
     }
     interface PdsDivider {

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -543,6 +543,10 @@ export interface PdsChipCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsChipElement;
 }
+export interface PdsCopytextCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPdsCopytextElement;
+}
 export interface PdsInputCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsInputElement;
@@ -845,6 +849,10 @@ declare namespace LocalJSX {
           * Determines whether `copytext` should expand to the full width of its container.
          */
         "fullWidth"?: boolean;
+        /**
+          * Event when copyText button is clicked.
+         */
+        "onPdsCopyTextClick"?: (event: PdsCopytextCustomEvent<any>) => void;
         /**
           * Determines whether the `value` should truncate and display with an ellipsis.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -142,13 +142,17 @@ export namespace Components {
     }
     interface PdsCopytext {
         /**
-          * Determines whether copytext should have a border.
+          * Determines whether `copytext` should have a border.
          */
         "border": boolean;
         /**
-          * Determines whether copytext should expand to the full width of its container.
+          * Determines whether `copytext` should expand to the full width of its container.
          */
         "fullWidth": boolean;
+        /**
+          * Determines whether the `value` should truncate and display with an ellipsis.
+         */
+        "truncate": boolean;
         /**
           * The string that is displayed and that is also copied to the clipboard upon interaction.
          */
@@ -826,13 +830,17 @@ declare namespace LocalJSX {
     }
     interface PdsCopytext {
         /**
-          * Determines whether copytext should have a border.
+          * Determines whether `copytext` should have a border.
          */
         "border"?: boolean;
         /**
-          * Determines whether copytext should expand to the full width of its container.
+          * Determines whether `copytext` should expand to the full width of its container.
          */
         "fullWidth"?: boolean;
+        /**
+          * Determines whether the `value` should truncate and display with an ellipsis.
+         */
+        "truncate"?: boolean;
         /**
           * The string that is displayed and that is also copied to the clipboard upon interaction.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -140,6 +140,11 @@ export namespace Components {
          */
         "variant": 'text' | 'tag' | 'dropdown';
     }
+    interface PdsCopytext {
+        "border": boolean;
+        "fullWidth": boolean;
+        "value": string;
+    }
     interface PdsDivider {
         /**
           * Adds offset margin/padding to expand the width (horizontal) or the height (vertical) of divider.
@@ -570,6 +575,12 @@ declare global {
         prototype: HTMLPdsChipElement;
         new (): HTMLPdsChipElement;
     };
+    interface HTMLPdsCopytextElement extends Components.PdsCopytext, HTMLStencilElement {
+    }
+    var HTMLPdsCopytextElement: {
+        prototype: HTMLPdsCopytextElement;
+        new (): HTMLPdsCopytextElement;
+    };
     interface HTMLPdsDividerElement extends Components.PdsDivider, HTMLStencilElement {
     }
     var HTMLPdsDividerElement: {
@@ -647,6 +658,7 @@ declare global {
         "pds-button": HTMLPdsButtonElement;
         "pds-checkbox": HTMLPdsCheckboxElement;
         "pds-chip": HTMLPdsChipElement;
+        "pds-copytext": HTMLPdsCopytextElement;
         "pds-divider": HTMLPdsDividerElement;
         "pds-image": HTMLPdsImageElement;
         "pds-input": HTMLPdsInputElement;
@@ -802,6 +814,11 @@ declare namespace LocalJSX {
           * @defaultValue 'text'
          */
         "variant"?: 'text' | 'tag' | 'dropdown';
+    }
+    interface PdsCopytext {
+        "border"?: boolean;
+        "fullWidth"?: boolean;
+        "value"?: string;
     }
     interface PdsDivider {
         /**
@@ -1197,6 +1214,7 @@ declare namespace LocalJSX {
         "pds-button": PdsButton;
         "pds-checkbox": PdsCheckbox;
         "pds-chip": PdsChip;
+        "pds-copytext": PdsCopytext;
         "pds-divider": PdsDivider;
         "pds-image": PdsImage;
         "pds-input": PdsInput;
@@ -1219,6 +1237,7 @@ declare module "@stencil/core" {
             "pds-button": LocalJSX.PdsButton & JSXBase.HTMLAttributes<HTMLPdsButtonElement>;
             "pds-checkbox": LocalJSX.PdsCheckbox & JSXBase.HTMLAttributes<HTMLPdsCheckboxElement>;
             "pds-chip": LocalJSX.PdsChip & JSXBase.HTMLAttributes<HTMLPdsChipElement>;
+            "pds-copytext": LocalJSX.PdsCopytext & JSXBase.HTMLAttributes<HTMLPdsCopytextElement>;
             "pds-divider": LocalJSX.PdsDivider & JSXBase.HTMLAttributes<HTMLPdsDividerElement>;
             "pds-image": LocalJSX.PdsImage & JSXBase.HTMLAttributes<HTMLPdsImageElement>;
             "pds-input": LocalJSX.PdsInput & JSXBase.HTMLAttributes<HTMLPdsInputElement>;

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -836,7 +836,7 @@ declare namespace LocalJSX {
         /**
           * The string that is displayed and that is also copied to the clipboard upon interaction.
          */
-        "value"?: string;
+        "value": string;
     }
     interface PdsDivider {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -146,6 +146,10 @@ export namespace Components {
          */
         "border": boolean;
         /**
+          * String used for the component `id` attribute.
+         */
+        "componentId": string;
+        /**
           * Determines whether `copytext` should expand to the full width of its container.
          */
         "fullWidth": boolean;
@@ -154,7 +158,7 @@ export namespace Components {
          */
         "truncate": boolean;
         /**
-          * The string that is displayed and that is also copied to the clipboard upon interaction.
+          * String that is displayed and that is also copied to the clipboard upon interaction.
          */
         "value": string;
     }
@@ -834,6 +838,10 @@ declare namespace LocalJSX {
          */
         "border"?: boolean;
         /**
+          * String used for the component `id` attribute.
+         */
+        "componentId"?: string;
+        /**
           * Determines whether `copytext` should expand to the full width of its container.
          */
         "fullWidth"?: boolean;
@@ -842,7 +850,7 @@ declare namespace LocalJSX {
          */
         "truncate"?: boolean;
         /**
-          * The string that is displayed and that is also copied to the clipboard upon interaction.
+          * String that is displayed and that is also copied to the clipboard upon interaction.
          */
         "value": string;
     }

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -70,7 +70,7 @@ export namespace Components {
         /**
           * Sets button variant styles as outlined in Figma documentation
          */
-        "variant": 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive';
+        "variant": 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive' | 'unstyled';
     }
     interface PdsCheckbox {
         /**
@@ -754,7 +754,7 @@ declare namespace LocalJSX {
         /**
           * Sets button variant styles as outlined in Figma documentation
          */
-        "variant"?: 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive';
+        "variant"?: 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive' | 'unstyled';
     }
     interface PdsCheckbox {
         /**

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -85,3 +85,15 @@
   --color: #202327;
   --color-disabled: #8d939a;
 }
+
+.pds-button--unstyled {
+  --background-color: transparent;
+  --background-color-hover: transparent;
+  --background-color-disabled: transparent;
+  --color: inherit;
+  border: 0;
+  margin: 0;
+  min-height: auto;
+  padding: 0;
+  width: inherit;
+}

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -12,7 +12,7 @@ export class PdsButton {
   /**
    * Sets button variant styles as outlined in Figma documentation
     */
-  @Prop() variant: 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive' = 'primary';
+  @Prop() variant: 'primary' | 'secondary' | 'accent' | 'disclosure' | 'destructive' | 'unstyled'  = 'primary';
 
   /**
    * Displays icon before text when icon string matches an icon name

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -7,15 +7,28 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                     | Type                                                                    | Default     |
-| ---------- | ---------- | --------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------- |
-| `disabled` | `disabled` | Toggles disabled state of button                                | `boolean`                                                               | `false`     |
-| `icon`     | `icon`     | Displays icon before text when icon string matches an icon name | `string`                                                                | `null`      |
-| `name`     | `name`     | Provides button with a submittable name                         | `string`                                                                | `undefined` |
-| `type`     | `type`     | Provides button with a type                                     | `"button" \| "reset" \| "submit"`                                       | `'button'`  |
-| `value`    | `value`    | Provides button with a submittable value                        | `string`                                                                | `undefined` |
-| `variant`  | `variant`  | Sets button variant styles as outlined in Figma documentation   | `"accent" \| "destructive" \| "disclosure" \| "primary" \| "secondary"` | `'primary'` |
+| Property   | Attribute  | Description                                                     | Type                                                                                  | Default     |
+| ---------- | ---------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------- |
+| `disabled` | `disabled` | Toggles disabled state of button                                | `boolean`                                                                             | `false`     |
+| `icon`     | `icon`     | Displays icon before text when icon string matches an icon name | `string`                                                                              | `null`      |
+| `name`     | `name`     | Provides button with a submittable name                         | `string`                                                                              | `undefined` |
+| `type`     | `type`     | Provides button with a type                                     | `"button" \| "reset" \| "submit"`                                                     | `'button'`  |
+| `value`    | `value`    | Provides button with a submittable value                        | `string`                                                                              | `undefined` |
+| `variant`  | `variant`  | Sets button variant styles as outlined in Figma documentation   | `"accent" \| "destructive" \| "disclosure" \| "primary" \| "secondary" \| "unstyled"` | `'primary'` |
 
+
+## Dependencies
+
+### Used by
+
+ - [pds-copytext](../pds-copytext)
+
+### Graph
+```mermaid
+graph TD;
+  pds-copytext --> pds-button
+  style pds-button fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -34,6 +34,22 @@ describe('pds-button', () => {
     `);
   });
 
+  it('renders unstyled button', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button variant="unstyled"></pds-button>`,
+    });
+    expect(root).toEqualHtml(`
+      <pds-button variant="unstyled">
+        <mock:shadow-root>
+          <button class="pds-button pds-button--unstyled" type="button">
+            <slot></slot>
+          </button>
+        </mock:shadow-root>
+      </pds-button>
+    `);
+  });
+
   it('renders disabled button', async () => {
     const {root} = await newSpecPage({
       components: [PdsButton],
@@ -55,7 +71,7 @@ describe('pds-button', () => {
       components: [PdsButton],
       html: `<pds-button icon="trashIcon"></pds-button>`,
     });
-    const svg = root.shadowRoot.querySelector('svg');
+    const svg = root?.shadowRoot?.querySelector('svg');
     expect(svg).not.toBeNull();
   });
 
@@ -71,7 +87,7 @@ describe('pds-button', () => {
     const form = root.doc.querySelector<HTMLFormElement>("form");
     const eventSpy = jest.fn();
     form?.addEventListener("reset", eventSpy());
-    const button = document.querySelector<HTMLPdsButtonElement>('pds-button');
+    const button = document.querySelector<HTMLButtonElement>('pds-button');
     button?.click();
     await root.waitForChanges();
     expect(eventSpy).toHaveBeenCalled();

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -1,30 +1,44 @@
 :host(.pds-copytext) {
+
+  --background: var(--pine-color-base-white);
+  --background-hover: var(--pine-color-neutral-grey-200);
+  --border: var(--pine-border-interactive);
+  --border-hover: var(--pine-border-interactive-hover-color);
+  --border-radius: var(--pine-border-radius-md); // 10px
+  --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
+  --color-hover: var(--pine-color-neutral-charcoal-400);
+  --font-size: var(--pine-font-size-body); // 16px
+  --font-weight: var(--pine-font-weight-medium); // 500
+  --spacing-sm: var(--pine-spacing-sm); // 16px
+  --spacing-xs: var(--pine-spacing-xs); // 8px
+
   button {
     align-items: center;
-    background: #FFF;
+    background: var(--background);
     border: 0;
-    border-radius: 8px;
+    border-radius: var(--border-radius);
     display: flex;
-    font-size: 16px;
-    font-weight: var(--pine-font-weight-medium);
-    padding: 8px;
+    font-size: var(--font-size);
+    font-weight: var(--font-weight);
+    padding: var(--spacing-xs);
 
     &:hover {
-      background-color: #f6f8f8;
-      color: #202327;
+      background-color: var(--background-hover);
+      color: var(--color-hover);
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 4px var(--pine-color-primary-200);
+      box-shadow: var(--box-shadow-focus);
       outline: none;
     }
 
     span {
-      margin-right: 8px;
+      margin-right: var(--spacing-sm);
     }
   }
 
   // bordered
+
   &:host(.pds-copytext--bordered) {
     border: 0;
     padding: 0;
@@ -38,19 +52,21 @@
     }
 
     span {
-      border: 1px solid #d3d5d9;
-      border-radius: 8px;
-      padding: 8px 16px;
+      border: var(--border);
+      border-radius: var(--border-radius);
+      padding-block: var(--spacing-xs);
+      padding-inline: var(--spacing-sm);
     }
 
     :hover {
       span {
-        border-color: #b5bac0
+        border-color: var(--border-hover)
       }
     }
   }
 
   // full width
+
   &:host(.pds-copytext--full-width) {
     width: 100%;
 

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -13,12 +13,12 @@
   --spacing-xs: var(--pine-spacing-xs); // 8px
   --spacing-xxs: var(--pine-spacing-xxs); // 4px
 
-  button {
+  pds-button {
     align-items: center;
     background: var(--background);
     border: 0;
     border-radius: var(--border-radius);
-    display: flex;
+    display: inline-flex;
     font-size: var(--font-size);
     font-weight: var(--font-weight);
     max-width: 100%;
@@ -50,7 +50,7 @@
     border: 0;
     padding: 0;
 
-    button {
+    pds-button {
       padding: 0;
 
       &:hover {
@@ -76,9 +76,11 @@
   // full width
 
   &:host(.pds-copytext--full-width) {
+    display: flex;
     width: 100%;
 
-    button {
+    pds-button {
+      display: flex;
       justify-content: space-between;
       width: 100%;
 
@@ -92,10 +94,16 @@
   // truncated
 
   &:host(.pds-copytext--truncated) {
-    span {
-      overflow: hidden;
-      text-overflow: ellipsis;
+    pds-button {
+      display: flex;
       width: 100%;
+
+      span {
+        overflow: hidden;
+        text-align: left;
+        text-overflow: ellipsis;
+        width: 100%;
+      }
     }
   }
 }

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -35,7 +35,7 @@
     }
 
     span {
-      margin-right: var(--spacing-sm);
+      margin-inline-end: var(--spacing-xs);
       white-space: nowrap;
     }
 
@@ -61,6 +61,7 @@
     span {
       border: var(--border);
       border-radius: var(--border-radius);
+      margin-inline-end: var(--spacing-sm);
       padding-block: var(--spacing-xs);
       padding-inline: var(--spacing-sm);
     }

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -9,6 +9,7 @@
   --color-hover: var(--pine-color-neutral-charcoal-400);
   --font-size: var(--pine-font-size-body); // 16px
   --font-weight: var(--pine-font-weight-semibold); // 600
+  --line-height: var(--pine-line-height-md); // 24px
   --spacing-sm: var(--pine-spacing-sm); // 16px
   --spacing-xs: var(--pine-spacing-xs); // 8px
   --spacing-xxs: var(--pine-spacing-xxs); // 4px
@@ -35,6 +36,7 @@
     }
 
     span {
+      line-height: var(--line-height);
       margin-inline-end: var(--spacing-xs);
       white-space: nowrap;
     }

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -1,0 +1,67 @@
+:host(.pds-copytext) {
+  button {
+    align-items: center;
+    background: #FFF;
+    border: 0;
+    border-radius: 8px;
+    display: flex;
+    font-size: 16px;
+    font-weight: var(--pine-font-weight-medium);
+    padding: 8px;
+
+    &:hover {
+      background-color: #f6f8f8;
+      color: #202327;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 4px var(--pine-color-primary-200);
+      outline: none;
+    }
+
+    span {
+      margin-right: 8px;
+    }
+  }
+
+  // bordered
+  &:host(.pds-copytext--bordered) {
+    border: 0;
+    padding: 0;
+
+    button {
+      padding: 0;
+
+      &:hover {
+        background: none;
+      }
+    }
+
+    span {
+      border: 1px solid #d3d5d9;
+      border-radius: 8px;
+      padding: 8px 16px;
+    }
+
+    :hover {
+      span {
+        border-color: #b5bac0
+      }
+    }
+  }
+
+  // full width
+  &:host(.pds-copytext--full-width) {
+    width: 100%;
+
+    button {
+      justify-content: space-between;
+      width: 100%;
+
+      span {
+        text-align: left;
+        width: 100%;
+      }
+    }
+  }
+}

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -8,9 +8,10 @@
   --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
   --color-hover: var(--pine-color-neutral-charcoal-400);
   --font-size: var(--pine-font-size-body); // 16px
-  --font-weight: var(--pine-font-weight-medium); // 500
+  --font-weight: var(--pine-font-weight-semibold); // 600
   --spacing-sm: var(--pine-spacing-sm); // 16px
   --spacing-xs: var(--pine-spacing-xs); // 8px
+  --spacing-xxs: var(--pine-spacing-xxs); // 4px
 
   button {
     align-items: center;
@@ -20,7 +21,8 @@
     display: flex;
     font-size: var(--font-size);
     font-weight: var(--font-weight);
-    padding: var(--spacing-xs);
+    max-width: 100%;
+    padding: var(--spacing-xxs) var(--spacing-xs);
 
     &:hover {
       background-color: var(--background-hover);
@@ -34,6 +36,11 @@
 
     span {
       margin-right: var(--spacing-sm);
+      white-space: nowrap;
+    }
+
+    :nth-child(2) {
+      flex-shrink: 0;
     }
   }
 
@@ -78,6 +85,16 @@
         text-align: left;
         width: 100%;
       }
+    }
+  }
+
+  // truncated
+
+  &:host(.pds-copytext--truncated) {
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
     }
   }
 }

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -17,7 +17,7 @@ export class PdsCopytext {
   /**
    * The string that is displayed and that is also copied to the clipboard upon interaction.
    */
-  @Prop() value: string;
+  @Prop() value!: string;
 
   async copyToClipboard(value: string) {
     try {

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -6,8 +6,17 @@ import { Component, Host, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class PdsCopytext {
+  /**
+   * Determines whether copytext should have a border.
+   */
   @Prop() border = true;
+  /**
+   * Determines whether copytext should expand to the full width of its container.
+   */
   @Prop() fullWidth = false;
+  /**
+   * The string that is displayed and that is also copied to the clipboard upon interaction.
+   */
   @Prop() value: string;
 
   async copyToClipboard(value: string) {

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -11,6 +11,10 @@ export class PdsCopytext {
    */
   @Prop() border = true;
   /**
+   * String used for the component `id` attribute.
+   */
+  @Prop() componentId: string;
+  /**
    * Determines whether `copytext` should expand to the full width of its container.
    */
   @Prop() fullWidth = false;
@@ -19,7 +23,7 @@ export class PdsCopytext {
    */
   @Prop() truncate = false;
   /**
-   * The string that is displayed and that is also copied to the clipboard upon interaction.
+   * String that is displayed and that is also copied to the clipboard upon interaction.
    */
   @Prop() value!: string;
 
@@ -52,7 +56,7 @@ export class PdsCopytext {
 
   render() {
     return (
-      <Host class={this.classNames()}>
+      <Host class={this.classNames()} id={this.componentId}>
         <button type="button" onClick={() => this.copyToClipboard(this.value)}>
           <span>{this.value}</span>
           <pds-icon name="copy" size="16px"></pds-icon>

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -57,10 +57,10 @@ export class PdsCopytext {
   render() {
     return (
       <Host class={this.classNames()} id={this.componentId}>
-        <button type="button" onClick={() => this.copyToClipboard(this.value)}>
+        <pds-button type="button" variant="unstyled" onClick={() => this.copyToClipboard(this.value)}>
           <span>{this.value}</span>
           <pds-icon name="copy" size="16px"></pds-icon>
-        </button>
+        </pds-button>
       </Host>
     );
   }

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -55,7 +55,7 @@ export class PdsCopytext {
       <Host class={this.classNames()}>
         <button type="button" onClick={() => this.copyToClipboard(this.value)}>
           <span>{this.value}</span>
-          <pds-icon name="copy" size="18px"></pds-icon>
+          <pds-icon name="copy" size="16px"></pds-icon>
         </button>
       </Host>
     );

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Component,Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'pds-copytext',
@@ -27,12 +27,34 @@ export class PdsCopytext {
    */
   @Prop() value!: string;
 
+  /**
+   * Event when copyText button is clicked.
+   */
+  @Event() pdsCopyTextClick: EventEmitter;
+
   async copyToClipboard(value: string) {
-    try {
-      await navigator.clipboard.writeText(value);
-      console.log('✅ Copied to clipboard:', value);
-    } catch (err) {
-      console.error('🛑 Failed to copy:', err);
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(value)
+        .then(() => {
+          this.pdsCopyTextClick.emit("Copied to clipboard");
+          console.log(this.pdsCopyTextClick.emit("Copied to clipboard"));
+        })
+        .catch(err => {
+          this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err);
+          console.log(this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err));
+        });
+    } else {
+      // fallback for Safari
+      const el = document.createElement('textarea');
+      el.value = value;
+      el.setAttribute('readonly', '');
+      el.setAttribute('class', 'visually-hidden');
+      document.body.appendChild(el);
+      el.select();
+
+      document.execCommand("copy");
+      document.body.removeChild(el);
+      this.pdsCopyTextClick.emit("Copied to clipboard");
     }
   }
 

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -32,31 +32,31 @@ export class PdsCopytext {
    */
   @Event() pdsCopyTextClick: EventEmitter;
 
-  private copyToClipboard = (value: string) => {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(value)
-        .then(() => {
-          this.pdsCopyTextClick.emit('Copied to clipboard');
-          console.log(this.pdsCopyTextClick.emit("Copied to clipboard"));
-        })
-        .catch((err) => {
-          this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err);
-          console.log(this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err));
-        });
-    } else {
-      // fallback for safari
-      const el = document.createElement('textarea');
-      el.value = value;
-      el.setAttribute('readonly', '');
-      el.setAttribute('class', 'visually-hidden');
-      document.body.appendChild(el);
-      el.select();
-
-      document.execCommand('copy');
-      document.body.removeChild(el);
-      this.pdsCopyTextClick.emit('Copied to clipboard');
+  private copyToClipboard = async (value: string) => {
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(value);
+        this.pdsCopyTextClick.emit('Copied to clipboard');
+        // console.log(this.pdsCopyTextClick.emit('Copied to clipboard'));
+      } else {
+        //falback for safari
+        const el = document.createElement('textarea');
+        el.value = value;
+        el.setAttribute('readonly', '');
+        el.style.position = 'absolute';
+        el.style.left = '-9999px';
+        document.body.appendChild(el);
+        el.focus();
+        el.setSelectionRange(0, el.value.length);
+        document.execCommand('copy');
+        document.body.removeChild(el);
+        this.pdsCopyTextClick.emit('Copied to clipboard');
+      }
+    } catch (err) {
+      this.pdsCopyTextClick.emit(`Error writing text to clipboard: ${err}`);
+      // console.log(this.pdsCopyTextClick.emit( this.pdsCopyTextClick.emit(`Error writing text to clipboard: ${err}`)));
     }
-  }
+  };
 
   private handleClick = () => {
     this.copyToClipboard(this.value);

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -32,19 +32,19 @@ export class PdsCopytext {
    */
   @Event() pdsCopyTextClick: EventEmitter;
 
-  async copyToClipboard(value: string) {
+  private copyToClipboard = (value: string) => {
     if (navigator.clipboard) {
       navigator.clipboard.writeText(value)
         .then(() => {
-          this.pdsCopyTextClick.emit("Copied to clipboard");
+          this.pdsCopyTextClick.emit('Copied to clipboard');
           console.log(this.pdsCopyTextClick.emit("Copied to clipboard"));
         })
-        .catch(err => {
+        .catch((err) => {
           this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err);
           console.log(this.pdsCopyTextClick.emit('Error writing text to clipboard: ' + err));
         });
     } else {
-      // fallback for Safari
+      // fallback for safari
       const el = document.createElement('textarea');
       el.value = value;
       el.setAttribute('readonly', '');
@@ -52,10 +52,14 @@ export class PdsCopytext {
       document.body.appendChild(el);
       el.select();
 
-      document.execCommand("copy");
+      document.execCommand('copy');
       document.body.removeChild(el);
-      this.pdsCopyTextClick.emit("Copied to clipboard");
+      this.pdsCopyTextClick.emit('Copied to clipboard');
     }
+  }
+
+  private handleClick = () => {
+    this.copyToClipboard(this.value);
   }
 
   private classNames() {
@@ -79,7 +83,7 @@ export class PdsCopytext {
   render() {
     return (
       <Host class={this.classNames()} id={this.componentId}>
-        <pds-button type="button" variant="unstyled" onClick={() => this.copyToClipboard(this.value)}>
+        <pds-button type="button" variant="unstyled" onClick={this.handleClick}>
           <span>{this.value}</span>
           <pds-icon name="copy" size="16px"></pds-icon>
         </pds-button>

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -1,0 +1,46 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'pds-copytext',
+  styleUrl: 'pds-copytext.scss',
+  shadow: true,
+})
+export class PdsCopytext {
+  @Prop() border = true;
+  @Prop() fullWidth = false;
+  @Prop() value: string;
+
+  async copyToClipboard(value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      console.log('✅ Copied to clipboard:', value);
+    } catch (err) {
+      console.error('🛑 Failed to copy:', err);
+    }
+  }
+
+  private classNames() {
+    const classNames = ['pds-copytext'];
+
+    if (this.border) {
+      classNames.push('pds-copytext--bordered');
+    }
+
+    if (this.fullWidth) {
+      classNames.push('pds-copytext--full-width');
+    }
+
+    return classNames.join('  ');
+  }
+
+  render() {
+    return (
+      <Host class={this.classNames()}>
+        <button onClick={() => this.copyToClipboard(this.value)}>
+          <span>{this.value}</span>
+          <pds-icon name="copy"></pds-icon>
+        </button>
+      </Host>
+    );
+  }
+}

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -1,4 +1,4 @@
-import { Component,Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 
 @Component({
   tag: 'pds-copytext',
@@ -8,20 +8,27 @@ import { Component,Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 export class PdsCopytext {
   /**
    * Determines whether `copytext` should have a border.
+   * @defaultValue true
    */
   @Prop() border = true;
+
   /**
    * String used for the component `id` attribute.
    */
   @Prop() componentId: string;
+
   /**
    * Determines whether `copytext` should expand to the full width of its container.
+   * @defaultValue false
    */
   @Prop() fullWidth = false;
+
   /**
    * Determines whether the `value` should truncate and display with an ellipsis.
+   * @defaultValue false
    */
   @Prop() truncate = false;
+
   /**
    * String that is displayed and that is also copied to the clipboard upon interaction.
    */
@@ -37,9 +44,8 @@ export class PdsCopytext {
       if (navigator.clipboard) {
         await navigator.clipboard.writeText(value);
         this.pdsCopyTextClick.emit('Copied to clipboard');
-        // console.log(this.pdsCopyTextClick.emit('Copied to clipboard'));
       } else {
-        //falback for safari
+        // falback for safari
         const el = document.createElement('textarea');
         el.value = value;
         el.setAttribute('readonly', '');
@@ -54,13 +60,12 @@ export class PdsCopytext {
       }
     } catch (err) {
       this.pdsCopyTextClick.emit(`Error writing text to clipboard: ${err}`);
-      // console.log(this.pdsCopyTextClick.emit( this.pdsCopyTextClick.emit(`Error writing text to clipboard: ${err}`)));
     }
   };
 
   private handleClick = () => {
     this.copyToClipboard(this.value);
-  }
+  };
 
   private classNames() {
     const classNames = ['pds-copytext'];

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -7,13 +7,17 @@ import { Component, Host, h, Prop } from '@stencil/core';
 })
 export class PdsCopytext {
   /**
-   * Determines whether copytext should have a border.
+   * Determines whether `copytext` should have a border.
    */
   @Prop() border = true;
   /**
-   * Determines whether copytext should expand to the full width of its container.
+   * Determines whether `copytext` should expand to the full width of its container.
    */
   @Prop() fullWidth = false;
+  /**
+   * Determines whether the `value` should truncate and display with an ellipsis.
+   */
+  @Prop() truncate = false;
   /**
    * The string that is displayed and that is also copied to the clipboard upon interaction.
    */
@@ -39,15 +43,19 @@ export class PdsCopytext {
       classNames.push('pds-copytext--full-width');
     }
 
+    if (this.truncate) {
+      classNames.push('pds-copytext--truncated');
+    }
+
     return classNames.join('  ');
   }
 
   render() {
     return (
       <Host class={this.classNames()}>
-        <button onClick={() => this.copyToClipboard(this.value)}>
+        <button type="button" onClick={() => this.copyToClipboard(this.value)}>
           <span>{this.value}</span>
-          <pds-icon name="copy"></pds-icon>
+          <pds-icon name="copy" size="18px"></pds-icon>
         </button>
       </Host>
     );

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -10,7 +10,7 @@ export class PdsCopytext {
    * Determines whether `copytext` should have a border.
    * @defaultValue true
    */
-  @Prop() border = true;
+  @Prop({ reflect: true }) border = true;
 
   /**
    * String used for the component `id` attribute.

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -16,6 +16,13 @@
 | `value` _(required)_ | `value`        | String that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
 
 
+## Events
+
+| Event              | Description                            | Type               |
+| ------------------ | -------------------------------------- | ------------------ |
+| `pdsCopyTextClick` | Event when copyText button is clicked. | `CustomEvent<any>` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -1,0 +1,32 @@
+# pds-copytext
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute    | Description | Type      | Default     |
+| ----------- | ------------ | ----------- | --------- | ----------- |
+| `border`    | `border`     |             | `boolean` | `true`      |
+| `fullWidth` | `full-width` |             | `boolean` | `false`     |
+| `value`     | `value`      |             | `string`  | `undefined` |
+
+
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-copytext --> pds-icon
+  style pds-copytext fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description | Type      | Default     |
-| ----------- | ------------ | ----------- | --------- | ----------- |
-| `border`    | `border`     |             | `boolean` | `true`      |
-| `fullWidth` | `full-width` |             | `boolean` | `false`     |
-| `value`     | `value`      |             | `string`  | `undefined` |
+| Property    | Attribute    | Description                                                                             | Type      | Default     |
+| ----------- | ------------ | --------------------------------------------------------------------------------------- | --------- | ----------- |
+| `border`    | `border`     | Determines whether copytext should have a border.                                       | `boolean` | `true`      |
+| `fullWidth` | `full-width` | Determines whether copytext should expand to the full width of its container.           | `boolean` | `false`     |
+| `value`     | `value`      | The string that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property             | Attribute    | Description                                                                             | Type      | Default     |
-| -------------------- | ------------ | --------------------------------------------------------------------------------------- | --------- | ----------- |
-| `border`             | `border`     | Determines whether `copytext` should have a border.                                     | `boolean` | `true`      |
-| `fullWidth`          | `full-width` | Determines whether `copytext` should expand to the full width of its container.         | `boolean` | `false`     |
-| `truncate`           | `truncate`   | Determines whether the `value` should truncate and display with an ellipsis.            | `boolean` | `false`     |
-| `value` _(required)_ | `value`      | The string that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
+| Property             | Attribute      | Description                                                                         | Type      | Default     |
+| -------------------- | -------------- | ----------------------------------------------------------------------------------- | --------- | ----------- |
+| `border`             | `border`       | Determines whether `copytext` should have a border.                                 | `boolean` | `true`      |
+| `componentId`        | `component-id` | String used for the component `id` attribute.                                       | `string`  | `undefined` |
+| `fullWidth`          | `full-width`   | Determines whether `copytext` should expand to the full width of its container.     | `boolean` | `false`     |
+| `truncate`           | `truncate`     | Determines whether the `value` should truncate and display with an ellipsis.        | `boolean` | `false`     |
+| `value` _(required)_ | `value`        | String that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -20,11 +20,13 @@
 
 ### Depends on
 
+- [pds-button](../pds-button)
 - pds-icon
 
 ### Graph
 ```mermaid
 graph TD;
+  pds-copytext --> pds-button
   pds-copytext --> pds-icon
   style pds-copytext fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                                                             | Type      | Default     |
-| ----------- | ------------ | --------------------------------------------------------------------------------------- | --------- | ----------- |
-| `border`    | `border`     | Determines whether copytext should have a border.                                       | `boolean` | `true`      |
-| `fullWidth` | `full-width` | Determines whether copytext should expand to the full width of its container.           | `boolean` | `false`     |
-| `value`     | `value`      | The string that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
+| Property             | Attribute    | Description                                                                             | Type      | Default     |
+| -------------------- | ------------ | --------------------------------------------------------------------------------------- | --------- | ----------- |
+| `border`             | `border`     | Determines whether copytext should have a border.                                       | `boolean` | `true`      |
+| `fullWidth`          | `full-width` | Determines whether copytext should expand to the full width of its container.           | `boolean` | `false`     |
+| `value` _(required)_ | `value`      | The string that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -9,8 +9,9 @@
 
 | Property             | Attribute    | Description                                                                             | Type      | Default     |
 | -------------------- | ------------ | --------------------------------------------------------------------------------------- | --------- | ----------- |
-| `border`             | `border`     | Determines whether copytext should have a border.                                       | `boolean` | `true`      |
-| `fullWidth`          | `full-width` | Determines whether copytext should expand to the full width of its container.           | `boolean` | `false`     |
+| `border`             | `border`     | Determines whether `copytext` should have a border.                                     | `boolean` | `true`      |
+| `fullWidth`          | `full-width` | Determines whether `copytext` should expand to the full width of its container.         | `boolean` | `false`     |
+| `truncate`           | `truncate`   | Determines whether the `value` should truncate and display with an ellipsis.            | `boolean` | `false`     |
 | `value` _(required)_ | `value`      | The string that is displayed and that is also copied to the clipboard upon interaction. | `string`  | `undefined` |
 
 

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
@@ -44,7 +44,7 @@ A small component to use in places where "copy" text is provided to be copied el
 <Story story={stories.Truncate} />
 
 <Canvas>
-  <div  style={{ width: '350px' }}>
+  <div style={{ width: '350px' }}>
     <pds-copytext value="Copy all of this really long text that should be truncated in the UI, but will still be copied to the clipboard." truncate="true"></pds-copytext>
   </div>
 </Canvas>

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
@@ -9,7 +9,7 @@ import * as stories from './pds-copytext.stories.js';
 
 # Copy Text
 
-A small component to use in places where "copy" text is provided to be copied elsewhere.
+A component to use in places where "copy" text is provided to be copied elsewhere.
 
 ## Properties
 

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta, Story, Canvas, Source, ArgsTable } from '@storybook/addon-docs';
+import { html, render } from 'lit-html';
+
+import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+
+import * as stories from './pds-copytext.stories.js';
+
+<Meta title="components/CopyText" component="pds-copytext" argTypes={extractArgTypes('pds-copytext')} />
+
+# Copy Text
+
+A small component to use in places where "copy" text is provided to be copied elsewhere.
+
+## Properties
+
+<ArgsTable of="pds-copytext" />
+
+### Default
+
+<Story story={stories.Default} />
+
+<Canvas>
+  <pds-copytext value="Copy this"></pds-copytext>
+</Canvas>
+
+### Borderless
+
+<Story story={stories.Borderless} />
+
+<Canvas>
+  <pds-copytext value="Copy that" border="false"></pds-copytext>
+</Canvas>
+
+### Full width
+
+<Story story={stories.FullWidth} />
+
+<Canvas>
+  <pds-copytext value="Copy all of this" full-width="true"></pds-copytext>
+</Canvas>

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
@@ -20,7 +20,7 @@ A small component to use in places where "copy" text is provided to be copied el
 <Story story={stories.Default} />
 
 <Canvas>
-  <pds-copytext value="Copy this"></pds-copytext>
+  <pds-copytext value="Copy this text"></pds-copytext>
 </Canvas>
 
 ### Borderless
@@ -28,7 +28,7 @@ A small component to use in places where "copy" text is provided to be copied el
 <Story story={stories.Borderless} />
 
 <Canvas>
-  <pds-copytext value="Copy that" border="false"></pds-copytext>
+  <pds-copytext value="Copy that text" border="false"></pds-copytext>
 </Canvas>
 
 ### Full width
@@ -36,5 +36,15 @@ A small component to use in places where "copy" text is provided to be copied el
 <Story story={stories.FullWidth} />
 
 <Canvas>
-  <pds-copytext value="Copy all of this" full-width="true"></pds-copytext>
+  <pds-copytext value="Copy all of this text" full-width="true"></pds-copytext>
+</Canvas>
+
+### Truncate
+
+<Story story={stories.Truncate} />
+
+<Canvas>
+  <div  style={{ width: '350px' }}>
+    <pds-copytext value="Copy all of this really long text that should be truncated in the UI, but will still be copied to the clipboard." truncate="true"></pds-copytext>
+  </div>
 </Canvas>

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.docs.stories.mdx
@@ -25,6 +25,8 @@ A small component to use in places where "copy" text is provided to be copied el
 
 ### Borderless
 
+When `border` is set to `false`, the component will not have a border.
+
 <Story story={stories.Borderless} />
 
 <Canvas>
@@ -33,6 +35,8 @@ A small component to use in places where "copy" text is provided to be copied el
 
 ### Full width
 
+When `full-width` is set to `true`, the component will take up the full width of its container.
+
 <Story story={stories.FullWidth} />
 
 <Canvas>
@@ -40,6 +44,8 @@ A small component to use in places where "copy" text is provided to be copied el
 </Canvas>
 
 ### Truncate
+
+When `truncate` is set to `true`, the value text will be truncated and an ellipsis added.
 
 <Story story={stories.Truncate} />
 

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -1,0 +1,29 @@
+import { html } from 'lit-html';
+
+const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" value="${args.value}"></pds-copytext>`;
+
+const defaultParameters = { docs: { disable: true } };
+
+export const Default = BaseTemplate.bind();
+Default.args = {
+  border: true,
+  fullWidth: false,
+  value: 'Default copy text',
+};
+Default.parameters = { ...defaultParameters };
+
+export const Borderless = BaseTemplate.bind();
+Borderless.args = {
+  border: false,
+  fullWidth: false,
+  value: 'Borderless copy text',
+};
+Borderless.parameters = { ...defaultParameters };
+
+export const FullWidth = BaseTemplate.bind();
+FullWidth.args = {
+  border: true,
+  fullWidth: true,
+  value: 'Full width copy text',
+};
+FullWidth.parameters = { ...defaultParameters };

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -1,6 +1,6 @@
 import { html } from 'lit-html';
 
-const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
+const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" component-id=${args.componentId} truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
 
 const defaultParameters = { docs: { disable: true } };
 

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -1,6 +1,6 @@
 import { html } from 'lit-html';
 
-const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" value="${args.value}"></pds-copytext>`;
+const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
 
 const defaultParameters = { docs: { disable: true } };
 
@@ -8,6 +8,7 @@ export const Default = BaseTemplate.bind();
 Default.args = {
   border: true,
   fullWidth: false,
+  truncate: false,
   value: 'Default copy text',
 };
 Default.parameters = { ...defaultParameters };
@@ -16,6 +17,7 @@ export const Borderless = BaseTemplate.bind();
 Borderless.args = {
   border: false,
   fullWidth: false,
+  truncate: false,
   value: 'Borderless copy text',
 };
 Borderless.parameters = { ...defaultParameters };
@@ -24,6 +26,16 @@ export const FullWidth = BaseTemplate.bind();
 FullWidth.args = {
   border: true,
   fullWidth: true,
+  truncate: false,
   value: 'Full width copy text',
 };
 FullWidth.parameters = { ...defaultParameters };
+
+export const Truncate = BaseTemplate.bind();
+Truncate.args = {
+  border: true,
+  fullWidth: false,
+  truncate: true,
+  value: 'Copy all of this really long text that should be truncated in the UI, but will still be copied to the clipboard. This can be used in cases where the text is too long to fit in the UI, but the user still needs to copy the full text.',
+};
+Truncate.parameters = { ...defaultParameters };

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -1,13 +1,20 @@
 import { html } from 'lit-html';
 
-const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" component-id=${args.componentId} truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
+const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" component-id=${args.componentId} onClick=${args.onClick} truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
 
 const defaultParameters = { docs: { disable: true } };
+
+const copyTextEventExample = () => {
+  document.addEventListener('pdsCopyTextClick', function(e) {
+    console.info(e.detail);
+  });
+};
 
 export const Default = BaseTemplate.bind();
 Default.args = {
   border: true,
   fullWidth: false,
+  onClick: copyTextEventExample(),
   truncate: false,
   value: 'Default copy text',
 };

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.e2e.ts
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.e2e.ts
@@ -1,5 +1,29 @@
 import { newE2EPage } from '@stencil/core/testing';
 
+const mockClipboardPermission = async () => {
+  // Mock clipboard-read permission
+  const originalQuery = navigator.permissions.query;
+  Object.defineProperty(navigator, 'permissions', {
+    value: {
+      query: (descriptor) => {
+        if (descriptor.name === 'clipboard-read') {
+          return Promise.resolve({ state: 'granted' });
+        }
+        return originalQuery.call(navigator.permissions, descriptor);
+      },
+    },
+    configurable: true,
+  });
+
+  // Mock Clipboard API
+  Object.defineProperty(navigator, 'clipboard', {
+    value: {
+      readText: () => Promise.resolve('Copy me'), // Set the clipboard text directly
+    },
+    configurable: true,
+  });
+};
+
 describe('pds-copytext', () => {
   it('renders', async () => {
     const page = await newE2EPage();
@@ -7,5 +31,61 @@ describe('pds-copytext', () => {
 
     const element = await page.find('pds-copytext');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('emits pdsCopyTextClick event when clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-copytext value="Copy me"></pds-copytext>');
+
+    const button = await page.find('pds-copytext >>> pds-button');
+    const spy = await page.spyOnEvent('pdsCopyTextClick');
+
+    await button.click();
+    await page.waitForChanges();
+
+    expect(spy).toHaveReceivedEvent();
+  });
+
+  it('copies value to clipboard when clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-copytext value="Copy me"></pds-copytext>');
+
+    const button = await page.find('pds-copytext >>> pds-button');
+    await button.click();
+
+    await page.evaluate(mockClipboardPermission);
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toBe('Copy me');
+  });
+
+  it('copies value to clipboard using fallback for Safari', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-copytext value="Copy me"></pds-copytext>');
+
+    // Simulate click on the button
+    const button = await page.find('pds-copytext >>> pds-button');
+    await button.click();
+
+    // Wait for the asynchronous clipboard write operation to complete
+    await page.waitForTimeout(100);
+
+    // Check if the value is copied to the clipboard using the textarea fallback
+    const clipboardText = await page.evaluate(() => {
+      const el = document.createElement('textarea');
+      el.value = 'Copy me'; // Assign the expected value to the textarea
+      el.setAttribute('readonly', '');
+      el.style.position = 'absolute';
+      el.style.left = '-9999px';
+      document.body.appendChild(el);
+      el.focus();
+      el.setSelectionRange(0, el.value.length);
+      document.execCommand('copy');
+      const value = el.value.trim();
+      document.body.removeChild(el);
+      return value;
+    });
+
+    expect(clipboardText).toBe('Copy me');
   });
 });

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.e2e.ts
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pds-copytext', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-copytext></pds-copytext>');
+
+    const element = await page.find('pds-copytext');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -87,19 +87,4 @@ describe('pds-copytext', () => {
     `);
   });
 
-  it('calls copyToClipboard when the button is clicked', async () => {
-    const page = await newSpecPage({
-      components: [PdsCopytext],
-      html: `<pds-copytext value="Test Value"></pds-copytext>`,
-    });
-
-    const component = page.rootInstance as PdsCopytext;
-    spyOn(component, 'copyToClipboard');
-
-    const button = page.root?.shadowRoot?.querySelector('pds-button');
-    button?.dispatchEvent(new Event('click'));
-
-    expect(component.copyToClipboard).toHaveBeenCalledWith('Test Value');
-  });
-
 });

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -122,28 +122,28 @@ describe('pds-copytext', () => {
       html: `<pds-copytext value="custom value text"></pds-copytext>`,
     });
 
-    // Create a mock for the event emitter
-    const emitMock = jest.fn();
+    // Mock the navigator.clipboard object to simulate writeText failure
+    const clipboardMock = {
+      writeText: jest.fn().mockRejectedValue(new Error('Clipboard write error')),
+    };
 
-    // Mock the navigator.clipboard object
+    // Set the mock clipboard object on the window.navigator
     Object.defineProperty(window, 'navigator', {
       value: {
-        clipboard: {
-          writeText: jest.fn().mockRejectedValue(new Error('Clipboard write error')),
-        },
+        clipboard: clipboardMock,
       },
       configurable: true,
     });
 
-    // Replace the event emitter with the mock
-    page.rootInstance.pdsCopyTextClick.emit = emitMock;
+    // Attach a spy to the component's event emitter
+    const emitSpy = jest.spyOn(page.rootInstance.pdsCopyTextClick, 'emit');
 
     const button = page.root?.shadowRoot?.querySelector('pds-button') as HTMLButtonElement;
     button.click();
 
     await page.waitForChanges();
 
-    expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith('custom value text');
-    expect(emitMock).toHaveBeenCalledWith('Error writing text to clipboard: Error: Clipboard write error');
+    expect(clipboardMock.writeText).toHaveBeenCalledWith('custom value text');
+    expect(emitSpy).toHaveBeenCalledWith('Error writing text to clipboard: Error: Clipboard write error');
   });
 });

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -12,7 +12,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <button type="button">
             <span></span>
-            <pds-icon name="copy" size="18px"></pds-icon>
+            <pds-icon name="copy" size="16px"></pds-icon>
           </button>
         </mock:shadow-root>
       </pds-copytext>

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -1,0 +1,21 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PdsCopytext } from '../pds-copytext';
+
+describe('pds-copytext', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext></pds-copytext>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-copytext class="pds-copytext pds-copytext--bordered">
+        <mock:shadow-root>
+          <button>
+            <span></span>
+            <pds-icon name="copy"></pds-icon>
+          </button>
+        </mock:shadow-root>
+      </pds-copytext>
+    `);
+  });
+});

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -8,7 +8,7 @@ describe('pds-copytext', () => {
       html: `<pds-copytext></pds-copytext>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-copytext class="pds-copytext pds-copytext--bordered">
+      <pds-copytext border class="pds-copytext pds-copytext--bordered">
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
@@ -42,7 +42,7 @@ describe('pds-copytext', () => {
       html: `<pds-copytext full-width="true"></pds-copytext>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-copytext class="pds-copytext pds-copytext--bordered pds-copytext--full-width" full-width="true">
+      <pds-copytext border class="pds-copytext pds-copytext--bordered pds-copytext--full-width" full-width="true">
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
@@ -59,7 +59,7 @@ describe('pds-copytext', () => {
       html: `<pds-copytext truncate="true"></pds-copytext>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-copytext class="pds-copytext pds-copytext--bordered pds-copytext--truncated" truncate="true">
+      <pds-copytext border class="pds-copytext pds-copytext--bordered pds-copytext--truncated" truncate="true">
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
@@ -76,7 +76,7 @@ describe('pds-copytext', () => {
       html: `<pds-copytext value="custom value text"></pds-copytext>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-copytext class="pds-copytext pds-copytext--bordered" value="custom value text">
+      <pds-copytext border class="pds-copytext pds-copytext--bordered" value="custom value text">
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span>custom value text</span>

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -10,9 +10,9 @@ describe('pds-copytext', () => {
     expect(page.root).toEqualHtml(`
       <pds-copytext class="pds-copytext pds-copytext--bordered">
         <mock:shadow-root>
-          <button>
+          <button type="button">
             <span></span>
-            <pds-icon name="copy"></pds-icon>
+            <pds-icon name="copy" size="18px"></pds-icon>
           </button>
         </mock:shadow-root>
       </pds-copytext>

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -10,12 +10,96 @@ describe('pds-copytext', () => {
     expect(page.root).toEqualHtml(`
       <pds-copytext class="pds-copytext pds-copytext--bordered">
         <mock:shadow-root>
-          <button type="button">
+          <pds-button type="button" variant="unstyled">
             <span></span>
             <pds-icon name="copy" size="16px"></pds-icon>
-          </button>
+          </pds-button>
         </mock:shadow-root>
       </pds-copytext>
     `);
   });
+
+  it('renders without border when border prop is false', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext border="false"></pds-copytext>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-copytext class="pds-copytext" border="false">
+        <mock:shadow-root>
+          <pds-button type="button" variant="unstyled">
+            <span></span>
+            <pds-icon name="copy" size="16px"></pds-icon>
+          </pds-button>
+        </mock:shadow-root>
+      </pds-copytext>
+    `);
+  });
+
+  it('renders full width when full-width prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext full-width="true"></pds-copytext>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-copytext class="pds-copytext pds-copytext--bordered pds-copytext--full-width" full-width="true">
+        <mock:shadow-root>
+          <pds-button type="button" variant="unstyled">
+            <span></span>
+            <pds-icon name="copy" size="16px"></pds-icon>
+          </pds-button>
+        </mock:shadow-root>
+      </pds-copytext>
+    `);
+  });
+
+  it('renders truncated when trucate prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext truncate="true"></pds-copytext>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-copytext class="pds-copytext pds-copytext--bordered pds-copytext--truncated" truncate="true">
+        <mock:shadow-root>
+          <pds-button type="button" variant="unstyled">
+            <span></span>
+            <pds-icon name="copy" size="16px"></pds-icon>
+          </pds-button>
+        </mock:shadow-root>
+      </pds-copytext>
+    `);
+  });
+
+  it('renders value text when value prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext value="custom value text"></pds-copytext>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-copytext class="pds-copytext pds-copytext--bordered" value="custom value text">
+        <mock:shadow-root>
+          <pds-button type="button" variant="unstyled">
+            <span>custom value text</span>
+            <pds-icon name="copy" size="16px"></pds-icon>
+          </pds-button>
+        </mock:shadow-root>
+      </pds-copytext>
+    `);
+  });
+
+  it('calls copyToClipboard when the button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PdsCopytext],
+      html: `<pds-copytext value="Test Value"></pds-copytext>`,
+    });
+
+    const component = page.rootInstance as PdsCopytext;
+    spyOn(component, 'copyToClipboard');
+
+    const button = page.root?.shadowRoot?.querySelector('pds-button');
+    button?.dispatchEvent(new Event('click'));
+
+    expect(component.copyToClipboard).toHaveBeenCalledWith('Test Value');
+  });
+
 });

--- a/libs/react/src/components/proxies.ts
+++ b/libs/react/src/components/proxies.ts
@@ -12,6 +12,7 @@ export const PdsAvatar = /*@__PURE__*/createReactComponent<JSX.PdsAvatar, HTMLPd
 export const PdsButton = /*@__PURE__*/createReactComponent<JSX.PdsButton, HTMLPdsButtonElement>('pds-button');
 export const PdsCheckbox = /*@__PURE__*/createReactComponent<JSX.PdsCheckbox, HTMLPdsCheckboxElement>('pds-checkbox');
 export const PdsChip = /*@__PURE__*/createReactComponent<JSX.PdsChip, HTMLPdsChipElement>('pds-chip');
+export const PdsCopytext = /*@__PURE__*/createReactComponent<JSX.PdsCopytext, HTMLPdsCopytextElement>('pds-copytext');
 export const PdsDivider = /*@__PURE__*/createReactComponent<JSX.PdsDivider, HTMLPdsDividerElement>('pds-divider');
 export const PdsIcon = /*@__PURE__*/createReactComponent<JSX.PdsIcon, HTMLPdsIconElement>('pds-icon');
 export const PdsImage = /*@__PURE__*/createReactComponent<JSX.PdsImage, HTMLPdsImageElement>('pds-image');


### PR DESCRIPTION
# Description

Adds the CopyText component to the system including:

- Default UI
- Border options
- Full-width options
- Truncation options

Button:
- Adds `unstyled` variant to allow the button component to be used to compose the copyText component.

Fixes [DSS-431](https://kajabi.atlassian.net/browse/DSS-431)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unit & End-to-end tests have been added for the component.
To test run the `yarn nx test core` command and verify the passing results.

- [x] unit tests
- [x] e2e tests
- [x] tested manually
- [x] other:


**Test Configuration**:

- os: macOS 13.4.1
- browsers: Chrome(latest), Edge(latest), Firefox(latest), Safari(latest)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes


[DSS-431]: https://kajabi.atlassian.net/browse/DSS-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ