### PR TITLE
DSS-458: Docs - Display Custom Events in Actions Tab 

### DIFF
--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -9,6 +9,7 @@ const config = {
     getAbsolutePath("@storybook/addon-essentials"),
     getAbsolutePath("@storybook/addon-links"),
     getAbsolutePath("@storybook/addon-a11y"),
+    getAbsolutePath("@storybook/addon-actions"),
     getAbsolutePath("@pxtrn/storybook-addon-docs-stencil"),
   ],
 

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1118,7 +1118,7 @@ declare namespace LocalJSX {
           * Sets the related tab name, this name must match a `pds-tabpanel`'s tab name property
          */
         "name": string;
-        "onTabClick"?: (event: PdsTabCustomEvent<object>) => void;
+        "onPdsTabClick"?: (event: PdsTabCustomEvent<object>) => void;
         "parentComponentId"?: string;
         "selected"?: boolean;
         "variant"?: string;

--- a/libs/core/src/components/pds-checkbox/stories/pds-checkbox.stories.js
+++ b/libs/core/src/components/pds-checkbox/stories/pds-checkbox.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-checkbox'),
@@ -11,6 +12,12 @@ export default {
     required: false,
   },
   component: 'pds-checkbox',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onchange', 'pdsCheckboxChange'],
+    },
+  },
   title: 'components/Checkbox',
 }
 

--- a/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
+++ b/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
@@ -1,9 +1,16 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-chip'),
   component: 'pds-chip',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onclick', 'pdsTagCloseClick'],
+    },
+  },
   title: 'components/Chip'
 }
 

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -1,25 +1,33 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-copytext'),
   component: 'pds-copytext',
-  title: 'components/Copytext'
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onclick', 'pdsCopyTextClick'],
+    },
+  },
+  title: 'components/Copy Text',
 }
 
-const BaseTemplate = (args) => html` <pds-copytext border="${args.border}" full-width="${args.fullWidth}" component-id=${args.componentId} onClick=${args.onClick} truncate="${args.truncate}" value="${args.value}"></pds-copytext>`;
-
-const copyTextEventExample = () => {
-  document.addEventListener('pdsCopyTextClick', function(e) {
-    console.info(e.detail);
-  });
-};
+const BaseTemplate = (args) => html`
+  <pds-copytext
+    border="${args.border}"
+    full-width="${args.fullWidth}"
+    component-id=${args.componentId}
+    onClick=${args.onClick}
+    truncate="${args.truncate}"
+    value="${args.value}">
+  </pds-copytext>`;
 
 export const Default = BaseTemplate.bind();
 Default.args = {
   border: true,
   fullWidth: false,
-  onClick: copyTextEventExample(),
   truncate: false,
   value: 'Default copy text',
 };

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-input'),
@@ -15,7 +16,13 @@ export default {
     type: 'text'
   },
   component: 'pds-input',
-  title: 'components/Input'
+  parameters: {
+    actions: {
+      handles: ['oninput', 'pdsInput'],
+    },
+  },
+  title: 'components/Input',
+  decorators: [withActions],
 }
 
 const BaseTemplate = (args) => html`<pds-input

--- a/libs/core/src/components/pds-radio/stories/pds-radio.stories.js
+++ b/libs/core/src/components/pds-radio/stories/pds-radio.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   args: {
@@ -10,7 +11,13 @@ export default {
   },
   argTypes: extractArgTypes('pds-radio'),
   component: 'pds-radio',
-  title: 'components/Radio'
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onchange', 'pdsRadioChange'],
+    },
+  },
+  title: 'components/Radio',
 }
 
 const BaseTemplate = (args) =>

--- a/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
+++ b/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   args: {
@@ -8,7 +9,13 @@ export default {
   },
   argTypes: extractArgTypes('pds-switch'),
   component: 'pds-switch',
-  title: 'components/Switch'
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onchange', 'pdsSwitchChange'],
+    },
+  },
+  title: 'components/Switch',
 }
 
 const BaseTemplate = (args) => html`
@@ -27,16 +34,6 @@ const BaseTemplate = (args) => html`
   />
 `;
 
-const switchEventExample = () => {
-  document.addEventListener('sageSwitchChange', function(e) {
-    const input = e.target.shadowRoot.querySelector(".pds-switch__input");
-    const inputState = input.checked ? '✅ checked' : '😭 not checked';
-
-    console.info('sageSwitchChange event', e);
-    console.info(`#${input.id} switch is: ${inputState}`);
-  });
-};
-
 export const Default = BaseTemplate.bind({});
 
 Default.args = {
@@ -46,7 +43,6 @@ Default.args = {
   invalid: false,
   label: 'checkbox switch',
   name: 'pds-switch-checkbox',
-  onChange: switchEventExample(),
   required: false,
   type: 'checkbox',
 };

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
@@ -41,9 +41,9 @@ export class PdsTab {
    * Emits an event upon tab click for `pds-tab` and `pds-tabpanel` to listen for
    */
   /** @internal */
-  @Event() tabClick: EventEmitter<object>;
+  @Event() pdsTabClick: EventEmitter<object>;
   private onTabClick(index, parentComponentId) {
-    this.tabClick.emit([index, parentComponentId]);
+    this.pdsTabClick.emit([index, parentComponentId]);
   }
 
   render() {

--- a/libs/core/src/components/pds-tabs/pds-tab/test/pds-tab.spec.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tab/test/pds-tab.spec.tsx
@@ -52,7 +52,7 @@ describe('pds-tabs', () => {
       html: `<pds-tab active-name="two" parent-component-id="foo" name="two">Content</pds-tab>`,
     });
     const eventSpy = jest.fn();
-    document.addEventListener('tabClick', eventSpy);
+    document.addEventListener('pdsTabClick', eventSpy);
     const component = page.doc.getElementById("foo__two");
     component?.click();
     expect(eventSpy).toHaveBeenCalled();

--- a/libs/core/src/components/pds-tabs/pds-tabs.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabs.tsx
@@ -41,7 +41,7 @@ export class PdsTabs {
   /** @internal */
   @Prop({mutable: true}) activeTabIndex: number;
 
-  @Listen('tabClick', {
+  @Listen('pdsTabClick', {
     target: 'body',
   })
   tabClickHandler(event: CustomEvent<any>) {

--- a/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
+++ b/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
@@ -1,9 +1,16 @@
 import { html, render } from 'lit';
+import { withActions } from '@storybook/addon-actions/decorator';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 
 export default {
   argTypes: extractArgTypes('pds-tabs'),
   component: 'pds-tabs',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['tabClick', 'keydown']
+    },
+  },
   title: 'components/Tabs',
 }
 

--- a/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
+++ b/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
@@ -8,7 +8,7 @@ export default {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['tabClick', 'keydown']
+      handles: ['pdsTabClick', 'keydown']
     },
   },
   title: 'components/Tabs',

--- a/libs/core/src/components/pds-tabs/test/pds-tabs.e2e.ts
+++ b/libs/core/src/components/pds-tabs/test/pds-tabs.e2e.ts
@@ -76,7 +76,7 @@ describe('pds-tabs', () => {
       </pds-tabs>
     `);
     const inactiveTabButton = await page.find(`pds-tab[name="one"] > button`);
-    const event = await page.spyOnEvent('tabClick');
+    const event = await page.spyOnEvent('pdsTabClick');
     inactiveTabButton.click();
     await page.waitForChanges();
     expect(event).toHaveReceivedEvent();

--- a/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
+++ b/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
@@ -55,7 +55,7 @@ it('renders variant prop', async () => {
     `);
   });
 
-  it('pds-tabs catches `tabClick` event', async () => {
+  it('pds-tabs catches `pdsTabClick` event', async () => {
     const page = await newSpecPage({
       components: [PdsTabs, PdsTab, PdsTabpanel],
       html: `
@@ -67,7 +67,7 @@ it('renders variant prop', async () => {
         </pds-tabs>`,
     });
 
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [0, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [0, 'test']}));
     await page.waitForChanges();
     const tabs = page.body.querySelector('pds-tabs[active-tab-name="one"]');
     expect(tabs).toBeTruthy();
@@ -85,7 +85,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on second activeTabIndex (1)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [1, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [1, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
@@ -115,7 +115,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on first activeTabIndex (0)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [0, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [0, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
@@ -145,7 +145,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on second activeTabIndex (1)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [1, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [1, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
@@ -175,7 +175,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on last activeTabIndex (2)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [2, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [2, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
@@ -205,7 +205,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on last activeTabIndex (2)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [1, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [1, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
@@ -235,7 +235,7 @@ it('renders variant prop', async () => {
     });
 
     // Move focus to tab by clicking on last activeTabIndex (2)
-    page.body.dispatchEvent(new CustomEvent('tabClick', {'detail': [1, 'test']}));
+    page.body.dispatchEvent(new CustomEvent('pdsTabClick', {'detail': [1, 'test']}));
     await page.waitForChanges();
     expect(page.body.querySelector('pds-tab[name="one"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
@@ -1,5 +1,6 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   args: {
@@ -17,7 +18,13 @@ export default {
   },
   argTypes: extractArgTypes('pds-textarea'),
   component: 'pds-textarea',
-  title: 'components/Textarea'
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['onchange', 'pdsTextareaChange'],
+    },
+  },
+  title: 'components/Textarea',
 }
 
 const BaseTemplate = (args) => html`<pds-textarea
@@ -37,20 +44,10 @@ const BaseTemplate = (args) => html`<pds-textarea
   >
 </pds-textarea>`;
 
-const textareaEventExample = () => {
-  document.addEventListener('pdsTextareaChange', function(e) {
-    const textarea = e.target.shadowRoot.querySelector(".pds-textarea__field");
-
-    console.log('e: ', textarea);
-    console.log(`The value has been update to #${textarea.value}`);
-  });
-};
-
 export const Default = BaseTemplate.bind({});
 Default.args = {
   componentId: 'pds-textarea-default-example',
   label: 'Name',
-  onChange: textareaEventExample(),
   name: 'Default',
 };
 

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
@@ -1,9 +1,16 @@
 import { html } from 'lit';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-image'),
   component: 'pds-tooltip',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['mouseEnter', 'pdsTooltipShow', 'mouseLeave', 'pdsTooltipHide'],
+    },
+  },
   title: 'components/Tooltip'
 }
 


### PR DESCRIPTION
# Description

Updates Storybook stories so that custom event data is displayed in the actions panel vs. using custom `console.log` approach which requires using browser dev tools.

Updates include the following components:

- Checkbox
- Chip - (tag variant)
- Copy Text
- Input
- Radio
- Sortable
- Switch
- Tabs (includes event renaming: `tabClick` > `pdsTabClick`)
- Textarea
- Tooltip

Fixes [DSS-458](https://kajabi.atlassian.net/browse/DSS-458)

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update


# How Has This Been Tested?

1. To test, navigate to the components listed above. 
2. Select a story and switch to the Actions panel. 
3. Interact with the component (keyboard, mouse, etc...)
4. Verify events are displayed in the Actions tab as expected.

- [] unit tests
- [] e2e tests
- [x] tested manually
- [] other:


**Test Configuration**:

- os: macOS 13.5.1
- browsers: Chrome(latest), Firefox(latest), Safari(latest)

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-458]: https://kajabi.atlassian.net/browse/DSS-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ