### PR TITLE
docs(tooltip): Update argTypes in story to display correct props

### DIFF
--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
@@ -3,7 +3,7 @@ import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
-  argTypes: extractArgTypes('pds-image'),
+  argTypes: extractArgTypes('pds-tooltip'),
   component: 'pds-tooltip',
   decorators: [withActions],
   parameters: {


### PR DESCRIPTION
# Description

The tooltip documentation currently displays the props table for the image component.
This update changes the story `argTypes` to use the tooltip component.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. Navigate to tooltip
2. Verify tooltip props table displays and not the image props table

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
