### PR TITLE
ci: add build.icons to core scripts to assist with deploy task

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -36,7 +36,8 @@
   ],
   "scripts": {
     "build": "npm run build.stencil",
-    "build.all": "run-s build.stencil build.tokens build.storybook",
+    "build.all": "run-s build.icons build.stencil build.tokens build.storybook",
+    "build.icons": "npx nx run icons:build",
     "build.stencil": "stencil build --docs",
     "build.storybook": "storybook build",
     "build.ts": "tsc -p scripts/tsconfig.json",


### PR DESCRIPTION
# Description

Add a script `build.icons` to the core `package.json` file. This is to assist with the deployment process.

