### PR TITLE
ci: create release workflow

### DIFF
--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -1,5 +1,5 @@
-name: 'Build Pine Core'
-description: 'Builds Pine Core library'
+name: 'Build Core'
+description: 'Builds the Core Design System library'
 
 inputs:
   node-version:
@@ -31,11 +31,9 @@ runs:
     - name: Cache node_modules
       uses: actions/cache@v3
       id: cache-node-modules
-      env:
-        cache-name: cache-node-modules
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-build-${{ github.sha }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-
 

--- a/.github/workflows/actions/download-archive/action.yml
+++ b/.github/workflows/actions/download-archive/action.yml
@@ -19,4 +19,4 @@ runs:
 
     - name:  Extract the Archive
       run: unzip -q -o ${{ inputs.path }}/${{ inputs.filename }}
-      shel: bash
+      shell: bash

--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -35,7 +35,7 @@ runs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
-      run: npm ci --ignore-scripts --legacy-peer-deps
+      run: npm ci --legacy-peer-deps --ignore-scripts
       shell: bash
 
     - name: Update Version

--- a/.github/workflows/actions/test-lint/action.yml
+++ b/.github/workflows/actions/test-lint/action.yml
@@ -19,6 +19,11 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
     - name: Cache node_modules
       uses: actions/cache@v3
       id: cache-node-modules

--- a/.github/workflows/actions/test-spec/action.yml
+++ b/.github/workflows/actions/test-spec/action.yml
@@ -19,6 +19,11 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
     - name: Cache node_modules
       uses: actions/cache@v3
       id: cache-node-modules

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,13 @@
+name: Continuous Deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/release.yml
+    with:
+      preid: ''
+      ref: 'main'
+      tag: 'latest'
+      version: ''

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,99 @@
+name: 'Release Packages'
+
+on:
+  workflow_call:
+    inputs:
+      preid:
+        description: 'The prerelease id used when doing a prerelease. e.g prerelease, premajor, preminor, etc.'
+        type: string
+        default: ''
+
+      ref:
+        description: 'This could be a branch name, tag, or a SHA.'
+        type: string
+        default: ''
+
+      tag:
+        description: 'The tag to publish on NPM.'
+        required: true
+        type: string
+
+      version:
+        description: 'The type of version to release.'
+        required: true
+        type: string
+
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+jobs:
+  release-core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Configure user
+        run: |
+          git config user.name "DSS Automation Bot"
+          git config user.email "dev+github-bot@kajabi.com"
+
+      - name: Publish Core
+        uses: ./.github/workflows/actions/publish-npm
+        with:
+          preid: ${{ inputs.preid }}
+          project: 'core'
+          tag: ${{ inputs.tag }}
+          token: ${{ secrets.NPM_TOKEN }}
+          version: ${{ inputs.version }}
+          working-directory: 'libs/core'
+
+      - name: Cache Built core
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: pine-core
+          output: libs/core/CoreBuild.zip
+          paths: libs/core/dist libs/core/components libs/core/css libs/core/hydrate libs/core/loader libs/core/src/components.d.ts
+
+  release-react:
+    needs: [release-core]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Restore core built cache
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: pine-core
+          path: ./libs/core
+          filename: CoreBuild.zip
+
+      - name: Configure user
+        run: |
+          git config user.name "Kajabi Automation Bot"
+          git config user.email "dev+github-bot@kajabi.com"
+
+      - name: Publish React
+        uses: ./.github/workflows/actions/publish-npm
+        with:
+          preid: ${{ inputs.preid }}
+          project: 'react'
+          tag: ${{ inputs.tag }}
+          token: ${{ secrets.NPM_TOKEN }}
+          version: ${{ inputs.version }}
+          working-directory: 'libs/react'
+
+      - name: Cache Built react
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: pine-react
+          output: libs/react/ReactBuild.zip
+          paths: libs/react/dist libs/react/css

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: 'Production Release'
+
+on:
+  workflow_call:
+    inputs:
+      preid:
+        description: Which prerelease id should be used? This is only needed when a version is "prepatch", "preminor", "premajor", or "prerelease".
+        type: string
+        default: ''
+
+      ref:
+        type: string
+        description: The branch name, tag, or SHA to be checked out. This can also be left blank.
+        default: ''
+
+      tag:
+        type: 'string'
+        required: true
+        description: Which npm tag should this be published to
+
+      version:
+        type: string
+        description: Which version should be published?
+
+  workflow_dispatch:
+    inputs:
+      preid:
+        type: choice
+        description: Which prerelease id should be used? This is only needed when a version is "prepatch", "preminor", "premajor", or "prerelease".
+        options:
+          - ''
+          - alpha
+          - beta
+          - rc
+          - next
+
+      ref:
+        type: string
+        description: The branch name, tag, or SHA to be checked out. This can also be left blank.
+        default: ''
+
+      tag:
+        type: choice
+        required: true
+        description: Which npm tag should this be published to
+        options:
+          - latest
+          - next
+          - dev
+
+      version:
+        type: choice
+        description: Which version should be published?
+        options:
+          - ''
+          - patch
+          - minor
+          - major
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
+
+jobs:
+    release:
+      permissions:
+        id-token: write
+      uses: ./.github/workflows/release-packages.yml
+      with:
+        preid: ${{ inputs.preid }}
+        tag: ${{ inputs.tag }}
+        version: ${{ inputs.version }}
+      secrets: inherit
+
+    finalize-release:
+      needs: release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            fetch-depth: 0
+            ref: ${{ inputs.ref }}
+
+        - name: Configure user
+          run: |
+            git config user.name "DSS Automation Bot"
+            git config user.email "dev+github-bot@kajabi.com"
+
+        - name: Create GitHub Release
+          run: lerna version ${{ inputs.version }} --yes --force-publish='*' --conventional-commits --create-release github --preid=${{ inputs.preid }}
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          shell: bash
+
+        # Lerna does not automatically bump versions
+        - name: Bump Package Lock
+          run: |
+            lerna exec "npm install --package-lock-only"
+            git add .
+            git commit -m "chore(): update package lock files"
+            git push
+          shell: bash

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -20,7 +20,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/core/core.esm.js",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/",
+    "access": "public",
     "directory": "dist"
   },
   "repository": {


### PR DESCRIPTION
# Description

Creates the workflows necessary to deploy the packages to NPM.

* release: This is the main workflow that executes the child workflows and steps
* release-packages: This workflow has the ownership of releasing each package. Currently, that is `core` and `react`
* cd: This will be the Continuous Deployment workflow. We as a team will need to iron out how we want this to look. 