### PR TITLE
Avatar - Has Selector

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -20,8 +20,15 @@ div {
     border-radius: 12px;
   }
 
-  &:has(img) {
-    background-color: transparent;
+  // Remove when FF has support for :has
+  :host(.pds-avatar--has-image) & {
+    background: transparent
+  }
+
+  @supports selector(:has) {
+    &:has(img) {
+      background-color: transparent
+    }
   }
 }
 

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -20,15 +20,8 @@ div {
     border-radius: 12px;
   }
 
-  // Remove when FF has support for :has
-  :host(.pds-avatar--has-image) & {
-    background: transparent
-  }
-
-  @supports selector(:has) {
-    &:has(img) {
-      background-color: transparent
-    }
+  &:has(img) {
+    background-color: transparent;
   }
 }
 

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -112,6 +112,7 @@ export class PdsAvatar {
   private classNames = () => (
     {
       'pds-avatar': true,
+      [`pds-avatar--has-image`]: this.image !== '' && this.image !== null, // Remove when FF supports :has selector
       [`pds-avatar--${this.variant}`]: this.variant === 'admin'
     }
   );

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -112,7 +112,6 @@ export class PdsAvatar {
   private classNames = () => (
     {
       'pds-avatar': true,
-      [`pds-avatar--has-image`]: this.image !== '' && this.image !== null, // Remove when FF supports :has selector
       [`pds-avatar--${this.variant}`]: this.variant === 'admin'
     }
   );

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -90,7 +90,7 @@ describe('pds-avatar', () => {
       html: `<pds-avatar image="https://placehold.co/64x64" size="lg"></pds-avatar>`
     });
     expect(page.root).toEqualHtml(`
-      <pds-avatar class="pds-avatar pds-avatar--has-image" image="https://placehold.co/64x64" size="lg" variant="customer">
+      <pds-avatar class="pds-avatar" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
           <div style="height: 56px; width: 56px;">
             <img src="https://placehold.co/64x64"/>
@@ -106,7 +106,7 @@ describe('pds-avatar', () => {
       html: `<pds-avatar alt="Customer Profile" image="https://placehold.co/64x64" size="lg"></pds-avatar>`
     });
     expect(page.root).toEqualHtml(`
-      <pds-avatar class="pds-avatar pds-avatar--has-image" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
+      <pds-avatar class="pds-avatar" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
           <div style="height: 56px; width: 56px;">
             <img alt="Customer Profile" src="https://placehold.co/64x64"/>
@@ -122,7 +122,7 @@ describe('pds-avatar', () => {
       html: `<pds-avatar badge="true" alt="Customer Profile" image="https://placehold.co/64x64" size="lg"></pds-avatar>`
     });
     expect(page.root).toEqualHtml(`
-      <pds-avatar class="pds-avatar pds-avatar--has-image" badge="true" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
+      <pds-avatar class="pds-avatar" badge="true" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
           <div style="height: 56px; width: 56px">
             <img alt="Customer Profile" src="https://placehold.co/64x64"/>

--- a/libs/core/src/components/pds-radio/readme.md
+++ b/libs/core/src/components/pds-radio/readme.md
@@ -12,7 +12,6 @@
 | `checked`                  | `checked`        | Determines whether or not the radio is checked.                                                     | `boolean` | `false`     |
 | `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute and the label `for` attribute. | `string`  | `undefined` |
 | `disabled`                 | `disabled`       | Determines whether or not the radio is disabled.                                                    | `boolean` | `false`     |
-| `errorMessage`             | `error-message`  | Displays message text describing an invalid state.                                                  | `string`  | `undefined` |
 | `helperMessage`            | `helper-message` | String used for helper message below radio.                                                         | `string`  | `undefined` |
 | `invalid`                  | `invalid`        | Determines whether or not the radio is invalid.                                                     | `boolean` | `false`     |
 | `label`                    | `label`          | String used for label text next to radio.                                                           | `string`  | `undefined` |

--- a/libs/core/src/components/pds-radio/readme.md
+++ b/libs/core/src/components/pds-radio/readme.md
@@ -12,6 +12,7 @@
 | `checked`                  | `checked`        | Determines whether or not the radio is checked.                                                     | `boolean` | `false`     |
 | `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute and the label `for` attribute. | `string`  | `undefined` |
 | `disabled`                 | `disabled`       | Determines whether or not the radio is disabled.                                                    | `boolean` | `false`     |
+| `errorMessage`             | `error-message`  | Displays message text describing an invalid state.                                                  | `string`  | `undefined` |
 | `helperMessage`            | `helper-message` | String used for helper message below radio.                                                         | `string`  | `undefined` |
 | `invalid`                  | `invalid`        | Determines whether or not the radio is invalid.                                                     | `boolean` | `false`     |
 | `label`                    | `label`          | String used for label text next to radio.                                                           | `string`  | `undefined` |


### PR DESCRIPTION
# Description
CSS `:has()` selector is now available for use in all major browsers. The final holdout was previously Firefox, but as of Firefox 121, it is now included.

This replaces an extra conditional CSS class `pds-avatar--has-image` in favor of using the `:has()` selector to achieve the same result, effectively removing a few lines of code.

## Type of change

- [x] Refactor (refactors code to use new browser feature)

# How Has This Been Tested?

The latest version of Firefox, version 121, is required to test this change.

Before (with no selector, note the yellow background visible):
<img width="503" alt="Screenshot 2023-12-19 at 11 31 25 AM" src="https://github.com/Kajabi/pine/assets/14791307/446e017c-127d-4089-8479-8514d8009e5a">

After (in FF 121):
<img width="1058" alt="Screenshot 2023-12-19 at 11 05 38 AM" src="https://github.com/Kajabi/pine/assets/14791307/2cb8ba54-d584-4937-8e77-c0a1b9666655">

- [x] tested manually

**Test Configuration**:

- Browsers: Firefox

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
