### PR TITLE
ci: change default branch to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "next", "*" ]
+    branches: [ "main", "*" ]
     paths-ignore:
       - 'spec/**'
       - '**/*.spec.*'
@@ -25,7 +25,7 @@ on:
       - '.github/**'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "next", "*" ]
+    branches: [ "main", "*" ]
     paths-ignore:
       - 'spec/**'
       - '**/*.spec.*'

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,7 +21,7 @@ metadata:
     - typescript
     - web-components
   annotations:
-    backstage.io/source-location: url:https://github.com/Kajabi/pine/tree/next
+    backstage.io/source-location: url:https://github.com/Kajabi/pine/tree/main
     github.com/project-slug: Kajabi/pine
 spec:
   type: library


### PR DESCRIPTION
# Description

This is in preparation for removing from the git-flow branching strategy. We will work off the main branch, similar to how things are done in Kajabi Products