### PR TITLE
fix(avatar): style issues for admin variant

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -11,13 +11,14 @@ div {
 
   align-items: center;
   background-color: var(--background-color);
-  border-radius: var(--radius-round);
+  border-radius: var(--admin-radius-round, var(--radius-round));
   display: inline-flex;
   justify-content: center;
   position: relative;
 
   :host(.pds-avatar--admin) & {
-    border-radius: 12px;
+    --admin-radius-round: 12px;
+    border-radius: var(--admin-radius-round);
   }
 
   // Remove when FF has support for :has
@@ -33,7 +34,6 @@ div {
 }
 
 .pds-avatar__button {
-  --radius-round: 50%;
   --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
 
   align-items: center;
@@ -63,6 +63,8 @@ div {
 }
 
 img {
-  border-radius: var(--radius-round);
+  border-radius: var(--admin-radius-round, var(--radius-round));
+  height: 100%;
+  object-fit: cover;
   width: 100%;
 }

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -73,7 +73,7 @@ export class PdsAvatar {
   private renderAvatar = () => {
     const style = {
       height: this.avatarSize(),
-      width: this.avatarSize(),
+      width: this.avatarSize()
     };
     return (
       this.dropdown


### PR DESCRIPTION
# Description

During our Battle planning we discovered that the Admin variant was broken when an image was applied.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In the playground on the Avatar docs page, set the following
1. size: `200px`
2. image: `https://images.fineartamerica.com/images/artworkimages/mediumlarge/3/mighty-mouse-terrytoons.jpg`
3. variant: `admin`

**Output**
![image](https://github.com/Kajabi/pine/assets/1633290/2dd69624-1069-469f-bc7b-c92d1291bb57)


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
