### PR TITLE
feat(button): add css shadow parts

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -1,6 +1,12 @@
 import { Component, Element, Host, h, Prop } from '@stencil/core';
 import { hasShadowDom } from '../../utils/utils';
 
+/**
+ * @part button - The main button element that represents the button component.
+ * @part caret - The caret icon element that appears when the button variant is 'disclosure'.
+ * @part icon - The icon element that appears before the text in the button, if provided.
+*/
+
 @Component({
   tag: 'pds-button',
   styleUrl: 'pds-button.scss',

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -87,12 +87,13 @@ export class PdsButton {
           class={this.classNames()}
           disabled={this.disabled}
           name={this.name}
+          part="button"
           type={this.type}
           value={this.value}
         >
-          {this.icon && this.variant !== 'disclosure' && <pds-icon name={this.icon}></pds-icon>}
+          {this.icon && this.variant !== 'disclosure' && <pds-icon name={this.icon} part="icon"></pds-icon>}
           <slot />
-          {this.variant === 'disclosure' && <pds-icon name="caret-down"></pds-icon>}
+          {this.variant === 'disclosure' && <pds-icon name="caret-down" part="caret"></pds-icon>}
         </button>
       </Host>
     );

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -20,11 +20,11 @@
 
 ## Shadow Parts
 
-| Part       | Description |
-| ---------- | ----------- |
-| `"button"` |             |
-| `"caret"`  |             |
-| `"icon"`   |             |
+| Part       | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `"button"` | The main button element that represents the button component.                |
+| `"caret"`  | The caret icon element that appears when the button variant is 'disclosure'. |
+| `"icon"`   | The icon element that appears before the text in the button, if provided.    |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -18,6 +18,15 @@
 | `variant`     | `variant`      | Sets button variant styles as outlined in Figma documentation         | `"accent" \| "destructive" \| "disclosure" \| "primary" \| "secondary" \| "unstyled"` | `'primary'` |
 
 
+## Shadow Parts
+
+| Part       | Description |
+| ---------- | ----------- |
+| `"button"` |             |
+| `"caret"`  |             |
+| `"icon"`   |             |
+
+
 ## Dependencies
 
 ### Used by

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -10,7 +10,7 @@ describe('pds-button', () => {
     expect(root).toEqualHtml(`
       <pds-button variant="primary">
         <mock:shadow-root>
-          <button class="pds-button pds-button--primary" type="button">
+          <button class="pds-button pds-button--primary" part="button" type="button">
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -26,7 +26,7 @@ describe('pds-button', () => {
     expect(root).toEqualHtml(`
       <pds-button variant="accent">
         <mock:shadow-root>
-          <button class="pds-button pds-button--accent" type="button">
+          <button class="pds-button pds-button--accent" part="button" type="button">
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -42,7 +42,7 @@ describe('pds-button', () => {
     expect(root).toEqualHtml(`
       <pds-button variant="unstyled">
         <mock:shadow-root>
-          <button class="pds-button pds-button--unstyled" type="button">
+          <button class="pds-button pds-button--unstyled" part="button" type="button">
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -58,7 +58,7 @@ describe('pds-button', () => {
     expect(root).toEqualHtml(`
       <pds-button disabled="true" aria-disabled="true" variant="primary">
         <mock:shadow-root>
-          <button class="pds-button pds-button--primary" type="button" disabled>
+          <button class="pds-button pds-button--primary" part="button" type="button" disabled>
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -75,7 +75,7 @@ describe('pds-button', () => {
     expect(page.root).toEqualHtml(`
       <pds-button component-id="test" id="test" variant="primary">
         <mock:shadow-root>
-          <button class="pds-button pds-button--primary" type="button">
+          <button class="pds-button pds-button--primary" part="button" type="button">
             <slot></slot>
           </button>
         </mock:shadow-root>


### PR DESCRIPTION
# Description

Adds CSS shadow parts to the button component. This will expose the parts making up the buttons to allow styling of the button component when it's placed within other components.

Fixes [DSS-523](https://kajabi.atlassian.net/browse/DSS-523)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- Navigate to Button
- Verify the parts (button, icon, caret) are displayed in the button markup/DOM as expected. (dev tools)

![Screenshot 2024-02-08 at 2 51 07 PM](https://github.com/Kajabi/pine/assets/1175111/8cd40acf-b742-4c9e-b2eb-d6d7bf8536ce)

---
- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-523]: https://kajabi.atlassian.net/browse/DSS-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ