### PR TITLE
Avatar - add image part

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -1,5 +1,8 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 
+/**
+ * @part image - The main image element that represents the avatar component.
+*/
 @Component({
   tag: 'pds-avatar',
   styleUrl: 'pds-avatar.scss',
@@ -79,13 +82,13 @@ export class PdsAvatar {
       this.dropdown
         ?
         <button class="pds-avatar__button" type="button">
-          <div style={style}>
+          <div style={style} part="image">
             {this.renderIconOrImage()}
             {this.renderBadge()}
           </div>
         </button>
         :
-        <div style={style}>
+        <div style={style} part="image">
           {this.renderIconOrImage()}
           {this.renderBadge()}
         </div>

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -73,25 +73,29 @@ export class PdsAvatar {
     }
   }
 
-  private renderAvatar = () => {
+  private renderAssetWrapper = () => {
     const style = {
       height: this.avatarSize(),
       width: this.avatarSize()
     };
+    
+    return (
+      <div style={style} part="asset-wrapper">
+        {this.renderIconOrImage()}
+        {this.renderBadge()}
+      </div>
+    )
+  };
+
+  private renderAvatar = () => {
     return (
       this.dropdown
         ?
         <button class="pds-avatar__button" type="button">
-          <div style={style} part="image">
-            {this.renderIconOrImage()}
-            {this.renderBadge()}
-          </div>
+          {this.renderAssetWrapper()}
         </button>
         :
-        <div style={style} part="image">
-          {this.renderIconOrImage()}
-          {this.renderBadge()}
-        </div>
+        this.renderAssetWrapper()
     )
   };
 

--- a/libs/core/src/components/pds-avatar/readme.md
+++ b/libs/core/src/components/pds-avatar/readme.md
@@ -18,6 +18,13 @@
 | `variant`     | `variant`      | Determines the variant of avatar. Changes appearance accordingly.     | `"admin" \| "customer"` | `'customer'` |
 
 
+## Shadow Parts
+
+| Part      | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `"image"` | The main image element that represents the avatar component. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/libs/core/src/components/pds-avatar/readme.md
+++ b/libs/core/src/components/pds-avatar/readme.md
@@ -20,9 +20,10 @@
 
 ## Shadow Parts
 
-| Part      | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| `"image"` | The main image element that represents the avatar component. |
+| Part              | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `"asset-wrapper"` |                                                              |
+| `"image"`         | The main image element that represents the avatar component. |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -10,7 +10,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px;">
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
@@ -27,7 +27,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar component-id="test" id="test" class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px;">
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
@@ -43,7 +43,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar pds-avatar--admin" size="lg" variant="admin">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px">
+          <div part="asset-wrapper" style="height: 56px; width: 56px">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
@@ -59,7 +59,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar" badge="true" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px;">
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
             <pds-icon class="pds-avatar__badge" name="check-circle-filled" size="33.53%"></pds-icon>
           </div>
@@ -76,7 +76,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar" size="128px" variant="customer">
         <mock:shadow-root>
-          <div style="height: 128px; width: 128px">
+          <div part="asset-wrapper" style="height: 128px; width: 128px">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
@@ -92,7 +92,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar pds-avatar--has-image" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px;">
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
             <img src="https://placehold.co/64x64"/>
           </div>
         </mock:shadow-root>
@@ -108,7 +108,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar pds-avatar--has-image" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px;">
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
             <img alt="Customer Profile" src="https://placehold.co/64x64"/>
           </div>
         </mock:shadow-root>
@@ -124,7 +124,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar pds-avatar--has-image" badge="true" alt="Customer Profile" image="https://placehold.co/64x64" size="lg" variant="customer">
         <mock:shadow-root>
-          <div style="height: 56px; width: 56px">
+          <div part="asset-wrapper" style="height: 56px; width: 56px">
             <img alt="Customer Profile" src="https://placehold.co/64x64"/>
             <pds-icon class="pds-avatar__badge" name="check-circle-filled" size="33.53%"></pds-icon>
           </div>
@@ -141,11 +141,46 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar" size="xl" variant="customer">
         <mock:shadow-root>
-          <div style="height: 64px; width: 64px;">
+          <div part="asset-wrapper" style="height: 64px; width: 64px;">
             <pds-icon name="user-filled" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
     `);
   });
+
+  it('renders avatar as a button when dropdown prop is true', async () => {
+    const page = await newSpecPage({
+      components: [PdsAvatar],
+      html: `<pds-avatar dropdown="true"></pds-avatar>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-avatar class="pds-avatar" dropdown="true" size="lg" variant="customer">
+        <mock:shadow-root>
+          <button class="pds-avatar__button" type="button">
+            <div part="asset-wrapper" style="height: 56px; width: 56px;">
+              <pds-icon name="user-filled" size="33.53%"></pds-icon>
+            </div>
+          </button>
+        </mock:shadow-root>
+      </pds-avatar>
+    `);
+  });
+  
+  it('renders avatar without button when dropdown prop is false', async () => {
+    const page = await newSpecPage({
+      components: [PdsAvatar],
+      html: `<pds-avatar dropdown="false"></pds-avatar>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-avatar class="pds-avatar" dropdown="false" size="lg" variant="customer">
+        <mock:shadow-root>
+          <div part="asset-wrapper" style="height: 56px; width: 56px;">
+            <pds-icon name="user-filled" size="33.53%"></pds-icon>
+          </div>
+        </mock:shadow-root>
+      </pds-avatar>
+    `);
+  });
+  
 });


### PR DESCRIPTION
# Description
This PR adds the `image` part to the image or icon wrapper. This is needed to apply additional styling to the `border-radius` for the upcoming [User Profile dropdown work in kp](https://github.com/Kajabi/kajabi-products/pull/32974). 

- [x] add `image` CSS part

Fixes #(issue) [DSS-528](https://kajabi.atlassian.net/browse/DSS-528)

## Screenshots
|  Before  |  After  |
|--------|--------|
|![Screenshot_2024-03-06_at_11_26_07 AM](https://github.com/Kajabi/pine/assets/1241836/04216508-4c53-4c99-bae2-ee28edbd7b4a)|![Screenshot_2024-03-06_at_11_24_49 AM](https://github.com/Kajabi/pine/assets/1241836/34a3378d-a535-4150-8bb0-f4e069b23bf4)|


## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-528]: https://kajabi.atlassian.net/browse/DSS-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ