### PR TITLE
Accordion - Updates Summary Font Style

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -8,9 +8,9 @@ details {
   --color-content-background: var(--pine-base-color-white);
   --color-background-hover: var(--pine-color-neutral-grey-300);
   --color-font: var(--pine-color-neutral-charcoal-200);
-  --color-font-active: var(--pine-color-neutral-charcoal-400);
+  --color-font-active: var(--pine-color-neutral-charcoal-500);
   --color-font-hover: var(--pine-color-neutral-charcoal-300);
-  --font-weight: var(--pine-font-weight-medium);
+  --font-weight: var(--pine-font-weight-semibold);
   --spacing-details-padding-inline: 12px;
   --spacing-summary-padding-block: var(--pine-spacing-xxs);
   --spacing-summary-padding-inline-start: var(--pine-spacing-xs);
@@ -26,6 +26,7 @@ details[open] {
 
   summary {
     color: var(--color-font-active);
+    font-weight: var(--font-weight);
   }
 }
 


### PR DESCRIPTION
# Description
Updates summary trigger button to 600 font weight by default and charcoal 500 when active.

[Figma](https://www.figma.com/file/k6e1a1j4OS8yYr54H1v0B4/%5BWIP%5D--%F0%9F%A7%A9-Pine-components?type=design&node-id=27040%3A16084&mode=design&t=eLGcNYZfWoAOiiKF-1)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

