### PR TITLE
docs: add documentation regarding assets for icons

### DIFF
--- a/libs/core/src/stories/assets.docs.mdx
+++ b/libs/core/src/stories/assets.docs.mdx
@@ -1,0 +1,69 @@
+import { Meta, Story } from '@storybook/blocks';
+
+<Meta title="Resources/Assets"/>
+
+# Assets
+
+The icon component require static assets during runtime.
+
+By default, Pine and `pds-icon` components will fetch these assets via [jsDelivr](https://www.jsdelivr.com/). JsDelivr is a free CDN for open source projects. However, as we cannot guarantee the availability and performance of this CDN, we recommend bundling the assets with your application.
+
+Copy the assets from the Pine Design System package to your application. We recommend including copying these assets in your build process, which ensures that the assets are always up to date.
+
+
+  You should add the copied assets (e.g. <code>public/assets/pine-ds/svg/*</code>) to your <code>.gitignore</code> file.
+
+For the following example, we assume you are using [Vite](https://vitejs.dev/). By default, Vite uses the `public` folder for static assets. To include the Pine Design System assets in your output bundle, you can copy them to this folder.
+
+First, install the `rollup-plugin-copy` plugin. This plugin allows you to copy files and folders while building.
+
+```sh
+npm install rollup-plugin-copy -D
+```
+
+Now include the copy plugin in your Vite config. Add the following code to your `vite.config.ts` file. This will copy the Pine Design System assets from the 'node_modules' folder to the 'public' folder, so Vite will bundle them.
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite'
+import copy from 'rollup-plugin-copy'
+
+export default defineConfig({
+  plugins: [
+    copy({
+      targets: [
+        {
+          src: 'node_modules/@pine-ds/core/dist/pine-core/svg/*',
+          dest: 'public/assets/pine-ds/svg',
+        },
+      ],
+      hook: 'buildStart',
+    }),
+    // ...other plugins e.g. react()
+  ],
+  // ...other config options
+})
+```
+
+You need to "tell" Pine Design System where to find the assets. The components will look for the `__PINE_ASSET_PATH__` variable in the `window` object. The path should point to the `pine-ds/svg` folder.
+
+You have 2 options:
+
+1. Specify the asset path using a metadata element in the document head section:
+
+```html
+<!-- index.html -->
+<meta data-pine-asset-path='/assets/pine-ds/'>
+```
+
+2. Specify the asset path by setting the `__PINE_ASSET_PATH__` variable on the `window` object:
+
+```tsx
+// main.tsx
+// if-clause only required in server-side rendering context
+if (typeof window !== 'undefined') {
+  window.__PINE_ASSET_PATH__ = '/assets/pine-ds/'
+}
+```
+
+Once the asset path is set and the assets are available on runtime, all components can automatically load their assets.


### PR DESCRIPTION
# Description

Adds documentation to show various options to set the asset path for Icons. 

Direct Path to deployment preview: https://deploy-preview-153--pine-design-system.netlify.app/?path=/docs/resources-assets--docs

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

