### PR TITLE
feat(accordion): add animation to accordion

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -47,7 +47,7 @@ details[open] {
 
     /* stylelint-disable-next-line selector-no-qualifying-type */
     &.open {
-      max-height: 5000px;
+      max-height: max-content;
     }
 
   }

--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -3,6 +3,7 @@
 }
 
 details {
+  --animation-transform-timing: 200ms;
   --border-radius: var(--pine-spacing-xs);
   --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
   --color-content-background: var(--pine-base-color-white);
@@ -17,16 +18,31 @@ details {
   --spacing-summary-padding-inline-end: var(--pine-spacing-xxs);
 
   border-radius: var(--border-radius);
-  padding-inline: var(--spacing-details-padding-inline)
+  padding-inline: var(--spacing-details-padding-inline);
+
+  pds-icon {
+    transform: scaleY(1);
+    transition: transform var(--animation-transform-timing);
+  }
 }
 
 /* stylelint-disable-next-line */
 details[open] {
   background-color: var(--color-content-background);
+  transition: transform var(--animation-transform-timing);
 
   summary {
     color: var(--color-font-active);
     font-weight: var(--font-weight);
+
+    ~ * {
+      animation: fadeIn 150ms ease-in;
+    }
+
+    pds-icon {
+      transform: scaleY(-1);
+      transition: transform var(--animation-transform-timing);
+    }
   }
 }
 
@@ -63,4 +79,16 @@ summary {
   pds-icon {
     margin-inline-start: auto;
   }
+}
+
+@keyframes fadeIn {
+ 0% {
+   opacity: 0;
+   transform: translateY(-10px);
+ }
+
+ 100% {
+   opacity: 1;
+   transform: translateY(0);
+ }
 }

--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -35,14 +35,21 @@ details[open] {
     color: var(--color-font-active);
     font-weight: var(--font-weight);
 
-    ~ * {
-      animation: fadeIn 150ms ease-in;
-    }
-
     pds-icon {
       transform: scaleY(-1);
       transition: transform var(--animation-transform-timing);
     }
+  }
+
+  /* stylelint-disable-next-line selector-no-qualifying-type */
+  .pds-accordion__body {
+    transition: max-height 1s ease-in-out;
+
+    /* stylelint-disable-next-line selector-no-qualifying-type */
+    &.open {
+      max-height: 5000px;
+    }
+
   }
 }
 
@@ -81,14 +88,8 @@ summary {
   }
 }
 
-@keyframes fadeIn {
- 0% {
-   opacity: 0;
-   transform: translateY(-10px);
- }
-
- 100% {
-   opacity: 1;
-   transform: translateY(0);
- }
+.pds-accordion__body {
+  max-height: 0;
+  overflow: hidden;
 }
+

--- a/libs/core/src/components/pds-accordion/pds-accordion.tsx
+++ b/libs/core/src/components/pds-accordion/pds-accordion.tsx
@@ -12,6 +12,7 @@ import { downSmall } from '@pine-ds/icons/icons';
 })
 export class PdsAccordion {
   private detailsEl: HTMLDetailsElement;
+  private containerEl: HTMLDivElement;
 
   /**
    * A unique identifier used for the underlying component `id` attribute.
@@ -32,6 +33,12 @@ export class PdsAccordion {
   @Watch('isOpen')
   handleOpenState(newValue: boolean) {
     this.isOpen = newValue;
+
+    if ( newValue === true ) {
+      this.containerEl.classList.add('open');
+    } else {
+      this.containerEl.classList.remove('open');
+    }
   }
 
   private handleToggle = () => {
@@ -57,7 +64,7 @@ export class PdsAccordion {
             <slot name="label">Details</slot>
             <pds-icon icon={ downSmall } />
           </summary>
-          <div class="pds-accordion__body">
+          <div class={`pds-accordion__body ${this.isOpen ? 'open' : ''}`} ref={(el) => this.containerEl = el as HTMLDivElement}>
             <slot />
           </div>
         </details>

--- a/libs/core/src/components/pds-accordion/pds-accordion.tsx
+++ b/libs/core/src/components/pds-accordion/pds-accordion.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Host, Prop, Watch } from '@stencil/core';
-import { downSmall, upSmall } from '@pine-ds/icons/icons';
+import { downSmall } from '@pine-ds/icons/icons';
 
 /**
  * @slot (default) - Accordion body content.
@@ -23,10 +23,10 @@ export class PdsAccordion {
    * Can be used to manually set the open state of the accordion.
    * @defaultValue false
    */
-  @Prop({ 
+  @Prop({
     attribute: 'open',
     mutable: true,
-    reflect: true 
+    reflect: true
   }) isOpen: boolean = false;
 
   @Watch('isOpen')
@@ -55,7 +55,7 @@ export class PdsAccordion {
         <details {...this.getOpenAttribute()} ref={(el) => this.detailsEl = el as HTMLDetailsElement}>
           <summary>
             <slot name="label">Details</slot>
-            <pds-icon icon={this.isOpen ? upSmall : downSmall } />
+            <pds-icon icon={ downSmall } />
           </summary>
           <div class="pds-accordion__body">
             <slot />

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
@@ -1,6 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsAccordion } from '../pds-accordion';
-import { downSmall, upSmall } from '@pine-ds/icons/icons';
+import { downSmall } from '@pine-ds/icons/icons';
 
 describe('pds-accordion', () => {
   it('renders the accordion', async () => {
@@ -36,7 +36,7 @@ describe('pds-accordion', () => {
             <details open>
               <summary>
                 <slot name="label">Details</slot>
-                <pds-icon icon="${upSmall}"></pds-icon>
+                <pds-icon icon="${downSmall}"></pds-icon>
               </summary>
               <div class="pds-accordion__body">
                 <slot />
@@ -130,7 +130,7 @@ describe('pds-accordion', () => {
           <details open>
             <summary>
               <slot name="label">Details</slot>
-              <pds-icon icon="${upSmall}"></pds-icon>
+              <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
             <div class="pds-accordion__body">
               <slot />

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
@@ -38,7 +38,7 @@ describe('pds-accordion', () => {
                 <slot name="label">Details</slot>
                 <pds-icon icon="${downSmall}"></pds-icon>
               </summary>
-              <div class="pds-accordion__body">
+              <div class="open pds-accordion__body">
                 <slot />
               </div>
             </details>
@@ -132,7 +132,7 @@ describe('pds-accordion', () => {
               <slot name="label">Details</slot>
               <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
-            <div class="pds-accordion__body">
+            <div class="open pds-accordion__body">
               <slot />
             </div>
           </details>


### PR DESCRIPTION
# Description

During the AppFrame design review, we agreed that we wanted to add a transition animation for the accordion


Loom video: https://www.loom.com/share/de94e5a22a8f41f39ec47e61699aef6f

Fixes #(issue)
https://kajabi.atlassian.net/browse/DSS-543

* Adds animation when opening the accordion
* Marker also animates when opening.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [x] other:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
