### PR TITLE
Accessibility: Updates Component Focus Rings

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -5,7 +5,7 @@
 details {
   --animation-transform-timing: 200ms;
   --border-radius: var(--pine-spacing-xs);
-  --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
+  --box-shadow-focus: inset 0 0 0 2px var(--pine-color-primary-200);
   --color-content-background: var(--pine-base-color-white);
   --color-background-hover: var(--pine-color-neutral-grey-300);
   --color-font: var(--pine-color-neutral-charcoal-200);

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -34,7 +34,8 @@ div {
 }
 
 .pds-avatar__button {
-  --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
+  --radius-round: 50%;
 
   align-items: center;
   appearance: none;

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -1,6 +1,8 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsAvatar } from '../pds-avatar';
 
+import { userFilled } from '@pine-ds/icons/icons';
+
 describe('pds-avatar', () => {
   it('renders a default avatar', async () => {
     const page = await newSpecPage({
@@ -11,7 +13,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -28,7 +30,7 @@ describe('pds-avatar', () => {
       <pds-avatar component-id="test" id="test" class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -44,7 +46,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar pds-avatar--admin" size="lg" variant="admin">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -60,7 +62,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" badge="true" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-primary-400)"icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)"icon="${userFilled}" size="33.53%"></pds-icon>
             <pds-icon class="pds-avatar__badge" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' class='pdsicon'><path d='M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8Zm4.473 5.807L7.14 11.14c-.26.26-.68.26-.94 0L3.533 8.473a.664.664 0 1 1 .94-.94l2.194 2.194 4.86-4.86c.26-.26.68-.26.94 0 .266.253.266.68.006.94Z'/></svg>" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
@@ -77,7 +79,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="128px" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 128px; width: 128px">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -142,7 +144,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="xl" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 64px; width: 64px;">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -159,7 +161,7 @@ describe('pds-avatar', () => {
         <mock:shadow-root>
           <button class="pds-avatar__button" type="button">
             <div part="asset-wrapper" style="height: 56px; width: 56px;">
-              <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+              <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
             </div>
           </button>
         </mock:shadow-root>
@@ -176,7 +178,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" dropdown="false" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-primary-400)" icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 17' class='pdsicon'><path fill-rule='evenodd' d='M11.667 3.697C11.667 5.687 10.067 8 8 8 5.933 8 4.333 5.687 4.333 3.697a3.667 3.667 0 1 1 7.334 0Zm-8.77 7.2c1-1 2.356-1.562 3.77-1.564h2.666a5.34 5.34 0 0 1 5.334 5.334.667.667 0 0 1-.464.635A22.19 22.19 0 0 1 8 16a22.19 22.19 0 0 1-6.203-.698.667.667 0 0 1-.464-.635 5.34 5.34 0 0 1 1.564-3.77Z'/></svg>" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-primary-400)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -64,9 +64,12 @@
     border-color: var(--border-color-hover);
   }
 
-  &:focus {
+  &:focus-visible {
+    --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
     border-color: var(--border-color-focus);
-    outline: 4px solid var(--outline-color);
+    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
+    outline: none;
   }
 
   &:disabled {

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -7,6 +7,8 @@
   --border-color-hover: var(--pine-border-interactive-hover-color);
   --border-color-icon: var(--pine-color-base-white);
   --border-radius: var(--pine-border-radius-xs);
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
+  --box-shadow-focus-invalid: 0 0 0 2px var(--pine-color-red-200);
   --color-checked: var(--pine-color-neutral-charcoal-500);
   --color-disabled: var(--pine-color-neutral-grey-300);
   --color-focus: var(--pine-color-primary-200);
@@ -30,7 +32,8 @@
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 4px var(--color-invalid-focus);
+      // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+      box-shadow: var(--box-shadow-focus-invalid); // Remove when outline radius is supported in Safari
       outline: none;
     }
   }
@@ -109,7 +112,8 @@ input {
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 4px var(--color-focus);
+    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
     outline: none;
   }
 }

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -17,7 +17,7 @@
   --background-warning: var(--pine-color-yellow-100);
   --background-warning-dot: var(--pine-color-yellow-300);
   --background-warning-interactive: var(--pine-color-yellow-200);
-  --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
 
   --border-radius: var(--pine-border-radius-lg);
   --font-size: var(--pine-font-size-body-sm);

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -5,7 +5,7 @@
   --border: var(--pine-border-interactive);
   --border-hover: var(--pine-border-interactive-hover-color);
   --border-radius: var(--pine-border-radius-md);
-  --box-shadow-focus: 0 0 0 4px var(--pine-color-primary-200);
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
   --color-hover: var(--pine-color-neutral-charcoal-400);
   --font-size: var(--pine-font-size-body);
   --font-weight: var(--pine-font-weight-semibold);
@@ -25,14 +25,10 @@
     max-width: 100%;
     padding: var(--spacing-xxs) var(--spacing-xs);
 
-    &:hover {
+    &::part(button):hover {
       background-color: var(--background-hover);
+      border-radius: none;
       color: var(--color-hover);
-    }
-
-    &:focus-visible {
-      box-shadow: var(--box-shadow-focus);
-      outline: none;
     }
 
     span {

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -10,7 +10,8 @@
   --border-color-default: var(--pine-color-neutral-grey-400);
   --border-color-hover: var(--pine-color-neutral-grey-500);
 
-  --focus-box-shadow: 0 0 0 4px var(--pine-color-primary-200);
+  --focus-box-shadow: 0 0 0 2px var(--pine-color-primary-200);
+  --focus-box-shadow-error: 0 0 0 2px var(--pine-color-red-200);
 
   --label-font-size: var(--pine-font-size-body);
   --label-font-weight: var(--pine-font-weight-medium);
@@ -61,7 +62,7 @@ input {
     border-color: var(--border-color-hover);
   }
 
-  &:focus {
+  &:focus-visible {
     box-shadow: var(--focus-box-shadow);
     outline: none;
   }
@@ -85,6 +86,11 @@ input {
 
   &:has(~.pds-input__error-message) {
     border-color: var(--color-error);
+
+    &:focus-visible {
+      box-shadow: var(--focus-box-shadow-error);
+      outline: none;
+    }
   }
   /* stylelint-enable */
 }

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -6,6 +6,8 @@
   --border-color-hover: var(--pine-border-interactive-hover-color);
   --border-color-disabled: var(--pine-color-neutral-grey-300);
   --border-radius: 50%;
+  --box-shadow-focus: 0 0 0 2px var(--color-focus);
+  --box-shadow-focus-error: 0 0 0 2px var(--color-invalid-focus);
   --color: var(--pine-color-neutral-charcoal-200);
   --color-checked: var(--pine-color-neutral-charcoal-500);
   --color-disabled: var(--pine-color-neutral-grey-500);
@@ -30,7 +32,7 @@
     }
 
     &:focus-visible {
-      box-shadow: 0 0 0 4px var(--color-invalid-focus);
+      box-shadow: var(--box-shadow-focus-error);
       outline: none;
     }
   }
@@ -98,7 +100,7 @@ input {
   }
 
   &:focus-visible {
-    box-shadow: 0 0 0 4px var(--color-focus);
+    box-shadow: var(--box-shadow-focus);
     outline: none;
   }
 

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -4,6 +4,8 @@
   --background-color-checked-hover: var(--pine-color-neutral-charcoal-400);
   --background-color-disabled: var(--pine-color-neutral-grey-300);
   --background-color-hover: var(--pine-color-neutral-grey-500);
+  --box-shadow-focus: 0 0 0 2px var(--outline-color-focus);
+  --box-shadow-focus-error: 0 0 0 2px var(--outline-color-focus-error);
 
   --input-border-radius: var(--pine-border-radius-lg);
   --input-height: 20px;
@@ -47,7 +49,7 @@
   }
 
   input:focus-visible:not(:disabled):not(:checked) {
-    box-shadow: 0 0 0 4px var(--outline-color-focus-error);
+    box-shadow: var(--box-shadow-focus-error);
   }
 }
 
@@ -136,7 +138,7 @@ input:hover:not(:disabled) {
 
  // Focus state
 input:focus-visible:not(:disabled) {
-  box-shadow: 0 0 0 4px var(--outline-color-focus);
+  box-shadow: var(--box-shadow-focus);
   outline: none;
 }
 

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -2,7 +2,8 @@ pds-tab {
   --background-color-tab: var(--pine-color-neutral-grey-300);
   --background-color-tab-active: var(--pine-color-neutral-charcoal-400);
   --background-color-tab-hover: var(--pine-color-neutral-grey-400);
-  --border-radius: var(--pine-border-radius-xs);
+  --border-radius: var(--pine-border-radius-md);
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-primary-200);
 
   --color: var(--pine-color-neutral-charcoal-200);
   --color-active: var(--pine-color-neutral-charcoal-400);
@@ -37,12 +38,6 @@ pds-tab {
   padding: 0;
 }
 
-// delete later
-*:focus-visible {
-  border-radius: var(--border-radius);
-  outline: var(--outline);
-}
-
 .pds-tab {
   @include pds-button-style-reset();
 
@@ -67,7 +62,9 @@ pds-tab {
   }
 
   &:focus-visible {
-    color: var(--color-focus);
+    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
+    outline: none;
   }
 
   .pds-tab__content {

--- a/libs/core/src/components/pds-tabs/pds-tabs.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabs.scss
@@ -17,11 +17,6 @@
   display: block;
 }
 
-// delete later
-*:focus {
-  outline: var(--outline);
-}
-
 .pds-tabs__tablist {
   display: flex;
   flex-wrap: wrap;

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -12,6 +12,9 @@
   --border-color-focus-visible: var(--pine-color-neutral-grey-300);
   --border-color-error: var(--pine-color-red-300);
 
+  --box-shadow-focus: 0 0 0 2px var(--focus-visible-outline-color);
+  --box-shadow-focus-error: 0 0 0 2px var(--focus-visible-outline-color-error);
+
   --focus-visible-outline-color: var(--pine-color-primary-200);
   --focus-visible-outline-color-error: var(--pine-color-red-200);
 
@@ -68,8 +71,9 @@ label {
   }
 
   &:focus-visible {
-    border-color: var(--border-color-focus-visible);
-    outline: 4px solid var(--focus-visible-outline-color);
+    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
+    outline: none;
   }
 
   &::placeholder {
@@ -78,7 +82,10 @@ label {
 
   &.is-invalid {
     border-color: var(--color-error);
-    outline-color: var(--focus-visible-outline-color-error);
+
+    &:focus-visible {
+      box-shadow: var(--box-shadow-focus-error);
+    }
   }
 }
 


### PR DESCRIPTION
# Description

Updates all component focus rings to 2px box shadows. 

Box shadows are currently used because outlines were bugged in Safari to not respect border-radius. This issue has been fixed as of [Safari 16.4](https://bugs.webkit.org/show_bug.cgi?id=20807). This can be updated to outlines at a later date.

[DSS-545](https://kajabi.atlassian.net/browse/DSS-545)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-545]: https://kajabi.atlassian.net/browse/DSS-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ