### PR TITLE
chore: cleanup icon usage for test

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -1,6 +1,8 @@
 import { Component, Element, Host, h, Prop } from '@stencil/core';
 import { hasShadowDom } from '../../utils/utils';
 
+import { caretDown } from '@pine-ds/icons/icons';
+
 /**
  * @part button - The main button element that represents the button component.
  * @part caret - The caret icon element that appears when the button variant is 'disclosure'.
@@ -99,7 +101,7 @@ export class PdsButton {
         >
           {this.icon && this.variant !== 'disclosure' && <pds-icon name={this.icon} part="icon"></pds-icon>}
           <slot />
-          {this.variant === 'disclosure' && <pds-icon name="caret-down" part="caret"></pds-icon>}
+          {this.variant === 'disclosure' && <pds-icon icon={caretDown} part="caret"></pds-icon>}
         </button>
       </Host>
     );

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { caretDown } from '@pine-ds/icons/icons';
 
 describe('pds-button', () => {
   it('renders', async () => {
@@ -99,13 +100,14 @@ describe('pds-button', () => {
 
   it('renders caret-down icon when variant is disclosure', async () => {
     const page = await newE2EPage();
+
     await page.setContent('<pds-button variant="disclosure"></pds-button>');
 
     const element = await page.find('pds-button >>> button');
     const icon = await element.find('pds-icon');
-    const iconName = await icon.getProperty('name');
+    const iconName = await icon.getProperty('icon');
 
     expect(icon).toBeTruthy();
-    expect(iconName).toBe('caret-down');
+    expect(iconName).toBe(caretDown);
   });
 });

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -78,26 +78,6 @@ describe('pds-button', () => {
     expect(value).toBe(true);
   });
 
-  it('renders toggle of icon', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pds-button></pds-button>');
-    const component = await page.find('pds-button');
-    expect(component).toHaveClass('hydrated');
-
-    const element = await page.find('pds-button >>> button');
-    let icon = await element.find('pds-icon');
-    expect(icon).toBeNull();
-
-    component.setProperty('icon', 'trash');
-    await page.waitForChanges();
-    icon = await element.find('pds-icon');
-
-    const iconName = await icon.getProperty('name');
-
-    expect(icon).toBeTruthy();
-    expect(iconName).toBe('trash');
-  });
-
   it('renders caret-down icon when variant is disclosure', async () => {
     const page = await newE2EPage();
 

--- a/libs/core/src/components/pds-chip/pds-chip.tsx
+++ b/libs/core/src/components/pds-chip/pds-chip.tsx
@@ -1,3 +1,4 @@
+import { downSmall, remove } from '@pine-ds/icons/icons';
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
 
 @Component({
@@ -71,7 +72,7 @@ export class PdsChip {
       <button class="pds-chip__button" type="button">
         {this.dot && <i class="pds-chip__dot" aria-hidden="true"></i>}
         {this.label}
-        <pds-icon name="down-small" size="12px" aria-hidden="true"></pds-icon>
+        <pds-icon icon={downSmall} size="12px" aria-hidden="true"></pds-icon>
       </button>
     ) : (
       <span class="pds-chip__label">
@@ -89,7 +90,7 @@ export class PdsChip {
         {this.setChipContent()}
         {this.variant === 'tag' && (
           <button class="pds-chip__close" type="button" onClick={this.handleCloseClick} aria-label="Remove">
-            <pds-icon name="remove" size="12px"></pds-icon>
+            <pds-icon icon={remove} size="12px"></pds-icon>
           </button>
         )}
       </Host>

--- a/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
+++ b/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
@@ -1,6 +1,8 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsChip } from '../pds-chip';
 
+import { downSmall, remove as removeIcon } from '@pine-ds/icons/icons';
+
 describe('pds-chip', () => {
   it('renders', async () => {
     const page = await newSpecPage({
@@ -104,7 +106,7 @@ describe('pds-chip', () => {
       <mock:shadow-root>
         <span class="pds-chip__label"></span>
         <button class="pds-chip__close" type="button" aria-label="Remove" >
-          <pds-icon name="remove" size="12px"></pds-icon>
+          <pds-icon icon="${removeIcon}" size="12px"></pds-icon>
         </button>
       </mock:shadow-root>
     </pds-chip>
@@ -121,7 +123,7 @@ describe('pds-chip', () => {
     <pds-chip class="pds-chip pds-chip--neutral pds-chip--dropdown" variant="dropdown">
       <mock:shadow-root>
         <button class="pds-chip__button" type="button">
-          <pds-icon name="down-small" size="12px" aria-hidden="true"></pds-icon>
+          <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>
         </button>
       </mock:shadow-root>
     </pds-chip>
@@ -139,7 +141,7 @@ describe('pds-chip', () => {
       <mock:shadow-root>
         <button class="pds-chip__button" type="button">
           <i class="pds-chip__dot" aria-hidden="true"></i>
-          <pds-icon name="down-small" size="12px" aria-hidden="true"></pds-icon>
+          <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>
         </button>
       </mock:shadow-root>
     </pds-chip>

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -1,5 +1,7 @@
 import { Component, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 
+import { copy as copyIcon } from '@pine-ds/icons/icons';
+
 @Component({
   tag: 'pds-copytext',
   styleUrl: 'pds-copytext.scss',
@@ -90,7 +92,7 @@ export class PdsCopytext {
       <Host class={this.classNames()} id={this.componentId}>
         <pds-button type="button" variant="unstyled" onClick={this.handleClick}>
           <span>{this.value}</span>
-          <pds-icon name="copy" size="16px"></pds-icon>
+          <pds-icon icon={copyIcon} size="16px"></pds-icon>
         </pds-button>
       </Host>
     );

--- a/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
+++ b/libs/core/src/components/pds-copytext/test/pds-copytext.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsCopytext } from '../pds-copytext';
+import { copy as copyIcon } from '@pine-ds/icons/icons';
 
 describe('pds-copytext', () => {
   it('renders', async () => {
@@ -12,7 +13,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
-            <pds-icon name="copy" size="16px"></pds-icon>
+            <pds-icon icon="${copyIcon}" size="16px"></pds-icon>
           </pds-button>
         </mock:shadow-root>
       </pds-copytext>
@@ -29,7 +30,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
-            <pds-icon name="copy" size="16px"></pds-icon>
+            <pds-icon icon="${copyIcon}" size="16px"></pds-icon>
           </pds-button>
         </mock:shadow-root>
       </pds-copytext>
@@ -46,7 +47,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
-            <pds-icon name="copy" size="16px"></pds-icon>
+            <pds-icon icon="${copyIcon}" size="16px"></pds-icon>
           </pds-button>
         </mock:shadow-root>
       </pds-copytext>
@@ -63,7 +64,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span></span>
-            <pds-icon name="copy" size="16px"></pds-icon>
+            <pds-icon icon="${copyIcon}" size="16px"></pds-icon>
           </pds-button>
         </mock:shadow-root>
       </pds-copytext>
@@ -80,7 +81,7 @@ describe('pds-copytext', () => {
         <mock:shadow-root>
           <pds-button type="button" variant="unstyled">
             <span>custom value text</span>
-            <pds-icon name="copy" size="16px"></pds-icon>
+            <pds-icon icon="${copyIcon}" size="16px"></pds-icon>
           </pds-button>
         </mock:shadow-root>
       </pds-copytext>

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
@@ -1,5 +1,7 @@
 import { Component, Element, Host, Prop, h, Event, EventEmitter, State } from '@stencil/core';
 
+import { downSmall, upSmall } from '@pine-ds/icons/icons';
+
 @Component({
   tag: 'pds-table-head-cell',
   styleUrl: 'pds-table-head-cell.scss',
@@ -92,7 +94,7 @@ export class PdsTableHeadCell {
       >
         <slot></slot>
         {this.sortable && (
-          <pds-icon name={this.sortingDirection === 'asc' ? 'up-small' : 'down-small'} />
+          <pds-icon icon={this.sortingDirection === 'asc' ? upSmall : downSmall} />
         )}
       </Host>
     );

--- a/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
@@ -2,6 +2,8 @@ import { newSpecPage } from '@stencil/core/testing';
 import { PdsTable } from '../../pds-table';
 import { PdsTableHeadCell } from '../pds-table-head-cell';
 
+import { upSmall } from '@pine-ds/icons/icons';
+
 describe('pds-table-head-cell', () => {
   it('renders', async () => {
     const page = await newSpecPage({
@@ -26,7 +28,7 @@ describe('pds-table-head-cell', () => {
       <pds-table-head-cell class="is-sortable sort-asc" role="columnheader" sortable="true">
         <mock:shadow-root>
           <slot></slot>
-          <pds-icon name="up-small"></pds-icon>
+          <pds-icon icon="${upSmall}"></pds-icon>
         </mock:shadow-root>
       </pds-table-head-cell>
     `);


### PR DESCRIPTION
# Description

When running specs, you would see these errors sprinkled in the console. Changing to use the ES6 imports for the icons, removed the dependency of the server to return the icons. 

![image](https://github.com/Kajabi/pine/assets/1633290/de50df63-d746-4afd-ab58-7e376a6936c3)

Fixes #(issue)
https://kajabi.atlassian.net/browse/DSS-556

## Type of change

- [X] Test errors

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
