### PR TITLE
fix(progress): progress bar not showing in storybook

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -461,7 +461,7 @@ export namespace Components {
         "componentId": string;
         /**
           * Sets the progress fill color. Accepts a color token or a [valid color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
-          * @defaultValue 'var(--pds-color-primary)'
+          * @defaultValue 'var(--pine-color-blue-300)'
          */
         "fillColor": string;
         /**
@@ -1668,7 +1668,7 @@ declare namespace LocalJSX {
         "componentId": string;
         /**
           * Sets the progress fill color. Accepts a color token or a [valid color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value).
-          * @defaultValue 'var(--pds-color-primary)'
+          * @defaultValue 'var(--pine-color-blue-300)'
          */
         "fillColor"?: string;
         /**

--- a/libs/core/src/components/pds-progress/docs/pds-progress.mdx
+++ b/libs/core/src/components/pds-progress/docs/pds-progress.mdx
@@ -8,12 +8,12 @@ Displays progress with a value.
 <DocArgsTable componentName='pds-progress' docSource={components} />
 
 ### Default
-
+_`percent` value used in source is only for demonstration purposes, otherwise progress bar would not appear_
 <DocCanvas client:only mdxSource={{
-  react: `<PdsProgress componentId="default" label="Default"></PdsProgress>`,
-  webComponent: `<pds-progress component-id="default" label="Default"></pds-progress>`
+  react: `<PdsProgress componentId="default" label="Default" percent="15"></PdsProgress>`,
+  webComponent: `<pds-progress component-id="default" label="Default" percent="15"></pds-progress>`
 }}>
-  <pds-progress component-id="default" label="Default"></pds-progress>
+  <pds-progress component-id="default" label="Default" percent="15"></pds-progress>
 </DocCanvas>
 
 ### Percent

--- a/libs/core/src/components/pds-progress/pds-progress.scss
+++ b/libs/core/src/components/pds-progress/pds-progress.scss
@@ -1,9 +1,11 @@
 :host {
   --color-progress-fill: var(--pine-color-blue-300);
   --sizing-progress-bar-height: 8px;
+  --sizing-progress-bar-width: 100%;
 
   align-items: center;
   display: flex;
+  width: var(--sizing-progress-bar-width);
 }
 
 @keyframes progressBar {
@@ -12,7 +14,7 @@
   }
 
   100% {
-    width: 100%
+    width: var(--sizing-progress-bar-width);
   }
 }
 


### PR DESCRIPTION
# Description

The issue was discovered during the Token Update. This was first introduced when I changed to allow spacing between multiple components in the DocCanvas. I changed the display to become `inline-flex`, which didn't work well with the Progress component. So this fixes that issue by setting the width 


|Before|After|
|-----|----|
|![image](https://github.com/Kajabi/pine/assets/1633290/015a7873-1dfc-4713-895c-3ce74f177e95)|![image](https://github.com/Kajabi/pine/assets/1633290/d299b3bf-71aa-43af-8536-f890d82fd72a)|

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documenation

# How Has This Been Tested?

- [x] tested manually
- [x] other: Storybook


# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
