### PR TITLE
Sortable - Sets `handle` prop based on parent type

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -590,7 +590,7 @@ export namespace Components {
           * Determines whether `sortable-item` should have a handle.
           * @defaultValue false
          */
-        "handle": boolean;
+        "showHandle": boolean;
     }
     interface PdsSwitch {
         /**
@@ -1805,7 +1805,7 @@ declare namespace LocalJSX {
           * Determines whether `sortable-item` should have a handle.
           * @defaultValue false
          */
-        "handle"?: boolean;
+        "showHandle"?: boolean;
     }
     interface PdsSwitch {
         /**

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -90,27 +90,28 @@ When `dividers` is set to `true`, a border will display between items.
 When `handle` is set to `true` on a `pds-sortable-item` a handle icon will be displayed within an item.
 
 <DocCanvas client:only mdxSource={{
-  react: `<PdsSortable componentId="handle" handleType="handle">
-  <PdsSortableItem>Item 1</PdsSortableItem>
-  <PdsSortableItem>Item 2</PdsSortableItem>
-  <PdsSortableItem>Item 3</PdsSortableItem>
+  react: `<PdsSortable componentId="handle" handleType="row">
+  <PdsSortableItem handle={true}>Item 1</PdsSortableItem>
+  <PdsSortableItem handle={true}>Item 2</PdsSortableItem>
+  <PdsSortableItem handle={true}>Item 3</PdsSortableItem>
 </PdsSortable>
   `,
-  webComponent: `<pds-sortable component-id="handle" handle-type="handle">
-  <pds-sortable-item>Item 1</pds-sortable-item>
-  <pds-sortable-item>Item 2</pds-sortable-item>
-  <pds-sortable-item>Item 3</pds-sortable-item>
+  webComponent: `<pds-sortable component-id="handle" handle-type="row">
+  <pds-sortable-item handle="true">Item 1</pds-sortable-item>
+  <pds-sortable-item handle="true">Item 2</pds-sortable-item>
+  <pds-sortable-item handle="true">Item 3</pds-sortable-item>
 </pds-sortable>
 `}}>
-  <pds-sortable component-id="handle" handle-type="handle">
-    <pds-sortable-item>Item 1</pds-sortable-item>
-    <pds-sortable-item>Item 2</pds-sortable-item>
-    <pds-sortable-item>Item 3</pds-sortable-item>
+  <pds-sortable component-id="handle" handle-type="row">
+    <pds-sortable-item handle="true">Item 1</pds-sortable-item>
+    <pds-sortable-item handle="true">Item 2</pds-sortable-item>
+    <pds-sortable-item handle="true">Item 3</pds-sortable-item>
   </pds-sortable>
 </DocCanvas>
 
 #### Handle vs. Row `handle-type`
-By default the full `row` is active for dragging/sorting. However, `handle-type` can be set to `handle` in order to allow only the handle to be used.
+
+By default the full `row` is active for dragging/sorting. However, `handle-type` can be set to `handle` in order to allow only the handle to be used. This will also render a handle icon within the sortable items automatically.
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsSortable componentId="handle-only" handleType="handle">
@@ -207,8 +208,8 @@ The `sortable-item-actions` slot is provided to place content within the `pds-so
 The following is a demo of how all the properties and slots can be used together to create a sortable list.
 
 <DocCanvas client:only mdxSource={{
-  react: `<PdsSortable border={true} dividers={true} componentId="demo" handleType="handle">
-  <PdsSortableItem enable-actions>
+  react: `<PdsSortable border={true} dividers={true} componentId="demo" handleType="row">
+  <PdsSortableItem enable-actions handle>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -217,7 +218,7 @@ The following is a demo of how all the properties and slots can be used together
       <PdsLink href="#" variant="plain">action</PdsLink>
     </div>
   </PdsSortableItem>
-  <PdsSortableItem enable-actions>
+  <PdsSortableItem enable-actions handle>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -226,7 +227,7 @@ The following is a demo of how all the properties and slots can be used together
       <PdsLink href="#" variant="plain">action</PdsLink>
     </div>
   </PdsSortableItem>
-  <PdsSortableItem enable-actions>
+  <PdsSortableItem enable-actions handle>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>
@@ -237,8 +238,8 @@ The following is a demo of how all the properties and slots can be used together
   </PdsSortableItem>
 </PdsSortable>
   `,
-  webComponent: `<pds-sortable border dividers component-id="demo" handle-type="handle">
-  <pds-sortable-item enable-actions>
+  webComponent: `<pds-sortable border dividers component-id="demo" handle-type="row">
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -247,7 +248,7 @@ The following is a demo of how all the properties and slots can be used together
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions>
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -256,7 +257,7 @@ The following is a demo of how all the properties and slots can be used together
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions>
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>
@@ -267,8 +268,8 @@ The following is a demo of how all the properties and slots can be used together
   </pds-sortable-item>
 </pds-sortable>
 `}}>
-  <pds-sortable border dividers component-id="demo" handle-type="handle">
-    <pds-sortable-item enable-actions>
+  <pds-sortable border dividers component-id="demo" handle-type="row">
+    <pds-sortable-item enable-actions handle>
       <div>
         <div><strong>Item 1</strong></div>
         <div>Item 1 description text</div>
@@ -277,7 +278,7 @@ The following is a demo of how all the properties and slots can be used together
         <pds-link href="#" variant="plain">action</pds-link>
       </div>
     </pds-sortable-item>
-    <pds-sortable-item enable-actions>
+    <pds-sortable-item enable-actions handle>
       <div>
         <div><strong>Item 2</strong></div>
         <div>Item 2 description text</div>
@@ -286,7 +287,7 @@ The following is a demo of how all the properties and slots can be used together
         <pds-link href="#" variant="plain">action</pds-link>
       </div>
     </pds-sortable-item>
-    <pds-sortable-item enable-actions>
+    <pds-sortable-item enable-actions handle>
       <div>
         <div><strong>Item 3</strong></div>
         <div>Item 3 description text</div>

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -90,46 +90,44 @@ When `dividers` is set to `true`, a border will display between items.
 When `handle` is set to `true` on a `pds-sortable-item` a handle icon will be displayed within an item.
 
 <DocCanvas client:only mdxSource={{
-  react: `<PdsSortable componentId="handle">
-  <PdsSortableItem handle={true}>Item 1</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 2</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 3</PdsSortableItem>
+  react: `<PdsSortable componentId="handle" handleType="handle">
+  <PdsSortableItem>Item 1</PdsSortableItem>
+  <PdsSortableItem>Item 2</PdsSortableItem>
+  <PdsSortableItem>Item 3</PdsSortableItem>
 </PdsSortable>
   `,
-  webComponent: `<pds-sortable component-id="handle">
-  <pds-sortable-item handle>Item 1</pds-sortable-item>
-  <pds-sortable-item handle>Item 2</pds-sortable-item>
-  <pds-sortable-item handle>Item 3</pds-sortable-item>
+  webComponent: `<pds-sortable component-id="handle" handle-type="handle">
+  <pds-sortable-item>Item 1</pds-sortable-item>
+  <pds-sortable-item>Item 2</pds-sortable-item>
+  <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>
 `}}>
-  <pds-sortable component-id="handle">
-    <pds-sortable-item handle>Item 1</pds-sortable-item>
-    <pds-sortable-item handle>Item 2</pds-sortable-item>
-    <pds-sortable-item handle>Item 3</pds-sortable-item>
+  <pds-sortable component-id="handle" handle-type="handle">
+    <pds-sortable-item>Item 1</pds-sortable-item>
+    <pds-sortable-item>Item 2</pds-sortable-item>
+    <pds-sortable-item>Item 3</pds-sortable-item>
   </pds-sortable>
 </DocCanvas>
 
 #### Handle vs. Row `handle-type`
 By default the full `row` is active for dragging/sorting. However, `handle-type` can be set to `handle` in order to allow only the handle to be used.
 
-This should be used in combination with `handle` set to `true` on the `pds-sortable-item`.
-
 <DocCanvas client:only mdxSource={{
   react: `<PdsSortable componentId="handle-only" handleType="handle">
-  <PdsSortableItem handle={true}>Item 1</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 2</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 3</PdsSortableItem>
+  <PdsSortableItem>Item 1</PdsSortableItem>
+  <PdsSortableItem>Item 2</PdsSortableItem>
+  <PdsSortableItem>Item 3</PdsSortableItem>
 </PdsSortable>`,
   webComponent: `<pds-sortable component-id="handle-only" handle-type="handle">
-  <pds-sortable-item handle>Item 1</pds-sortable-item>
-  <pds-sortable-item handle>Item 2</pds-sortable-item>
-  <pds-sortable-item handle>Item 3</pds-sortable-item>
+  <pds-sortable-item>Item 1</pds-sortable-item>
+  <pds-sortable-item>Item 2</pds-sortable-item>
+  <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>
 `}}>
   <pds-sortable component-id="handle-only" handle-type="handle">
-    <pds-sortable-item handle>Item 1</pds-sortable-item>
-    <pds-sortable-item handle>Item 2</pds-sortable-item>
-    <pds-sortable-item handle>Item 3</pds-sortable-item>
+    <pds-sortable-item>Item 1</pds-sortable-item>
+    <pds-sortable-item>Item 2</pds-sortable-item>
+    <pds-sortable-item>Item 3</pds-sortable-item>
   </pds-sortable>
 </DocCanvas>
 
@@ -209,8 +207,8 @@ The `sortable-item-actions` slot is provided to place content within the `pds-so
 The following is a demo of how all the properties and slots can be used together to create a sortable list.
 
 <DocCanvas client:only mdxSource={{
-  react: `<PdsSortable border={true} dividers={true} componentId="demo">
-  <PdsSortableItem enable-actions handle>
+  react: `<PdsSortable border={true} dividers={true} componentId="demo" handleType="handle">
+  <PdsSortableItem enable-actions>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -219,7 +217,7 @@ The following is a demo of how all the properties and slots can be used together
       <PdsLink href="#" variant="plain">action</PdsLink>
     </div>
   </PdsSortableItem>
-  <PdsSortableItem enable-actions handle>
+  <PdsSortableItem enable-actions>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -228,7 +226,7 @@ The following is a demo of how all the properties and slots can be used together
       <PdsLink href="#" variant="plain">action</PdsLink>
     </div>
   </PdsSortableItem>
-  <PdsSortableItem enable-actions handle>
+  <PdsSortableItem enable-actions>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>
@@ -239,8 +237,8 @@ The following is a demo of how all the properties and slots can be used together
   </PdsSortableItem>
 </PdsSortable>
   `,
-  webComponent: `<pds-sortable border dividers component-id="demo">
-  <pds-sortable-item enable-actions handle>
+  webComponent: `<pds-sortable border dividers component-id="demo" handle-type="handle">
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -249,7 +247,7 @@ The following is a demo of how all the properties and slots can be used together
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -258,7 +256,7 @@ The following is a demo of how all the properties and slots can be used together
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>
@@ -269,8 +267,8 @@ The following is a demo of how all the properties and slots can be used together
   </pds-sortable-item>
 </pds-sortable>
 `}}>
-  <pds-sortable border dividers component-id="demo">
-    <pds-sortable-item enable-actions handle>
+  <pds-sortable border dividers component-id="demo" handle-type="handle">
+    <pds-sortable-item enable-actions>
       <div>
         <div><strong>Item 1</strong></div>
         <div>Item 1 description text</div>
@@ -279,7 +277,7 @@ The following is a demo of how all the properties and slots can be used together
         <pds-link href="#" variant="plain">action</pds-link>
       </div>
     </pds-sortable-item>
-    <pds-sortable-item enable-actions handle>
+    <pds-sortable-item enable-actions>
       <div>
         <div><strong>Item 2</strong></div>
         <div>Item 2 description text</div>
@@ -288,7 +286,7 @@ The following is a demo of how all the properties and slots can be used together
         <pds-link href="#" variant="plain">action</pds-link>
       </div>
     </pds-sortable-item>
-    <pds-sortable-item enable-actions handle>
+    <pds-sortable-item enable-actions>
       <div>
         <div><strong>Item 3</strong></div>
         <div>Item 3 description text</div>

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -87,25 +87,25 @@ When `dividers` is set to `true`, a border will display between items.
 
 ### Handle
 
-When `handle` is set to `true` on a `pds-sortable-item` a handle icon will be displayed within an item.
+When `show-handle` is set to `true` on a `pds-sortable-item`, a handle icon will be displayed within an item.
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsSortable componentId="handle" handleType="row">
-  <PdsSortableItem handle={true}>Item 1</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 2</PdsSortableItem>
-  <PdsSortableItem handle={true}>Item 3</PdsSortableItem>
+  <PdsSortableItem showHandle={true}>Item 1</PdsSortableItem>
+  <PdsSortableItem showHandle={true}>Item 2</PdsSortableItem>
+  <PdsSortableItem showHandle={true}>Item 3</PdsSortableItem>
 </PdsSortable>
   `,
   webComponent: `<pds-sortable component-id="handle" handle-type="row">
-  <pds-sortable-item handle="true">Item 1</pds-sortable-item>
-  <pds-sortable-item handle="true">Item 2</pds-sortable-item>
-  <pds-sortable-item handle="true">Item 3</pds-sortable-item>
+  <pds-sortable-item show-handle="true">Item 1</pds-sortable-item>
+  <pds-sortable-item show-handle="true">Item 2</pds-sortable-item>
+  <pds-sortable-item show-handle="true">Item 3</pds-sortable-item>
 </pds-sortable>
 `}}>
   <pds-sortable component-id="handle" handle-type="row">
-    <pds-sortable-item handle="true">Item 1</pds-sortable-item>
-    <pds-sortable-item handle="true">Item 2</pds-sortable-item>
-    <pds-sortable-item handle="true">Item 3</pds-sortable-item>
+    <pds-sortable-item show-handle="true">Item 1</pds-sortable-item>
+    <pds-sortable-item show-handle="true">Item 2</pds-sortable-item>
+    <pds-sortable-item show-handle="true">Item 3</pds-sortable-item>
   </pds-sortable>
 </DocCanvas>
 

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop } from '@stencil/core';
+import { Component, Element, Host, h, Prop } from '@stencil/core';
 
 import { handle } from '@pine-ds/icons/icons';
 /**
@@ -10,6 +10,8 @@ import { handle } from '@pine-ds/icons/icons';
   scoped: true,
 })
 export class PdsSortableItem {
+  @Element() el: HTMLPdsSortableItemElement;
+  sortableRef: HTMLPdsSortableElement;
   /**
    * Determines whether `sortable-item-actions` slot should be enabled.
    * @defaultValue false
@@ -25,7 +27,17 @@ export class PdsSortableItem {
    * Determines whether `sortable-item` should have a handle.
    * @defaultValue false
    */
-  @Prop() handle = false;
+  @Prop({ mutable: true }) handle = false;
+
+  componentWillRender() {
+    // When the parent sortable has a type of 'handle', the sortable items
+    // will automatically set handle to 'true'.
+    this.sortableRef = this.el.closest('pds-sortable') as HTMLPdsSortableElement;
+
+    if (this.sortableRef && this.sortableRef.handleType === 'handle') {
+      this.handle = true;
+    }
+  }
 
   render() {
     return (

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Host, h, Prop } from '@stencil/core';
 
-import { handle } from '@pine-ds/icons/icons';
+import { handle as handleIcon } from '@pine-ds/icons/icons';
 /**
  * @slot sortable-item-actions - Content is placed within the `pds-sortable-item__actions` element as children. This slot is only rendered if `actions` is set to `true`.
  */
@@ -27,24 +27,24 @@ export class PdsSortableItem {
    * Determines whether `sortable-item` should have a handle.
    * @defaultValue false
    */
-  @Prop({ mutable: true }) handle = false;
+  @Prop({ mutable: true }) showHandle = false;
 
   componentWillRender() {
     // When the parent sortable has a type of 'handle', the sortable items
-    // will automatically set handle to 'true'.
+    // will automatically set showHandle to 'true'.
     this.sortableRef = this.el.closest('pds-sortable') as HTMLPdsSortableElement;
 
     if (this.sortableRef && this.sortableRef.handleType === 'handle') {
-      this.handle = true;
+      this.showHandle = true;
     }
   }
 
   render() {
     return (
       <Host class="pds-sortable-item" id={this.componentId}>
-        {this.handle && (
+        {this.showHandle && (
           <div class="pds-sortable-item__handle">
-            <pds-icon icon={handle}></pds-icon>
+            <pds-icon icon={handleIcon}></pds-icon>
           </div>
         )}
         <slot></slot>

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/readme.md
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/readme.md
@@ -11,7 +11,7 @@
 | --------------- | ---------------- | ------------------------------------------------------------------ | --------- | ----------- |
 | `componentId`   | `component-id`   | A unique identifier used for the sortable item `id` attribute.     | `string`  | `undefined` |
 | `enableActions` | `enable-actions` | Determines whether `sortable-item-actions` slot should be enabled. | `boolean` | `false`     |
-| `handle`        | `handle`         | Determines whether `sortable-item` should have a handle.           | `boolean` | `false`     |
+| `showHandle`    | `show-handle`    | Determines whether `sortable-item` should have a handle.           | `boolean` | `false`     |
 
 
 ## Slots

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/stories/pds-sortable-item.stories.js
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/stories/pds-sortable-item.stories.js
@@ -11,7 +11,7 @@ const BaseTemplate = (args) => html`
 <pds-sortable-item
   action="${args.enableActions}"
   component-id="${args.componentId}"
-  handle="${args.handle}"
+  show-handle="${args.showHandle}"
 >
   Item
 </pds-sortable-item>`;
@@ -20,5 +20,5 @@ export const Default = BaseTemplate.bind();
 Default.args = {
   componentId: 'default',
   enableActions: false,
-  handle: false,
+  showHandle: false,
 };

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/test/pds-sortable-item.spec.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/test/pds-sortable-item.spec.tsx
@@ -1,7 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsSortableItem } from '../pds-sortable-item';
 
-import { handle } from '@pine-ds/icons/icons';
+import { handle as handleIcon } from '@pine-ds/icons/icons';
 
 describe('pds-sortable-item', () => {
   it('renders', async () => {
@@ -27,19 +27,19 @@ describe('pds-sortable-item', () => {
     `);
   });
 
-  it('renders with handle when prop is set', async () => {
+  it('renders with handle icon when prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsSortableItem],
       html: `
-        <pds-sortable-item handle="true">
+        <pds-sortable-item show-handle="true">
         </pds-sortable-item>
       `,
     });
 
     expect(page.root).toEqualHtml(`
-      <pds-sortable-item class="pds-sortable-item" handle="true">
+      <pds-sortable-item class="pds-sortable-item" show-handle="true">
         <div class="pds-sortable-item__handle">
-          <pds-icon icon="${handle}"></pds-icon>
+          <pds-icon icon="${handleIcon}"></pds-icon>
         </div>
       </pds-sortable-item>
     `);

--- a/libs/core/src/components/pds-sortable/pds-sortable.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import { SortableType } from './sortable-interface';
 import Sortable from 'sortablejs';
 
 @Component({
@@ -46,7 +47,7 @@ export class PdsSortable {
       classNames.push('pds-sortable--divided');
     }
 
-    if (this.handleType) {
+    if (this.handleType !== undefined) {
       classNames.push(`pds-sortable--handle-type-${this.handleType}`);
     }
 
@@ -55,7 +56,7 @@ export class PdsSortable {
 
   componentDidLoad() {
 
-    let sortableOptions: any = {
+    let sortableOptions: SortableType = {
       animation: 150,
       ghostClass: 'pds-sortable-item--ghost',
       dragClass: 'pds-sortable-item--drag',

--- a/libs/core/src/components/pds-sortable/sortable-interface.ts
+++ b/libs/core/src/components/pds-sortable/sortable-interface.ts
@@ -1,0 +1,7 @@
+export interface SortableType {
+  animation: number;
+  ghostClass: string;
+  dragClass: string;
+  onEnd: (evt: Event) => void;
+  handle?: string;
+}

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
@@ -52,7 +52,7 @@ const ActionsTemplate = (args) => html`
 
 const FullDemoTemplate = (args) => html`
 <pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -61,7 +61,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -70,7 +70,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
@@ -52,7 +52,7 @@ const ActionsTemplate = (args) => html`
 
 const FullDemoTemplate = (args) => html`
 <pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
-  <pds-sortable-item enable-actions>
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -61,7 +61,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions>
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -70,7 +70,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions>
+  <pds-sortable-item enable-actions handle>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
@@ -23,9 +23,9 @@ const BaseTemplate = (args) => html`
 
 const HandleTemplate = (args) => html`
 <pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
-  <pds-sortable-item handle>Item 1</pds-sortable-item>
-  <pds-sortable-item handle>Item 2</pds-sortable-item>
-  <pds-sortable-item handle>Item 3</pds-sortable-item>
+  <pds-sortable-item>Item 1</pds-sortable-item>
+  <pds-sortable-item>Item 2</pds-sortable-item>
+  <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>`;
 
 const ActionsTemplate = (args) => html`
@@ -52,7 +52,7 @@ const ActionsTemplate = (args) => html`
 
 const FullDemoTemplate = (args) => html`
 <pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 1</strong></div>
       <div>Item 1 description copy text</div>
@@ -61,7 +61,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 2</strong></div>
       <div>Item 2 description copy text</div>
@@ -70,7 +70,7 @@ const FullDemoTemplate = (args) => html`
       <pds-link href="#" variant="plain">action</pds-link>
     </div>
   </pds-sortable-item>
-  <pds-sortable-item enable-actions handle>
+  <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 3</strong></div>
       <div>Item 3 description copy text</div>

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
@@ -9,7 +9,7 @@ describe('pds-sortable', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('sets sortable item handle prop to true when handleType is set to "handle"', async () => {
+  it('sets sortable item show-handle prop to true when handleType is set to "handle"', async () => {
     const page = await newE2EPage();
 
     await page.setContent(`
@@ -20,7 +20,7 @@ describe('pds-sortable', () => {
       </pds-sortable>`);
 
     const item = await page.find('.pds-sortable-item');
-    expect(await item.getProperty('handle')).toBe(true);
+    expect(await item.getProperty('showHandle')).toBe(true);
   })
 
   it('reorders items when an item is dragged and dropped', async () => {

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
@@ -9,6 +9,20 @@ describe('pds-sortable', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('sets sortable item handle prop to true when handleType is set to "handle"', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <pds-sortable handle-type="handle">
+        <pds-sortable-item>Item 1</pds-sortable-item>
+        <pds-sortable-item>Item 2</pds-sortable-item>
+        <pds-sortable-item>Item 3</pds-sortable-item>
+      </pds-sortable>`);
+
+    const item = await page.find('.pds-sortable-item');
+    expect(await item.getProperty('handle')).toBe(true);
+  })
+
   it('reorders items when an item is dragged and dropped', async () => {
     const page = await newE2EPage();
 


### PR DESCRIPTION
# Description

Allows the sortable items to set their `handle` prop to `true` when the parent element `handleType` is set to `handle`. This automatically shows the handle icon without the user having to manually set them.

[DSS-601](https://kajabi.atlassian.net/browse/DSS-601)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Some instances of the `handle` prop have been removed from the sortable items where not necessary. Please check that sorting still works without it. When the `handleType` is `row`, the sortable items should still be able to have their icons set manually to allow the whole row to remain draggable.

- [ ] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-601]: https://kajabi.atlassian.net/browse/DSS-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ