### PR TITLE
fix(accordion): adjust animation for open accordion refresh

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -14,12 +14,12 @@ details {
   --color-text-default: var(--pine-color-charcoal-200);
   --color-text-active: var(--pine-color-charcoal-500);
   --color-text-hover: var(--pine-color-charcoal-300);
-  
+
   --spacing-details-padding-inline: var(--pine-spacing-150);
   --spacing-summary-padding-block: var(--pine-spacing-050);
   --spacing-summary-padding-inline-start: var(--pine-spacing-100);
   --spacing-summary-padding-inline-end: var(--pine-spacing-050);
-  
+
   --typography-default: var(--pine-font-weight-semi-bold) var(--pine-font-size-100)/var(--pine-line-height-150) var(--pine-font-family-circular);
 
   border-radius: var(--border-radius-default);
@@ -33,10 +33,16 @@ details {
 
 @keyframes slide-down {
   from {
+    opacity: 0;
     transform: translateY(-100%)
   }
 
+  65% {
+    opacity: 0;
+  }
+
   to {
+    opacity: 1;
     transform: translateY(0%);
   }
 }


### PR DESCRIPTION
# Description

When the accordion is already "open" and a customer refreshes the page, the animation will start above the "panel". 

Adding a keyframe within the animation, and adjusting the opacity solves this on both Chrome and Safari. 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: Storybook

- Browsers: Chrome and Safari
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
