### PR TITLE
docs(accordion): Update icon name in story

### DIFF
--- a/libs/core/src/components/pds-accordion/stories/pds-accordion.stories.js
+++ b/libs/core/src/components/pds-accordion/stories/pds-accordion.stories.js
@@ -15,7 +15,7 @@ const BaseTemplate = (args) => html`
 	<pds-accordion component-id="${args.componentId}" open="${args.isOpen}">
     <pds-row align-items="center" slot="label">
       <pds-box align-items="center">
-        <pds-icon name="products-outline"></pds-icon>
+        <pds-icon name="product"></pds-icon>
         <span style="display: inline-block; margin-left: 8px;">Products</span>
       </pds-box>
     </pds-row>


### PR DESCRIPTION
# Description
Due to recent icon naming updates the name of the icon in the accordion story should be corrected.

## Type of change
- [x] Docs. This change requires a documentation update

# How Has This Been Tested?
Navigate to the [Accordion story](http://localhost:6006/?path=/docs/components-accordion--docs#playground) and verify the package icon displays in the story/playground.

![Screenshot 2024-06-06 at 10 02 35 AM](https://github.com/Kajabi/pine/assets/1175111/1fb3003f-5909-4a7f-83f8-79392985d0e7)

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
