### PR TITLE
Remove accordion open animation

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -31,22 +31,6 @@ details {
   }
 }
 
-@keyframes slide-down {
-  from {
-    opacity: 0;
-    transform: translateY(-100%)
-  }
-
-  65% {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0%);
-  }
-}
-
 /* stylelint-disable-next-line */
 details[open] {
   background-color: var(--color-content-background);
@@ -64,13 +48,12 @@ details[open] {
 
   /* stylelint-disable-next-line selector-no-qualifying-type */
   .pds-accordion__body {
-    transition: max-height 1s ease-in-out;
+    display: none;
 
     /* stylelint-disable-next-line selector-no-qualifying-type */
     &.open {
-      max-height: 1000px;
+      display: block;
     }
-
   }
 }
 
@@ -108,10 +91,3 @@ summary {
     margin-inline-start: auto;
   }
 }
-
-.pds-accordion__body {
-  animation: slide-down var(--number-animation-transform-timing);
-  max-height: 0;
-  overflow: hidden;
-}
-


### PR DESCRIPTION
# Description

This PR removes the `slideDown` animation from the accordion component. The sidebar implementation is causing several user experience issues. As a result the sidebar is beginning to behave differently in different situations:
- Navigating to a page
- Refreshing the page
- Refreshing a page, while having the active accordion open then opening a second

|  Before  |  After  |
|--------|--------|
|![accordion-animation-before](https://github.com/Kajabi/pine/assets/1241836/f05cd968-5ef5-4f7f-a29c-a32ea6d04cb2)|![accordion-animation-after](https://github.com/Kajabi/pine/assets/1241836/f85f0fd0-8ded-4520-8194-a43403dfa618)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Go to the Accordion view
- Click on  the [Content Slots Set example](http://localhost:6006/?path=/docs/components-accordion--docs#content-slots-set) and verify that the accordion no longer animates open

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
