### PR TITLE
Tooltip - resolve trigger alignment when present in a group

### DIFF
--- a/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
+++ b/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
@@ -90,7 +90,7 @@ enable the `htmlContent` property and provide your element in the `content` slot
 }}>
   <pds-tooltip has-arrow="true" placement="right">
     text
-    <div slot="content">
+    <div class="sb-unstyled" slot="content">
       <p>this is a sentence in a tooltip.</p>
       <p>this is a sentence in a tooltip.</p>
     </div>

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.scss
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.scss
@@ -29,6 +29,7 @@
   }
 
   ::slotted([slot="content"]) {
+    display: block;
     white-space: normal;
     width: var(--sizing-width-default);
   }

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.scss
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.scss
@@ -24,6 +24,10 @@
   display: inline-block;
   position: relative;
 
+  ::slotted(*) {
+    display: flex;
+  }
+
   ::slotted([slot="content"]) {
     white-space: normal;
     width: var(--sizing-width-default);

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.docs.mdx
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.docs.mdx
@@ -10,6 +10,6 @@ import Docs from '../docs/pds-tooltip.mdx';
 
 # Playground
 
-<Canvas of={stories.Default} />
+<Canvas of={stories.Default} layout="centered" />
 
 <Controls of={stories.Default} />

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
@@ -14,12 +14,6 @@ export default {
   title: 'components/Tooltip'
 }
 
-const defaultParameters = {
-  docs: {
-    disable: true
-  }
-};
-
 const BaseTemplate = (args) => html`
   <pds-tooltip content=${args.content} has-arrow=${args.hasArrow} placement=${args.placement}>${args.slot}</pds-tooltip>`;
 
@@ -88,21 +82,17 @@ Default.args = {
   placement: "right",
   slot: "target text"
 };
-Default.parameters = { ...defaultParameters };
 
 export const HTMLContent = HTMLContentTemplate.bind({});
 HTMLContent.args = {
   htmlContent: true,
   placement: "bottom-start",
 };
-HTMLContent.parameters = { ...defaultParameters }
-
 
 export const Positioning = PositionTemplate.bind({});
 Positioning.args = {
   content: "Trigger",
 };
-Positioning.parameters = { ...defaultParameters }
 
 export const NoArrow = BaseTemplate.bind({});
 NoArrow.args = {
@@ -111,4 +101,3 @@ NoArrow.args = {
   placement: "bottom-start",
   slot: "target text"
 };
-NoArrow.parameters = { ...defaultParameters }


### PR DESCRIPTION
# Description
This is visible when a tooltip is present next to text within a table header cell. 

- [x] add flexbox to the tooltip slot to resolve alignment

|  Before  |  After  |
|--------|--------|
|![Screenshot 2024-06-18 at 11 49 42 AM](https://github.com/Kajabi/pine/assets/1241836/653e9e15-46f5-40eb-9f72-19621217ac89)|![Screenshot 2024-06-18 at 11 47 47 AM](https://github.com/Kajabi/pine/assets/1241836/0b9a753d-6fd7-44a3-93cc-64a35f1e0569)|

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
replace the `<pds-table-head-cell>`s in `libs/core/src/components/pds-table/docs/pds-table.mdx` in the Sortable example, line 1040 - 1042

```
<pds-table-head-cell sortable={true}><pds-box align-items="center" gap="xxs"> Name <pds-tooltip content="hello"><pds-icon name="info-circle" size="10px"></pds-icon></pds-tooltip></pds-box></pds-table-head-cell>
<pds-table-head-cell sortable={true}><pds-box align-items="center" gap="xxs"> Address <pds-tooltip content="hello"><pds-icon name="info-circle" size-="small"></pds-icon></pds-tooltip></pds-box></pds-table-head-cell>
<pds-table-head-cell sortable={true}><pds-box align-items="center" gap="xxs"> Email <pds-tooltip content="hello"><pds-icon name="info-circle" size="medium"></pds-icon></pds-tooltip></pds-box></pds-table-head-cell>
```

Visit the table page and verify that tooltip icons in the Sortable example are center aligned

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
