### PR TITLE
Fix: no self-closing web components

### DIFF
--- a/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
+++ b/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
@@ -14,9 +14,9 @@ Checkboxes provide users with selectable options like toggling a single setting 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="default" label="Label" />`,
-    webComponent: `<pds-checkbox component-id="default" label="Label" />`
+    webComponent: `<pds-checkbox component-id="default" label="Label"></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="default" label="Label" />
+  <pds-checkbox component-id="default" label="Label"></pds-checkbox>
 </DocCanvas>
 
 ### Checked
@@ -26,9 +26,9 @@ Checkboxes appear as checked when activated.
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="checked" label="Label" checked />`,
-    webComponent: `<pds-checkbox component-id="checked" label="Label" checked />`
+    webComponent: `<pds-checkbox component-id="checked" label="Label" checked></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="checked" label="Label" checked />
+  <pds-checkbox component-id="checked" label="Label" checked></pds-checkbox>
 </DocCanvas>
 
 ### Indeterminate
@@ -40,9 +40,9 @@ Only JavaScript can set the objects `indeterminate` property. See [MDN Web Docs]
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="indeterminate" label="Label" checked indeterminate />`,
-    webComponent: `<pds-checkbox component-id="indeterminate" label="Label" checked indeterminate />`
+    webComponent: `<pds-checkbox component-id="indeterminate" label="Label" checked indeterminate></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="indeterminate" label="Label" checked indeterminate />
+  <pds-checkbox component-id="indeterminate" label="Label" checked indeterminate></pds-checkbox>
 </DocCanvas>
 
 ### Disabled
@@ -52,9 +52,9 @@ Disabled visually indicates and functionally prevents interaction with the check
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="disabled" label="Label" disabled />`,
-    webComponent: `<pds-checkbox component-id="disabled" label="Label" disabled />`
+    webComponent: `<pds-checkbox component-id="disabled" label="Label" disabled></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="disabled" label="Label" disabled />
+  <pds-checkbox component-id="disabled" label="Label" disabled></pds-checkbox>
 </DocCanvas>
 
 ### Message
@@ -64,9 +64,9 @@ Message is a string of text that displays below the label text.
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="message1" label="Label" helperMessage="This is short message text." />`,
-    webComponent: `<pds-checkbox component-id="message1" label="Label" helper-message="This is short message text." />`
+    webComponent: `<pds-checkbox component-id="message1" label="Label" helper-message="This is short message text."></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="message1" label="Label" helper-message="This is short message text." />
+  <pds-checkbox component-id="message1" label="Label" helper-message="This is short message text."></pds-checkbox>
 </DocCanvas>
 
 ### Invalid
@@ -78,9 +78,9 @@ An optional error message can be displayed for additional instructions, displaye
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsCheckbox componentId="invalid" label="Label" invalid errorMessage="This is a short error message" />`,
-    webComponent: `<pds-checkbox component-id="invalid" label="Label" invalid error-message="This is a short error message" />`
+    webComponent: `<pds-checkbox component-id="invalid" label="Label" invalid error-message="This is a short error message"></pds-checkbox>`
 }}>
-  <pds-checkbox component-id="invalid" label="Label" invalid error-message="This is a short error message" />
+  <pds-checkbox component-id="invalid" label="Label" invalid error-message="This is a short error message"></pds-checkbox>
 </DocCanvas>
 
 ## Events

--- a/libs/core/src/components/pds-chip/docs/pds-chip.mdx
+++ b/libs/core/src/components/pds-chip/docs/pds-chip.mdx
@@ -14,9 +14,9 @@ Chips are used to inform users of the status of an object or to relate propertie
 <DocCanvas client:only
   mdxSource={{
     react: '<pdsChip label="Label" />',
-    webComponent: '<pds-chip label="Label" />'
+    webComponent: '<pds-chip label="Label"></pds-chip>'
 }}>
-  <pds-chip label="Label" />
+  <pds-chip label="Label"></pds-chip>
 </DocCanvas>
 
 ### Sentiment
@@ -34,20 +34,20 @@ The `sentiment` property represents the named color scheme of the chip component
     <pdsChip label="Warning" sentiment="warning" />
     `,
     webComponent: `
-    <pds-chip label="Accent" sentiment="accent" />
-    <pds-chip label="Danger" sentiment="danger" />
-    <pds-chip label="Info" sentiment="info" />
-    <pds-chip label="Neutral" sentiment="neutral" />
-    <pds-chip label="Success" sentiment="success" />
-    <pds-chip label="Warning" sentiment="warning" />
+    <pds-chip label="Accent" sentiment="accent"></pds-chip>
+    <pds-chip label="Danger" sentiment="danger"></pds-chip>
+    <pds-chip label="Info" sentiment="info"></pds-chip>
+    <pds-chip label="Neutral" sentiment="neutral"></pds-chip>
+    <pds-chip label="Success" sentiment="success"></pds-chip>
+    <pds-chip label="Warning" sentiment="warning"></pds-chip>
     `
 }}>
-  <pds-chip label="Accent" sentiment="accent" />
-  <pds-chip label="Danger" sentiment="danger" />
-  <pds-chip label="Info" sentiment="info" />
-  <pds-chip label="Neutral" sentiment="neutral" />
-  <pds-chip label="Success" sentiment="success" />
-  <pds-chip label="Warning" sentiment="warning" />
+  <pds-chip label="Accent" sentiment="accent"></pds-chip>
+  <pds-chip label="Danger" sentiment="danger"></pds-chip>
+  <pds-chip label="Info" sentiment="info"></pds-chip>
+  <pds-chip label="Neutral" sentiment="neutral"></pds-chip>
+  <pds-chip label="Success" sentiment="success"></pds-chip>
+  <pds-chip label="Warning" sentiment="warning"></pds-chip>
 </DocCanvas>
 
 ### Dot
@@ -65,20 +65,20 @@ A small circular indicator displayed within a chip. Dot colors are determined by
     <pdsChip label="Warning" sentiment="warning" dot />
     `,
     webComponent: `
-    <pds-chip label="Accent" sentiment="accent" dot />
-    <pds-chip label="Danger" sentiment="danger" dot />
-    <pds-chip label="Info" sentiment="info" dot />
+    <pds-chip label="Accent" sentiment="accent" dot></pds-chip>
+    <pds-chip label="Danger" sentiment="danger" dot></pds-chip>
+    <pds-chip label="Info" sentiment="info" dot></pds-chip>
     <pds-chip label="Neutral" sentiment="neutral" dot/>
-    <pds-chip label="Success" sentiment="success" dot />
-    <pds-chip label="Warning" sentiment="warning" dot />
+    <pds-chip label="Success" sentiment="success" dot></pds-chip>
+    <pds-chip label="Warning" sentiment="warning" dot></pds-chip>
     `
 }}>
-  <pds-chip label="Accent" sentiment="accent" dot />
-  <pds-chip label="Danger" sentiment="danger" dot />
-  <pds-chip label="Info" sentiment="info" dot />
+  <pds-chip label="Accent" sentiment="accent" dot></pds-chip>
+  <pds-chip label="Danger" sentiment="danger" dot></pds-chip>
+  <pds-chip label="Info" sentiment="info" dot></pds-chip>
   <pds-chip label="Neutral" sentiment="neutral" dot/>
-  <pds-chip label="Success" sentiment="success" dot />
-  <pds-chip label="Warning" sentiment="warning" dot />
+  <pds-chip label="Success" sentiment="success" dot></pds-chip>
+  <pds-chip label="Warning" sentiment="warning" dot></pds-chip>
 </DocCanvas>
 
 ### Dropdown
@@ -98,20 +98,20 @@ Should be used in conjunction with the `pds-dropdown` component. {/* TODO: Add l
     <pdsChip label="Warning" sentiment="warning" variant="dropdown" />
     `,
     webComponent: `
-    <pds-chip label="Accent" sentiment="accent" variant="dropdown" />
-    <pds-chip label="Danger" sentiment="danger" variant="dropdown" />
-    <pds-chip label="Info" sentiment="info" variant="dropdown" />
-    <pds-chip label="Neutral" sentiment="neutral" variant="dropdown" />
-    <pds-chip label="Success" sentiment="success" variant="dropdown" />
-    <pds-chip label="Warning" sentiment="warning" variant="dropdown" />
+    <pds-chip label="Accent" sentiment="accent" variant="dropdown"></pds-chip>
+    <pds-chip label="Danger" sentiment="danger" variant="dropdown"></pds-chip>
+    <pds-chip label="Info" sentiment="info" variant="dropdown"></pds-chip>
+    <pds-chip label="Neutral" sentiment="neutral" variant="dropdown"></pds-chip>
+    <pds-chip label="Success" sentiment="success" variant="dropdown"></pds-chip>
+    <pds-chip label="Warning" sentiment="warning" variant="dropdown"></pds-chip>
     `
 }}>
-  <pds-chip label="Accent" sentiment="accent" variant="dropdown" />
-  <pds-chip label="Danger" sentiment="danger" variant="dropdown" />
-  <pds-chip label="Info" sentiment="info" variant="dropdown" />
-  <pds-chip label="Neutral" sentiment="neutral" variant="dropdown" />
-  <pds-chip label="Success" sentiment="success" variant="dropdown" />
-  <pds-chip label="Warning" sentiment="warning" variant="dropdown" />
+  <pds-chip label="Accent" sentiment="accent" variant="dropdown"></pds-chip>
+  <pds-chip label="Danger" sentiment="danger" variant="dropdown"></pds-chip>
+  <pds-chip label="Info" sentiment="info" variant="dropdown"></pds-chip>
+  <pds-chip label="Neutral" sentiment="neutral" variant="dropdown"></pds-chip>
+  <pds-chip label="Success" sentiment="success" variant="dropdown"></pds-chip>
+  <pds-chip label="Warning" sentiment="warning" variant="dropdown"></pds-chip>
 </DocCanvas>
 
 ## Tag
@@ -130,18 +130,18 @@ Tag is often used to represent a selected item or a removable element and includ
     <pdsChip label="Warning" sentiment="warning" variant="tag" />
     `,
     webComponent: `
-    <pds-chip label="Danger" sentiment="danger" variant="tag" />
-    <pds-chip label="Info" sentiment="info" variant="tag" />
-    <pds-chip label="Neutral" sentiment="neutral" variant="tag" />
-    <pds-chip label="Success" sentiment="success" variant="tag" />
-    <pds-chip label="Warning" sentiment="warning" variant="tag" />
+    <pds-chip label="Danger" sentiment="danger" variant="tag"></pds-chip>
+    <pds-chip label="Info" sentiment="info" variant="tag"></pds-chip>
+    <pds-chip label="Neutral" sentiment="neutral" variant="tag"></pds-chip>
+    <pds-chip label="Success" sentiment="success" variant="tag"></pds-chip>
+    <pds-chip label="Warning" sentiment="warning" variant="tag"></pds-chip>
     `
 }}>
-  <pds-chip label="Danger" sentiment="danger" variant="tag" />
-  <pds-chip label="Info" sentiment="info" variant="tag" />
-  <pds-chip label="Neutral" sentiment="neutral" variant="tag" />
-  <pds-chip label="Success" sentiment="success" variant="tag" />
-  <pds-chip label="Warning" sentiment="warning" variant="tag" />
+  <pds-chip label="Danger" sentiment="danger" variant="tag"></pds-chip>
+  <pds-chip label="Info" sentiment="info" variant="tag"></pds-chip>
+  <pds-chip label="Neutral" sentiment="neutral" variant="tag"></pds-chip>
+  <pds-chip label="Success" sentiment="success" variant="tag"></pds-chip>
+  <pds-chip label="Warning" sentiment="warning" variant="tag"></pds-chip>
 </DocCanvas>
 
 ### Large
@@ -157,14 +157,14 @@ Large chips will be displayed with a larger visual footprint compared to the def
     <pdsChip label="Success" sentiment="success" variant="tag" large />
     `,
     webComponent: `
-    <pds-chip label="Accent" sentiment="accent" variant="text" large />
-    <pds-chip label="Danger" sentiment="danger" dot large />
-    <pds-chip label="Info" sentiment="info" variant="dropdown" large />
-    <pds-chip label="Success" sentiment="success" variant="tag" large />
+    <pds-chip label="Accent" sentiment="accent" variant="text" large></pds-chip>
+    <pds-chip label="Danger" sentiment="danger" dot large></pds-chip>
+    <pds-chip label="Info" sentiment="info" variant="dropdown" large></pds-chip>
+    <pds-chip label="Success" sentiment="success" variant="tag" large></pds-chip>
     `
 }}>
-  <pds-chip label="Accent" sentiment="accent" variant="text" large />
-  <pds-chip label="Danger" sentiment="danger" dot large />
-  <pds-chip label="Info" sentiment="info" variant="dropdown" large />
-  <pds-chip label="Success" sentiment="success" variant="tag" large />
+  <pds-chip label="Accent" sentiment="accent" variant="text" large></pds-chip>
+  <pds-chip label="Danger" sentiment="danger" dot large></pds-chip>
+  <pds-chip label="Info" sentiment="info" variant="dropdown" large></pds-chip>
+  <pds-chip label="Success" sentiment="success" variant="tag" large></pds-chip>
 </DocCanvas>

--- a/libs/core/src/components/pds-divider/docs/pds-divider.mdx
+++ b/libs/core/src/components/pds-divider/docs/pds-divider.mdx
@@ -16,7 +16,7 @@ The default divider displays a horizontal line.
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsDivider />',
-    webComponent: '<pds-divider />'
+    webComponent: '<pds-divider></pds-divider>'
 }}>
   <pds-divider />
 </DocCanvas>
@@ -36,12 +36,12 @@ To display the divider vertically, the `vertical` prop can be set to `true`.
     `,
     webComponent: `
 <div style={{ height: '150px' }}>
-  <pds-divider vertical="true" />
+  <pds-divider vertical="true"></pds-divider>
 </div>
     `
 }}>
   <div style={{ height: '150px' }}>
-    <pds-divider vertical="true" />
+    <pds-divider vertical="true"></pds-divider>
   </div>
 </DocCanvas>
 
@@ -54,9 +54,9 @@ Offset sizes follow the global spacing sizes: `xxs`:4px, `xs`:8px, `sm`:12px,`md
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsDivider offset="lg" />',
-    webComponent: '<pds-divider offset="lg" />'
+    webComponent: '<pds-divider offset="lg"></pds-divider>'
 }}>
-  <pds-divider offset="lg" />
+  <pds-divider offset="lg"></pds-divider>
 </DocCanvas>
 
 Below you will see a vertical divider using a large offset.
@@ -70,11 +70,11 @@ Below you will see a vertical divider using a large offset.
     `,
     webComponent: `
 <div style={{ height: '150px' }}>
-  <pds-divider offset="lg" vertical="true" />
+  <pds-divider offset="lg" vertical="true"></pds-divider>
 </div>
     `
 }}>
   <div style={{ height: '150px' }}>
-    <pds-divider offset="lg" vertical="true" />
+    <pds-divider offset="lg" vertical="true"></pds-divider>
   </div>
 </DocCanvas>

--- a/libs/core/src/components/pds-radio/docs/pds-radio.mdx
+++ b/libs/core/src/components/pds-radio/docs/pds-radio.mdx
@@ -13,9 +13,9 @@ Radio components provide users a way to select only one option from a list of tw
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsRadio componentId="default" label="Label" />`,
-  webComponent: `<pds-radio component-id="default" label="Label" />`
+  webComponent: `<pds-radio component-id="default" label="Label"></pds-radio>`
 }}>
-  <pds-radio component-id="default" label="Label" />
+  <pds-radio component-id="default" label="Label"></pds-radio>
 </DocCanvas>
 
 ### Checked
@@ -24,9 +24,9 @@ Radios appear as checked when activated.
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsRadio componentId="checked" label="Label" checked={true} />`,
-  webComponent: `<pds-radio component-id="checked" label="Label" checked />`
+  webComponent: `<pds-radio component-id="checked" label="Label" checked></pds-radio>`
 }}>
-  <pds-radio component-id="checked" label="Label" checked />
+  <pds-radio component-id="checked" label="Label" checked></pds-radio>
 </DocCanvas>
 
 ### Disabled
@@ -35,9 +35,9 @@ Disabled visually indicates and functionally prevents interaction with the radio
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsRadio componentId="disabled" label="Label" disabled={true} />`,
-  webComponent: `<pds-radio component-id="disabled" label="Label" disabled />`
+  webComponent: `<pds-radio component-id="disabled" label="Label" disabled></pds-radio>`
 }}>
-  <pds-radio component-id="disabled" label="Label" disabled />
+  <pds-radio component-id="disabled" label="Label" disabled></pds-radio>
 </DocCanvas>
 
 ### Message
@@ -46,9 +46,9 @@ Message is a string of text that displays below the label text.
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsRadio componentId="message1" label="Label" helperMessage="This is short message text." />`,
-  webComponent: `<pds-radio component-id="message1" label="Label" helper-message="This is short message text." />`
+  webComponent: `<pds-radio component-id="message1" label="Label" helper-message="This is short message text."></pds-radio>`
 }}>
-  <pds-radio component-id="message1" label="Label" helper-message="This is short message text." />
+  <pds-radio component-id="message1" label="Label" helper-message="This is short message text."></pds-radio>
 </DocCanvas>
 
 ### Invalid
@@ -59,9 +59,9 @@ An optional error message can be displayed for additional instructions, displaye
 
 <DocCanvas client:only mdxSource={{
   react: `<PdsRadio componentId="invalid" label="Label" invalid errorMessage="This is a short error message" />`,
-  webComponent: `<pds-radio component-id="invalid" label="Label" invalid error-message="This is a short error message" />`
+  webComponent: `<pds-radio component-id="invalid" label="Label" invalid error-message="This is a short error message"></pds-radio>`
 }}>
-  <pds-radio component-id="invalid" label="Label" invalid error-message="This is a short error message" />
+  <pds-radio component-id="invalid" label="Label" invalid error-message="This is a short error message"></pds-radio>
 </DocCanvas>
 
 ### Group
@@ -79,14 +79,14 @@ Once a radio group is created, only one radio at a time can be selected.
   `,
   webComponent: `<div>
   <pds-radio component-id="default1" label="Label" name="radio" checked />
-  <pds-radio component-id="default2" label="Label" name="radio" />
-  <pds-radio component-id="default3" label="Label" name="radio" />
+  <pds-radio component-id="default2" label="Label" name="radio"></pds-radio>
+  <pds-radio component-id="default3" label="Label" name="radio"></pds-radio>
 </div>
 `}}>
   <>
-    <pds-radio component-id="default1" label="Label" name="radio" checked />
-    <pds-radio component-id="default2" label="Label" name="radio" />
-    <pds-radio component-id="default3" label="Label" name="radio" />
+    <pds-radio component-id="default1" label="Label" name="radio" checked></pds-radio>
+    <pds-radio component-id="default2" label="Label" name="radio"></pds-radio>
+    <pds-radio component-id="default3" label="Label" name="radio"></pds-radio>
   </>
 </DocCanvas>
 

--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -37,7 +37,7 @@ The default switch style uses a checkbox input.
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsSwitch componentId="pds-switch-default-example" label="Default Switch" name="pds-switch-default" type="checkbox" />',
-    webComponent: '<pds-switch component-id="pds-switch-default-example" label="Default Switch" name="pds-switch-default" type="checkbox" />'
+    webComponent: '<pds-switch component-id="pds-switch-default-example" label="Default Switch" name="pds-switch-default" type="checkbox"></pds-switch>'
   }}>
   <div>
     <pds-switch
@@ -45,7 +45,7 @@ The default switch style uses a checkbox input.
       label="Default Switch"
       name="pds-switch-default"
       type="checkbox"
-    />
+    ></pds-switch>
   </div>
 </DocCanvas>
 
@@ -57,7 +57,7 @@ Renders a switch using a radio button input. Just like a [standard radio button]
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsSwitch componentId="pds-switch-radio-example" label="Radio Switch" name="pds-switch-radio" type="radio" value="pds-switch-radio" />',
-    webComponent: '<pds-switch component-id="pds-switch-radio-example" label="Radio Switch" name="pds-switch-radio" type="radio" value="pds-switch-radio"/>'
+    webComponent: '<pds-switch component-id="pds-switch-radio-example" label="Radio Switch" name="pds-switch-radio" type="radio" value="pds-switch-radio"></pds-switch>'
 }}>
   <pds-switch
     component-id="pds-switch-radio-example"
@@ -65,7 +65,7 @@ Renders a switch using a radio button input. Just like a [standard radio button]
     name="pds-switch-radio"
     type="radio"
     value="pds-switch-radio"
-  />
+  ></pds-switch>
 </DocCanvas>
 
 ### Disabled
@@ -75,7 +75,7 @@ Prevents user interaction on the input.
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsSwitch componentId="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled" type="checkbox"/>`,
-    webComponent: `<pds-switch component-id="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled" type="checkbox"/>`
+    webComponent: `<pds-switch component-id="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled" type="checkbox"></pds-switch>`
 }}>
   <pds-switch
     component-id="pds-switch-disabled-example"
@@ -83,7 +83,7 @@ Prevents user interaction on the input.
     label="Can't touch this"
     name="pds-switch-disabled"
     type="checkbox"
-  />
+  ></pds-switch>
 </DocCanvas>
 
 ### Helper message
@@ -93,7 +93,7 @@ Displays additional descriptive text underneath the main label.
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsSwitch componentId="pds-switch-helper-example" helperMessage="Save my login details for next time." label="Remember me" name="pds-switch-helper" type="checkbox" />',
-    webComponent: '<pds-switch component-id="pds-switch-helper-example" helper-message="Save my login details for next time." label="Remember me" name="pds-switch-helper" type="checkbox" />'
+    webComponent: '<pds-switch component-id="pds-switch-helper-example" helper-message="Save my login details for next time." label="Remember me" name="pds-switch-helper" type="checkbox"></pds-switch>'
   }}>
   <>
     <pds-switch
@@ -102,7 +102,7 @@ Displays additional descriptive text underneath the main label.
       label="Remember me"
       name="pds-switch-helper"
       type="checkbox"
-    />
+   ></pds-switch>
   </>
 </DocCanvas>
 
@@ -113,7 +113,7 @@ An optional error message can be displayed for additional instructions, displaye
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsSwitch componentId="pds-switch-invalid-example" errorMessage="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true" type="checkbox"/>',
-    webComponent: '<pds-switch component-id="pds-switch-invalid-example" error-message="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true" type="checkbox"/>'
+    webComponent: '<pds-switch component-id="pds-switch-invalid-example" error-message="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true" type="checkbox"></pds-switch>'
 }}>
   <pds-switch
     component-id="pds-switch-invalid-example"
@@ -123,5 +123,5 @@ An optional error message can be displayed for additional instructions, displaye
     name="pds-switch-invalid"
     required="true"
     type="checkbox"
-  />
+  ></pds-switch>
 </DocCanvas>


### PR DESCRIPTION
# Description

During implementation of web components for a `kajabi-products` update, the divider did not output simply using `<pds-divider />`. This was code directly copied from the Pine doc site. After reviewing the issue, it was found that in order to properly display web components, they need to not be self-closing. Rather than use `<pds-divider />` use `<pds-divider></pds-divider>`.

Fixes #(issue)
[DSS-659](https://kajabi.atlassian.net/browse/DSS-659)

## Type of change
- [X] This change requires a documentation update

# How Has This Been Tested?
- [X] tested manually

1. Navigate to [Divider documentation](http://localhost:6006/?path=/docs/components-divider--docs) locally
2. Select "Web Component" under the Default example. 
3. Verify it is outputting the correct format, `<pds-divider></pds-divider>`
4. Verify the same for all other fixed components: 
- [ ] pds-checkbox
- [ ] pds-chip
- [ ] pds-radio
- [ ] pds-switch

**Test Configuration**:

- Pine versions: current
- OS: Mac
- Browsers: Firefox
- Screen readers: N/A
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-659]: https://kajabi.atlassian.net/browse/DSS-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ