### PR TITLE
feature(table): adds select-all checkbox to the table header

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -224,7 +224,7 @@ export namespace Components {
         /**
           * It determines whether or not the checkbox is checked.
          */
-        "checked": boolean;
+        "checked"?: boolean;
         /**
           * A unique identifier used for the underlying component `id` attribute and the label `for` attribute.
          */
@@ -680,6 +680,14 @@ export namespace Components {
         "truncate": boolean;
     }
     interface PdsTableHead {
+        /**
+          * Indicates that the selection state is indeterminate.
+         */
+        "indeterminate"?: boolean;
+        /**
+          * A local state to track whether the row is currently selected.
+         */
+        "isSelected": boolean;
     }
     interface PdsTableHeadCell {
         /**
@@ -688,6 +696,14 @@ export namespace Components {
         "sortable": boolean;
     }
     interface PdsTableRow {
+        /**
+          * Indicates that the selection state is indeterminate.
+         */
+        "indeterminate"?: boolean;
+        /**
+          * A local state to track whether the row is currently selected.
+         */
+        "isSelected"?: boolean;
     }
     interface PdsTabpanel {
         /**
@@ -853,6 +869,14 @@ export interface PdsTabCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsTabElement;
 }
+export interface PdsTableCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPdsTableElement;
+}
+export interface PdsTableHeadCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPdsTableHeadElement;
+}
 export interface PdsTableHeadCellCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsTableHeadCellElement;
@@ -896,6 +920,7 @@ declare global {
     };
     interface HTMLPdsCheckboxElementEventMap {
         "pdsCheckboxChange": CheckboxChangeEventDetail;
+        "pdsCheckboxInput": CheckboxChangeEventDetail;
     }
     interface HTMLPdsCheckboxElement extends Components.PdsCheckbox, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsCheckboxElementEventMap>(type: K, listener: (this: HTMLPdsCheckboxElement, ev: PdsCheckboxCustomEvent<HTMLPdsCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1066,7 +1091,19 @@ declare global {
         prototype: HTMLPdsTabElement;
         new (): HTMLPdsTabElement;
     };
+    interface HTMLPdsTableElementEventMap {
+        "pdsTableSelect": { rowIndex: number; isSelected: boolean };
+        "pdsTableSelectAll": { isSelected: boolean };
+    }
     interface HTMLPdsTableElement extends Components.PdsTable, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPdsTableElementEventMap>(type: K, listener: (this: HTMLPdsTableElement, ev: PdsTableCustomEvent<HTMLPdsTableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPdsTableElementEventMap>(type: K, listener: (this: HTMLPdsTableElement, ev: PdsTableCustomEvent<HTMLPdsTableElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLPdsTableElement: {
         prototype: HTMLPdsTableElement;
@@ -1084,7 +1121,24 @@ declare global {
         prototype: HTMLPdsTableCellElement;
         new (): HTMLPdsTableCellElement;
     };
+    interface HTMLPdsTableHeadElementEventMap {
+        "pdsTableSelectAll": {
+    isSelected: boolean
+  };
+        "pdsTableSelect": {
+    rowIndex: number
+    isSelected: boolean
+  };
+    }
     interface HTMLPdsTableHeadElement extends Components.PdsTableHead, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPdsTableHeadElementEventMap>(type: K, listener: (this: HTMLPdsTableHeadElement, ev: PdsTableHeadCustomEvent<HTMLPdsTableHeadElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPdsTableHeadElementEventMap>(type: K, listener: (this: HTMLPdsTableHeadElement, ev: PdsTableHeadCustomEvent<HTMLPdsTableHeadElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLPdsTableHeadElement: {
         prototype: HTMLPdsTableHeadElement;
@@ -1108,7 +1162,8 @@ declare global {
         new (): HTMLPdsTableHeadCellElement;
     };
     interface HTMLPdsTableRowElementEventMap {
-        "pdsTableRowSelected": { rowIndex: number; isSelected: boolean; };
+        "pdsTableSelect": { rowIndex: number; isSelected: boolean; };
+        "pdsTableSelectAll": { isSelected: boolean };
     }
     interface HTMLPdsTableRowElement extends Components.PdsTableRow, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsTableRowElementEventMap>(type: K, listener: (this: HTMLPdsTableRowElement, ev: PdsTableRowCustomEvent<HTMLPdsTableRowElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1456,6 +1511,7 @@ declare namespace LocalJSX {
           * Event emitted that contains the `value` and `checked`.
          */
         "onPdsCheckboxChange"?: (event: PdsCheckboxCustomEvent<CheckboxChangeEventDetail>) => void;
+        "onPdsCheckboxInput"?: (event: PdsCheckboxCustomEvent<CheckboxChangeEventDetail>) => void;
         /**
           * It determines whether or not the checkbox is required.
          */
@@ -1882,6 +1938,8 @@ declare namespace LocalJSX {
           * Determines if table displays fixed column which fixes the first column of the table.
          */
         "fixedColumn"?: boolean;
+        "onPdsTableSelect"?: (event: PdsTableCustomEvent<{ rowIndex: number; isSelected: boolean }>) => void;
+        "onPdsTableSelectAll"?: (event: PdsTableCustomEvent<{ isSelected: boolean }>) => void;
         /**
           * Enables the table to be responsive by horizontally scrolling on smaller screens.
          */
@@ -1900,6 +1958,27 @@ declare namespace LocalJSX {
         "truncate"?: boolean;
     }
     interface PdsTableHead {
+        /**
+          * Indicates that the selection state is indeterminate.
+         */
+        "indeterminate"?: boolean;
+        /**
+          * A local state to track whether the row is currently selected.
+         */
+        "isSelected"?: boolean;
+        /**
+          * Emitted with row index and selected state.
+         */
+        "onPdsTableSelect"?: (event: PdsTableHeadCustomEvent<{
+    rowIndex: number
+    isSelected: boolean
+  }>) => void;
+        /**
+          * Emitted with selected state.
+         */
+        "onPdsTableSelectAll"?: (event: PdsTableHeadCustomEvent<{
+    isSelected: boolean
+  }>) => void;
     }
     interface PdsTableHeadCell {
         /**
@@ -1913,9 +1992,21 @@ declare namespace LocalJSX {
     }
     interface PdsTableRow {
         /**
+          * Indicates that the selection state is indeterminate.
+         */
+        "indeterminate"?: boolean;
+        /**
+          * A local state to track whether the row is currently selected.
+         */
+        "isSelected"?: boolean;
+        /**
           * Event that is emitted when the checkbox is clicked, carrying the selected value.
          */
-        "onPdsTableRowSelected"?: (event: PdsTableRowCustomEvent<{ rowIndex: number; isSelected: boolean; }>) => void;
+        "onPdsTableSelect"?: (event: PdsTableRowCustomEvent<{ rowIndex: number; isSelected: boolean; }>) => void;
+        /**
+          * Emitted with selected state.
+         */
+        "onPdsTableSelectAll"?: (event: PdsTableRowCustomEvent<{ isSelected: boolean }>) => void;
     }
     interface PdsTabpanel {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1122,13 +1122,7 @@ declare global {
         new (): HTMLPdsTableCellElement;
     };
     interface HTMLPdsTableHeadElementEventMap {
-        "pdsTableSelectAll": {
-    isSelected: boolean
-  };
-        "pdsTableSelect": {
-    rowIndex: number
-    isSelected: boolean
-  };
+        "pdsTableSelectAll": { isSelected: boolean };
     }
     interface HTMLPdsTableHeadElement extends Components.PdsTableHead, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsTableHeadElementEventMap>(type: K, listener: (this: HTMLPdsTableHeadElement, ev: PdsTableHeadCustomEvent<HTMLPdsTableHeadElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1162,8 +1156,7 @@ declare global {
         new (): HTMLPdsTableHeadCellElement;
     };
     interface HTMLPdsTableRowElementEventMap {
-        "pdsTableSelect": { rowIndex: number; isSelected: boolean; };
-        "pdsTableSelectAll": { isSelected: boolean };
+        "pdsTableRowSelected": { rowIndex: number; isSelected: boolean; };
     }
     interface HTMLPdsTableRowElement extends Components.PdsTableRow, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsTableRowElementEventMap>(type: K, listener: (this: HTMLPdsTableRowElement, ev: PdsTableRowCustomEvent<HTMLPdsTableRowElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1967,18 +1960,9 @@ declare namespace LocalJSX {
          */
         "isSelected"?: boolean;
         /**
-          * Emitted with row index and selected state.
-         */
-        "onPdsTableSelect"?: (event: PdsTableHeadCustomEvent<{
-    rowIndex: number
-    isSelected: boolean
-  }>) => void;
-        /**
           * Emitted with selected state.
          */
-        "onPdsTableSelectAll"?: (event: PdsTableHeadCustomEvent<{
-    isSelected: boolean
-  }>) => void;
+        "onPdsTableSelectAll"?: (event: PdsTableHeadCustomEvent<{ isSelected: boolean }>) => void;
     }
     interface PdsTableHeadCell {
         /**
@@ -2002,11 +1986,7 @@ declare namespace LocalJSX {
         /**
           * Event that is emitted when the checkbox is clicked, carrying the selected value.
          */
-        "onPdsTableSelect"?: (event: PdsTableRowCustomEvent<{ rowIndex: number; isSelected: boolean; }>) => void;
-        /**
-          * Emitted with selected state.
-         */
-        "onPdsTableSelectAll"?: (event: PdsTableRowCustomEvent<{ isSelected: boolean }>) => void;
+        "onPdsTableRowSelected"?: (event: PdsTableRowCustomEvent<{ rowIndex: number; isSelected: boolean; }>) => void;
     }
     interface PdsTabpanel {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1931,7 +1931,13 @@ declare namespace LocalJSX {
           * Determines if table displays fixed column which fixes the first column of the table.
          */
         "fixedColumn"?: boolean;
+        /**
+          * Event that is emitted when the checkbox is clicked, carrying the rowIndex and selected value.
+         */
         "onPdsTableSelect"?: (event: PdsTableCustomEvent<{ rowIndex: number; isSelected: boolean }>) => void;
+        /**
+          * Event that is emitted when the select all checkbox is clicked, carrying the selected value.
+         */
         "onPdsTableSelectAll"?: (event: PdsTableCustomEvent<{ isSelected: boolean }>) => void;
         /**
           * Enables the table to be responsive by horizontally scrolling on smaller screens.
@@ -1960,7 +1966,7 @@ declare namespace LocalJSX {
          */
         "isSelected"?: boolean;
         /**
-          * Emitted with selected state.
+          * Event that is emitted when the select all checkbox is clicked, carrying the selected value.
          */
         "onPdsTableSelectAll"?: (event: PdsTableHeadCustomEvent<{ isSelected: boolean }>) => void;
     }

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -48,10 +48,23 @@
 }
 
 :host(.is-indeterminate) {
-  input:checked {
+  input {
+    background: var(--color-checked);
+    border-color: var(--color-checked);
+
     &::after {
+      border: 1px solid var(--color-border-icon);
       border-bottom: 0;
+      border-left: 0;
+      border-top: 0;
+      content: "";
+      display: block;
+      height: 7px;
+      left: 50%;
+      position: absolute;
+      top: 50%;
       transform: rotate(87deg) translate3d(-114%, 25%, 0);
+      width: 4px;
     }
   }
 }

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Host, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop, Host, Event, EventEmitter, Watch } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
 import { CheckboxChangeEventDetail } from './checkbox-interface';
@@ -12,7 +12,7 @@ export class PdsCheckbox {
   /**
    * It determines whether or not the checkbox is checked.
    */
-  @Prop({ mutable: true }) checked: boolean;
+  @Prop({ mutable: true }) checked?: boolean = false;
 
   /**
    * A unique identifier used for the underlying component `id` attribute and the label `for` attribute.
@@ -38,7 +38,7 @@ export class PdsCheckbox {
    * If `true`, the checkbox will visually appear as indeterminate.
    * Only JavaScript can set the objects `indeterminate` property. See [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes).
    */
-  @Prop() indeterminate: boolean;
+  @Prop({ mutable: true }) indeterminate: boolean;
 
   /**
    * It determines whether or not the checkbox is invalid.
@@ -75,6 +75,13 @@ export class PdsCheckbox {
    */
   @Event() pdsCheckboxChange: EventEmitter<CheckboxChangeEventDetail>;
 
+  @Event() pdsCheckboxInput: EventEmitter<CheckboxChangeEventDetail>;
+
+  @Watch('checked')
+  updateIndeterminate() {
+    this.indeterminate = undefined
+  }
+
   private handleCheckboxChange = (e: Event) => {
     if (this.disabled) {
       return;
@@ -85,6 +92,13 @@ export class PdsCheckbox {
 
     this.pdsCheckboxChange.emit({
       checked: target.checked,
+      value: this.value
+    });
+  }
+
+  private handleInput = () => {
+    this.pdsCheckboxInput.emit({
+      checked: this.checked,
       value: this.value
     });
   }
@@ -103,16 +117,18 @@ export class PdsCheckbox {
     return (
       <Host class={this.classNames()}>
         <input
+          type="checkbox"
           aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
           aria-invalid={this.invalid ? "true" : undefined}
-          type="checkbox"
           id={this.componentId}
+          indeterminate={this.indeterminate}
           name={this.name}
           value={this.value}
           checked={this.checked}
           required={this.required}
           disabled={this.disabled}
           onChange={this.handleCheckboxChange}
+          onInput={this.handleInput}
         />
         <PdsLabel htmlFor={this.componentId} text={this.label} classNames={this.labelHidden ? 'visually-hidden' : ''} />
         {this.helperMessage &&

--- a/libs/core/src/components/pds-checkbox/readme.md
+++ b/libs/core/src/components/pds-checkbox/readme.md
@@ -9,7 +9,7 @@
 
 | Property                   | Attribute        | Description                                                                                                                                                                                                                                               | Type      | Default     |
 | -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
-| `checked`                  | `checked`        | It determines whether or not the checkbox is checked.                                                                                                                                                                                                     | `boolean` | `undefined` |
+| `checked`                  | `checked`        | It determines whether or not the checkbox is checked.                                                                                                                                                                                                     | `boolean` | `false`     |
 | `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute and the label `for` attribute.                                                                                                                                                       | `string`  | `undefined` |
 | `disabled`                 | `disabled`       | It determines whether or not the checkbox is disabled.                                                                                                                                                                                                    | `boolean` | `undefined` |
 | `errorMessage`             | `error-message`  | Displays message text describing an invalid state.                                                                                                                                                                                                        | `string`  | `undefined` |
@@ -28,17 +28,20 @@
 | Event               | Description                                            | Type                                          |
 | ------------------- | ------------------------------------------------------ | --------------------------------------------- |
 | `pdsCheckboxChange` | Event emitted that contains the `value` and `checked`. | `CustomEvent<CheckboxChangeEventDetail<any>>` |
+| `pdsCheckboxInput`  |                                                        | `CustomEvent<CheckboxChangeEventDetail<any>>` |
 
 
 ## Dependencies
 
 ### Used by
 
+ - [pds-table-head](../pds-table/pds-table-head)
  - [pds-table-row](../pds-table/pds-table-row)
 
 ### Graph
 ```mermaid
 graph TD;
+  pds-table-head --> pds-checkbox
   pds-table-row --> pds-checkbox
   style pds-checkbox fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -79,7 +79,7 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-indeterminate" component-id="default" label="Label text" indeterminate>
         <mock:shadow-root>
-          <input type="checkbox" id="default">
+          <input indeterminate="" type="checkbox" id="default">
           <label htmlfor="default">Label text</label>
         </mock:shadow-root>
       </pds-checkbox>

--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.tsx
@@ -7,7 +7,7 @@ import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 })
 export class PdsTableCell {
   @Element() hostElement: HTMLPdsTableCellElement;
-  tableRef: HTMLPdsTableElement;
+  private tableRef: HTMLPdsTableElement;
 
   componentWillRender() {
     this.tableRef = this.hostElement.closest('pds-table') as HTMLPdsTableElement;

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
@@ -9,7 +9,7 @@ import { downSmall, upSmall } from '@pine-ds/icons/icons';
 })
 export class PdsTableHeadCell {
   @Element() hostElement: HTMLPdsTableHeadCellElement;
-  tableRef: HTMLPdsTableElement;
+  private tableRef: HTMLPdsTableElement;
 
   /**
    * Determines whether the table column is sortable when set to `true`.
@@ -23,6 +23,11 @@ export class PdsTableHeadCell {
 
   @State() private sortingDirection: 'asc' | 'desc' = 'asc';
   @State() private tableScrolling: boolean = false;
+
+  /**
+   * A local state to track whether the row is currently selected.
+   */
+  @State() isSelected: boolean = false;
 
   componentWillRender() {
     this.tableRef = this.hostElement.closest('pds-table') as HTMLPdsTableElement;

--- a/libs/core/src/components/pds-table/pds-table-head/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head/readme.md
@@ -5,16 +5,33 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property        | Attribute       | Description                                                   | Type      | Default     |
+| --------------- | --------------- | ------------------------------------------------------------- | --------- | ----------- |
+| `indeterminate` | `indeterminate` | Indicates that the selection state is indeterminate.          | `boolean` | `undefined` |
+| `isSelected`    | `is-selected`   | A local state to track whether the row is currently selected. | `boolean` | `undefined` |
+
+
+## Events
+
+| Event               | Description                                                                                 | Type                                    |
+| ------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `pdsTableSelectAll` | Event that is emitted when the select all checkbox is clicked, carrying the selected value. | `CustomEvent<{ isSelected: boolean; }>` |
+
+
 ## Dependencies
 
 ### Depends on
 
 - [pds-table-head-cell](../pds-table-head-cell)
+- [pds-checkbox](../../pds-checkbox)
 
 ### Graph
 ```mermaid
 graph TD;
   pds-table-head --> pds-table-head-cell
+  pds-table-head --> pds-checkbox
   pds-table-head-cell --> pds-icon
   style pds-table-head fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.e2e.ts
+++ b/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.e2e.ts
@@ -8,4 +8,28 @@ describe('pds-table-head', () => {
     const element = await page.find('pds-table-head');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('emits pdsTableSelectAll event when the pds-checkbox is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-table selectable="true">
+        <pds-table-head>
+          <pds-table-head-cell>Column Title</pds-table-head-cell>
+          <pds-table-head-cell>Column Title</pds-table-head-cell>
+          <pds-table-head-cell>Column Title</pds-table-head-cell>
+        </pds-table-head>
+      </pds-table>
+    `);
+
+    const head = await page.find('pds-table-head');
+    const checkbox = await page.find('pds-table-head >>> pds-checkbox');
+
+    const pdsTableSelectAllSpy = await head.spyOnEvent('pdsTableSelectAll');
+
+
+    await checkbox.triggerEvent('input');
+    await page.waitForChanges();
+
+    expect(pdsTableSelectAllSpy).toHaveReceivedEventDetail({ isSelected: true });
+  });
 });

--- a/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.spec.tsx
@@ -75,4 +75,57 @@ describe('pds-table-head', () => {
       expect(checkboxCell.getAttribute('part')).toBe('');
     }
   });
+
+  it('renders a pds-checkbox when selectable is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHead, PdsTable],
+      html: `
+        <pds-table selectable="true" fixed-column="true">
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+        </pds-table>`,
+    });
+
+    const head = page.root?.querySelector('pds-table-head');
+    const checkbox = head?.shadowRoot?.querySelector('pds-checkbox');
+
+    expect(checkbox).not.toBeNull();
+    expect(checkbox?.getAttribute('label')).toBe('Select All Rows');
+  });
+
+  it('sets isSelected to true when checkbox is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHead, PdsTable],
+      html: `
+        <pds-table selectable="true">
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Row 1, Column 1</pds-table-cell>
+              <pds-table-cell>Row 1, Column 2</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>`,
+    });
+
+    const head = page.root?.querySelector('pds-table-head');
+    const checkbox = head?.shadowRoot?.querySelector('pds-checkbox');
+    const inputEvent = new Event('input', {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    checkbox?.dispatchEvent(inputEvent);
+    await page.waitForChanges();
+
+    // Check if isSelected is toggled
+    expect((head as unknown as PdsTableHead).isSelected).toBe(true);
+  })
 });

--- a/libs/core/src/components/pds-table/pds-table-row/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-row/readme.md
@@ -5,6 +5,14 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property        | Attribute       | Description                                                   | Type      | Default     |
+| --------------- | --------------- | ------------------------------------------------------------- | --------- | ----------- |
+| `indeterminate` | `indeterminate` | Indicates that the selection state is indeterminate.          | `boolean` | `undefined` |
+| `isSelected`    | `is-selected`   | A local state to track whether the row is currently selected. | `boolean` | `undefined` |
+
+
 ## Events
 
 | Event                 | Description                                                                      | Type                                                      |

--- a/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.e2e.ts
+++ b/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.e2e.ts
@@ -35,6 +35,7 @@ describe('pds-table-row', () => {
       <pds-table selectable="true">
         <pds-table-body>
           <pds-table-row></pds-table-row>
+          <pds-table-row></pds-table-row>
         </pds-table-body>
       </pds-table>
     `);
@@ -42,11 +43,11 @@ describe('pds-table-row', () => {
     const row = await page.find('pds-table-row');
     const checkbox = await page.find('pds-table-row >>> pds-checkbox');
 
-    const pdsTableRowSelectedSpy = await row.spyOnEvent('pdsTableRowSelected');
+    const pdsTableSelectSpy = await row.spyOnEvent('pdsTableRowSelected');
 
     await checkbox.click();
     await page.waitForChanges();
 
-    expect(pdsTableRowSelectedSpy).toHaveReceivedEventDetail({ rowIndex: 0, isSelected: true });
+    expect(pdsTableSelectSpy).toHaveReceivedEventDetail({ rowIndex: 0, isSelected: true });
   });
 });

--- a/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.spec.tsx
@@ -38,4 +38,42 @@ describe('pds-table-row', () => {
 
     expect(row?.classList.contains('is-selected')).toBe(true);
   });
+
+  it('adds the class is-fixed to the table-cell when table has fixedColumn', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableRow],
+      html: `
+      <pds-table fixed-column="true">
+        <pds-table-row>
+          <pds-table-cell>Cell Content</pds-table-cell>
+        </pds-table-row>
+      </pds-table>
+      `,
+    });
+
+    const cell = page.root?.querySelector('pds-table-cell');
+    expect(cell?.classList.contains('is-fixed')).toBe(true);
+  });
+
+  it('emits pdsTableRowSelected event when isSelected is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableBody, PdsTableRow],
+      html: `
+      <pds-table selectable="true">
+        <pds-table-body>
+          <pds-table-row is-selected=true indeterminate=true></pds-table-row>
+        </pds-table-body>
+      </pds-table>
+      `,
+    });
+
+    const row = page.root?.querySelector('pds-table-row');
+    const checkbox = row?.shadowRoot?.querySelector('pds-checkbox') as HTMLFormElement;
+
+
+    checkbox.click();
+    await page.waitForChanges();
+
+    expect((row as PdsTableRow).indeterminate).toBe(false);
+  });
 });

--- a/libs/core/src/components/pds-table/readme.md
+++ b/libs/core/src/components/pds-table/readme.md
@@ -16,6 +16,14 @@
 | `selectable`               | `selectable`   | Determines if table displays checkboxes for selectable rows.                         | `boolean` | `undefined` |
 
 
+## Events
+
+| Event               | Description                                                                                   | Type                                                      |
+| ------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `pdsTableSelect`    | Event that is emitted when the checkbox is clicked, carrying the rowIndex and selected value. | `CustomEvent<{ rowIndex: number; isSelected: boolean; }>` |
+| `pdsTableSelectAll` | Event that is emitted when the select all checkbox is clicked, carrying the selected value.   | `CustomEvent<{ isSelected: boolean; }>`                   |
+
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -8,7 +8,7 @@ export default {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['onclick', 'pdsTableRowSelected'],
+      handles: ['onclick', 'pdsTableRowSelected', 'onclick', 'pdsTableSelectAll'],
     },
   },
   title: 'components/Table',

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -94,4 +94,100 @@ describe('pds-table', () => {
     // Assert that the values are sorted in ascending order based on Column 1
     expect(values).toEqual(['Row 1, Column 1', 'Row 2, Column 1']);
   });
+
+  it('sorts the table in DESC order when pdsTableSort event is triggered', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="test-table" responsive>
+          <pds-table-head>
+            <pds-table-head-cell sortable>Column 1</pds-table-head-cell>
+            <pds-table-head-cell sortable>Column 2</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>A 1, Column 1</pds-table-cell>
+              <pds-table-cell>B 1, Column 2</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>C 2, Column 1</pds-table-cell>
+              <pds-table-cell>D 2, Column 2</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const table = page.body.querySelector('pds-table') as HTMLElement;
+    const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
+
+    // Trigger the pdsTableSort event to simulate user interaction
+    table.dispatchEvent(
+      new CustomEvent('pdsTableSort', {
+        detail: { column: 'Column 1', direction: 'desc' },
+      }),
+    );
+
+    // Wait for changes to be applied
+    await page.waitForChanges();
+
+    // Check if the table rows are sorted correctly
+    const rows = Array.from(tableBody.querySelectorAll('pds-table-row')) as any;
+    const values = rows.map((row) => row.querySelector('pds-table-cell').textContent?.trim());
+
+    // Assert that the values are sorted in ascending order based on Column 1
+    expect(values).toEqual(['C 2, Column 1', 'A 1, Column 1']);
+  });
+
+
+  it('should select the header checkbox when all rows are selected', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableBody, PdsTableRow],
+      html: `
+        <pds-table selectable>
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row is-selected>
+              <pds-table-cell>Row 1, Column 1</pds-table-cell>
+              <pds-table-cell>Row 1, Column 2</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row is-selected>
+              <pds-table-cell>Row 1, Column 1</pds-table-cell>
+              <pds-table-cell>Row 1, Column 2</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const table = page.root?.querySelector('pds-table');
+    const head = page.root?.querySelector('pds-table-head');
+    const rows = page.root?.querySelectorAll('pds-table-row');
+
+    const headerCheckbox = head?.shadowRoot?.querySelector('pds-checkbox') as HTMLInputElement;
+
+    rows?.forEach((row, idx) => {
+      table?.dispatchEvent(
+        new CustomEvent('pdsTableRowSelected', {
+          detail: { rowIndex: idx, isSelected: true },
+          bubbles: true,
+        })
+      );
+    });
+
+    // Simulate all rows being selected
+    const event = new CustomEvent('pdsTableRowSelected', {
+      detail: { rowIndex: 0, isSelected: true },
+      bubbles: true,
+    });
+    table?.dispatchEvent(event);
+    await page.waitForChanges();
+
+    // Check if the header checkbox is selected
+    expect(headerCheckbox?.checked).toBe(true);
+  });
 });

--- a/libs/core/src/utils/closest.ts
+++ b/libs/core/src/utils/closest.ts
@@ -1,0 +1,9 @@
+// This helper function is similar to Element.closest(),
+// however it also traverses shadow DOM boundaries.
+export const closest = (selector: string, el: Element | Document) => {
+  return (
+    el &&
+    (('closest' in el && el.closest(selector)) ||
+      closest(selector, (el.getRootNode() as unknown as ShadowRoot).host))
+  )
+}


### PR DESCRIPTION
# Description

In the current table implementation, we allow customers to select individual rows but don't allow them to select all with a single click. 

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: See below

- This has been thoroughly tested with Unit and End to End test. You can also use Storybook to test various scenarios (see below).

### Scenario 1
  - Select all, checks all rows
  - Select all, deselects all rows
  
### Scenario 2, start with no rows selected.
  - Select a single row, sets header row `indeterminate`
  - select remaining rows so all are selected, header checkbox should be `checked`.
  - deselect a row, header should go to `indeterminate` state
  - click heder row checkbox, all rows should be selected and header checkbox should be checked.
  

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
