### PR TITLE
Table - Fixes a11y Issue

### DIFF
--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -8,6 +8,13 @@
   width: 100%;
 }
 
+:host(:focus-visible) {
+  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
+  box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
+  outline: none;
+}
+
 :host(.is-responsive) {
   background-attachment: local, local, scroll, scroll;
   background-image: linear-gradient(to right, var(--color-background-default), var(--color-background-default)),

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -111,6 +111,7 @@ export class PdsTable {
         id={this.componentId}
         role="grid"
         selectable={this.selectable}
+        tabindex="0"
       >
         <slot></slot>
       </Host>

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -13,7 +13,7 @@ describe('pds-table', () => {
       html: `<pds-table></pds-table>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-table class="pds-table" role="grid">
+      <pds-table class="pds-table" role="grid" tabindex="0">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -28,7 +28,7 @@ describe('pds-table', () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <pds-table class="pds-table is-compact" compact="true" role="grid">
+      <pds-table class="pds-table is-compact" compact="true" role="grid" tabindex="0">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -43,7 +43,7 @@ describe('pds-table', () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <pds-table class="pds-table is-responsive" responsive="true" role="grid">
+      <pds-table class="pds-table is-responsive" responsive="true" role="grid" tabindex="0">
         <mock:shadow-root>
           <slot></slot>
         </mock:shadow-root>
@@ -55,7 +55,7 @@ describe('pds-table', () => {
     const page = await newSpecPage({
       components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
       html: `
-        <pds-table component-id="test-table" responsive>
+        <pds-table component-id="test-table" responsive tabindex="0">
           <pds-table-head>
             <pds-table-head-cell sortable>Column 1</pds-table-head-cell>
             <pds-table-head-cell sortable>Column 2</pds-table-head-cell>


### PR DESCRIPTION
# Description

Fixes an a11y issue where there was no way for keyboard users to scroll horizontally within scrollable tables. Adds `tabindex="0"` to the table and a `focus-visible` ring.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
