### PR TITLE
fix: update pine-ds/icons & corrects tokens path

### DIFF
--- a/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
+++ b/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import allTokenJson from '../../../../core/src/global/styles/tokens/tokens.json';
+import allTokenJson from '../../../../core/src/global/styles/tokens/core/core.json';
 
 import './docTokenTable.css';
 
@@ -49,7 +49,7 @@ const applyStyle = (category: string, value: string): React.CSSProperties => {
 }
 
 const DocTokenTable: React.FC<DocTokenTableProps> = ({ category }) => {
-  const pineTokens = allTokenJson.core[category as keyof typeof allTokenJson.core] as Token;
+  const pineTokens = allTokenJson[category as keyof typeof allTokenJson] as Token;
 
   const buildValue = (item: string | Record<string, unknown> | ArrayLike<unknown>): string => {
     const boxShadowValue = Object.values(item) as unknown as string[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5257,9 +5257,9 @@
       "link": true
     },
     "node_modules/@pine-ds/icons": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@pine-ds/icons/-/icons-7.0.1.tgz",
-      "integrity": "sha512-PljJ4tAPWTOfFLWgFqK629LcqYGwjkokW42Zab3w+MUWLWrVTkvWT4tv3Hpm/XalMvR7CcFLQyjwGeFQc1Fs6Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@pine-ds/icons/-/icons-7.2.0.tgz",
+      "integrity": "sha512-N8a9k/w/0UFlbxXOXdyR2FDE9KO2SKKdDQUHZkbPNc3xcPdXwPfYuCxreCbBQXnSnThLxu+qSdcQlQYYkoLzhQ==",
       "dependencies": {
         "@stencil/core": "^4.8.1"
       }


### PR DESCRIPTION
# Description

Update Pine Icon dependency to the latest version.
Corrects tokens path in tokens table.

## Type of change

- [x] Chore: Icon version update & tokens path correction

# How Has This Been Tested?

- [x] tested manually - storybook

[Navigate to token docs](https://deploy-preview-221--pine-design-system.netlify.app/?path=/docs/foundations-design-tokens-borders--docs) and ensure tokens display as expected

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
