### PR TITLE
style(link): correct token naming for icon spacing

### DIFF
--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -11,7 +11,7 @@
   --font-size-xs: var(--pine-font-size-075);
   --font-weight: var(--pine-font-weight-medium);
 
-  --spacing-inline-start-margin: var(--pine-spacing-050);
+  --spacing-inline-start-margin: var(--pine-spacing-50);
   --sizing-svg-lg: 15px;
   --sizing-svg-md: 13px;
   --sizing-svg-sm: 11px;


### PR DESCRIPTION
# Description
The spacing token name is incorrect in the `pds-link` component. This causes incorrect spacing for the external icon.


### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2024-08-06 at 4 22 30 PM](https://github.com/user-attachments/assets/19364c48-9f9f-4556-9301-82f71bb933cd)|![Screenshot 2024-08-06 at 4 22 45 PM](https://github.com/user-attachments/assets/1e914336-b6cf-460e-aefe-8ecaacc74f96)|

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
