### PR TITLE
Accordion: Minor Styling Updates

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -8,10 +8,12 @@ details {
   --box-shadow-focus: inset 0 0 0 2px var(--pine-color-blue-200);
 
   --color-background-default: var(--pine-color-white);
-  --color-background-hover: var(--pine-color-grey-300);
-  --color-text-default: var(--pine-color-charcoal-200);
-  --color-text-active: var(--pine-color-charcoal-500);
-  --color-text-hover: var(--pine-color-charcoal-300);
+  --color-background-hover: var(--pine-color-mercury-150);
+  --color-text-default: var(--pine-color-grey-700);
+  --color-text-active: var(--pine-color-grey-950);
+  --color-text-hover: var(--pine-color-grey-800);
+
+  --font-weight-active: var(--pine-font-weight-semi-bold);
 
   --number-animation-transform-timing: 200ms;
 
@@ -21,7 +23,7 @@ details {
   --spacing-summary-padding-inline-start: var(--pine-spacing-100);
   --spacing-summary-padding-inline-end: var(--pine-spacing-50);
 
-  --typography-default: var(--pine-font-weight-semi-bold) var(--pine-font-size-100)/var(--pine-line-height-150) var(--pine-font-family-inter);
+  --typography-default: var(--pine-font-weight-medium) var(--pine-font-size-100)/var(--pine-line-height-150) var(--pine-font-family-inter);
 
   border-radius: var(--border-radius-default);
 
@@ -37,7 +39,7 @@ details[open] {
 
   summary {
     color: var(--color-text-active);
-    font: var(--typography-default);
+    font-weight: var(--font-weight-active);
 
     pds-icon {
       transform: scaleY(-1);

--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -7,7 +7,7 @@ details {
 
   --box-shadow-focus: inset 0 0 0 2px var(--pine-color-blue-200);
 
-  --color-content-background-default: var(--pine-color-white);
+  --color-background-default: var(--pine-color-white);
   --color-background-hover: var(--pine-color-grey-300);
   --color-text-default: var(--pine-color-charcoal-200);
   --color-text-active: var(--pine-color-charcoal-500);
@@ -16,14 +16,14 @@ details {
   --number-animation-transform-timing: 200ms;
 
   --spacing-details-padding-inline: var(--pine-spacing-150);
-  --spacing-summary-padding-block: var(--pine-spacing-050);
+  --spacing-details-padding-block: var(--pine-spacing-100);
+  --spacing-summary-padding-block: var(--pine-spacing-50);
   --spacing-summary-padding-inline-start: var(--pine-spacing-100);
-  --spacing-summary-padding-inline-end: var(--pine-spacing-050);
+  --spacing-summary-padding-inline-end: var(--pine-spacing-50);
 
-  --typography-default: var(--pine-font-weight-semi-bold) var(--pine-font-size-100)/var(--pine-line-height-150) var(--pine-font-family-circular);
+  --typography-default: var(--pine-font-weight-semi-bold) var(--pine-font-size-100)/var(--pine-line-height-150) var(--pine-font-family-inter);
 
   border-radius: var(--border-radius-default);
-  padding-inline: var(--spacing-details-padding-inline);
 
   pds-icon {
     transform: scaleY(1);
@@ -33,7 +33,7 @@ details {
 
 /* stylelint-disable-next-line */
 details[open] {
-  background-color: var(--color-content-background);
+  background-color: var(--color-background-default);
 
   summary {
     color: var(--color-text-active);
@@ -47,6 +47,7 @@ details[open] {
 }
 
 summary {
+  background-color: var(--color-background-default);
   border-radius: var(--border-radius-default);
   color: var(--color-text-default);
   font: var(--typography-default);
@@ -79,4 +80,9 @@ summary {
   pds-icon {
     margin-inline-start: auto;
   }
+}
+
+.pds-accordion__body {
+  padding-block: var(--spacing-details-padding-block);
+  padding-inline: var(--spacing-details-padding-inline);
 }


### PR DESCRIPTION
# Description

Updates the accordion with the following updates:
- Moves content padding from `details` element to `pds-accordion__body`
- Updates background to white
- Fixes deprecated spacing token (050 -> 50)
- Updates font family token to Inter

[DSS-759](https://kajabi.atlassian.net/browse/DSS-759)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-759]: https://kajabi.atlassian.net/browse/DSS-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ