### PR TITLE
fix(docTokenTable): the algorithm to sort the components was incorrect

### DIFF
--- a/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
+++ b/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
@@ -63,11 +63,7 @@ const DocTokenTable: React.FC<DocTokenTableProps> = ({ category }) => {
 
     // sets and sorts data based on numerical value
     // and ignores box-shadow and color
-    const data = ['box-shadow', 'color'].includes(category)
-      ? entries
-      : entries.sort(([ , tokenA], [ , tokenB]) =>
-          parseInt(tokenA.value as string) - parseInt(tokenB.value as string)
-        )
+    const data = entries.sort((tokenKeyA, tokenKeyB) => parseInt(tokenKeyA[0]) - parseInt(tokenKeyB[0]));
 
     return data.map(([key, token]): JSX.Element => {
 


### PR DESCRIPTION
# Description

In our feature branch `mercury-rising` we discovered that the sort wasn't correct. 

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually
- [x] other: Storybook

