### PR TITLE
style: updates accordion styling to better match Figma specs

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -8,7 +8,7 @@ details {
   --box-shadow-focus: inset 0 0 0 2px var(--pine-color-blue-200);
 
   --color-background-default: var(--pine-color-white);
-  --color-background-hover: var(--pine-color-mercury-150);
+  --color-background-hover: var(--pine-color-grey-150);
   --color-text-default: var(--pine-color-grey-700);
   --color-text-active: var(--pine-color-grey-950);
   --color-text-hover: var(--pine-color-grey-800);
@@ -18,8 +18,8 @@ details {
   --number-animation-transform-timing: 200ms;
 
   --spacing-details-padding-inline: var(--pine-spacing-150);
-  --spacing-details-padding-block-end: calc(var(--pine-spacing-200) + 2) //18 + 2 = 18px;
-  --spacing-summary-padding-block: calc(var(--pine-spacing-150) / 2) //12 / 2 = 6px;
+  --spacing-details-padding-block-end: calc(var(--pine-spacing-200) + 2); //18 + 2 = 18px
+  --spacing-summary-padding-block: calc(var(--pine-spacing-150) / 2); //12 / 2 = 6px
   --spacing-summary-padding-inline-start: var(--pine-spacing-100);
   --spacing-summary-padding-inline-end: var(--pine-spacing-050);
 
@@ -29,7 +29,6 @@ details {
 
   pds-icon {
     transform: scaleY(1);
-    transition: transform var(--number-animation-transform-timing);
   }
 }
 
@@ -43,7 +42,6 @@ details[open] {
 
     pds-icon {
       transform: scaleY(-1);
-      transition: transform var(--number-animation-transform-timing);
     }
   }
 }

--- a/libs/core/src/components/pds-accordion/pds-accordion.tsx
+++ b/libs/core/src/components/pds-accordion/pds-accordion.tsx
@@ -2,6 +2,7 @@ import { Component, h, Host, Prop, Watch } from '@stencil/core';
 import { downSmall } from '@pine-ds/icons/icons';
 
 /**
+ * @part accordion-body - Accordion body styles.
  * @slot (default) - Accordion body content.
  * @slot label - Accordion trigger button content.
  */
@@ -57,7 +58,7 @@ export class PdsAccordion {
             <slot name="label">Details</slot>
             <pds-icon icon={downSmall} />
           </summary>
-          <div class="pds-accordion__body">
+          <div part="accordion-body" class="pds-accordion__body">
             <slot />
           </div>
         </details>

--- a/libs/core/src/components/pds-accordion/readme.md
+++ b/libs/core/src/components/pds-accordion/readme.md
@@ -21,6 +21,13 @@
 | `"label"`     | Accordion trigger button content. |
 
 
+## Shadow Parts
+
+| Part               | Description            |
+| ------------------ | ---------------------- |
+| `"accordion-body"` | Accordion body styles. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
@@ -16,7 +16,7 @@ describe('pds-accordion', () => {
                 <slot name="label">Details</slot>
                 <pds-icon icon="${downSmall}"></pds-icon>
               </summary>
-              <div class="pds-accordion__body">
+              <div part="accordion-body" class="pds-accordion__body">
                 <slot />
               </div>
             </details>
@@ -38,7 +38,7 @@ describe('pds-accordion', () => {
                 <slot name="label">Details</slot>
                 <pds-icon icon="${downSmall}"></pds-icon>
               </summary>
-              <div class="pds-accordion__body">
+              <div part="accordion-body" class="pds-accordion__body">
                 <slot />
               </div>
             </details>
@@ -61,7 +61,7 @@ describe('pds-accordion', () => {
               <slot name="label">Details</slot>
               <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
-            <div class="pds-accordion__body">
+            <div part="accordion-body" class="pds-accordion__body">
               <slot />
             </div>
           </details>
@@ -84,7 +84,7 @@ describe('pds-accordion', () => {
               <slot name="label">Details</slot>
               <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
-            <div class="pds-accordion__body">
+            <div part="accordion-body" class="pds-accordion__body">
               <slot />
             </div>
           </details>
@@ -108,7 +108,7 @@ describe('pds-accordion', () => {
               <slot name="label">Details</slot>
               <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
-            <div class="pds-accordion__body">
+            <div part="accordion-body" class="pds-accordion__body">
               <slot />
             </div>
           </details>
@@ -132,7 +132,7 @@ describe('pds-accordion', () => {
               <slot name="label">Details</slot>
               <pds-icon icon="${downSmall}"></pds-icon>
             </summary>
-            <div class="pds-accordion__body">
+            <div part="accordion-body" class="pds-accordion__body">
               <slot />
             </div>
           </details>


### PR DESCRIPTION
# Description

This PR addresses the following issues:

- Fixes a styling bug with the summary padding. 
- Updates `summary` hover styling to grey 150 from mercury 150
- Removes arrow icon animation on open
- Adds a `part` to the accordion body so that it may be styled from outside the shadow DOM.

[Figma](https://www.figma.com/design/CC1YmaGKHnsvB28yLY9mEH/Sage-%E2%86%92-Mercury-components?node-id=32330-1859&t=iOrUqtQzQgShfS39-1)

[DSS-794](https://kajabi.atlassian.net/browse/DSS-794)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This PR should be tested in `kp` via Pine bridge with this `kp` PR: https://github.com/Kajabi/kajabi-products/pull/36251

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-794]: https://kajabi.atlassian.net/browse/DSS-794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ