### PR TITLE
style(tabs): change active tab underline color

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -11,6 +11,7 @@ pds-tab {
   --color-background-availability: var(--pine-color-white);
   --color-background-default: var(--pine-color-grey-300);
   --color-background-hover: var(--pine-color-grey-400);
+  --color-indicator-active: var(--pine-color-mercury-500);
   --color-text-active: var(--pine-color-grey-900);
   --color-text-active-inverse: var(--pine-color-white);
   --color-text-default: var(--pine-color-grey-700);
@@ -86,7 +87,7 @@ pds-tab {
     position: relative;
 
     &::after {
-      background-color: currentColor;
+      background-color: var(--color-indicator-active);
       bottom: 0;
       content: '';
       height: 3px;


### PR DESCRIPTION
# Description
With the rebrand, the design requires changing the active tab indicator to be `mercury-500`.

Fixes #(issue)
https://kajabi.atlassian.net/browse/DSS-861

## Type of change
- [x] Style change no impact to code, just visual changes

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [x] other: Storybook

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/31ac03bc-ac3a-4638-a635-5d6f8a9d4199)|![image](https://github.com/user-attachments/assets/2d7c050d-bdfb-4dd9-aec8-d4e50be8e065)|
# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
