### PR TITLE
style: focus state updates

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -5,7 +5,7 @@
 details {
   --border-radius-default: var(--pine-border-radius-100);
 
-  --box-shadow-focus: inset 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-default: var(--pine-color-white);
   --color-background-hover: var(--pine-color-grey-150);

--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -5,7 +5,7 @@
 details {
   --border-radius-default: var(--pine-border-radius-100);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-default: var(--pine-color-white);
   --color-background-hover: var(--pine-color-grey-150);

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -39,7 +39,7 @@ div {
 }
 
 .pds-avatar__button {
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
   --border-radius-round: var(--pine-border-radius-round);
 
   align-items: center;

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -39,7 +39,7 @@ div {
 }
 
 .pds-avatar__button {
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
   --border-radius-round: var(--pine-border-radius-round);
 
   align-items: center;

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -116,7 +116,7 @@
   --color-outline: var(--color-outline-destructive);
 
   &:focus-visible {
-    --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-background-destructive-default);
+    --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-background-destructive-default);
     box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
     outline: none;
   }

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -75,7 +75,7 @@
   }
 
   &:focus-visible {
-    --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+    --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
     border-color: var(--color-border-focus);
     // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
     box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -75,7 +75,7 @@
   }
 
   &:focus-visible {
-    --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+    --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
     border-color: var(--color-border-focus);
     // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
     box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
@@ -114,6 +114,12 @@
   --color-text-default: var(--color-text-destructive-default);
   --color-text-disabled: var(--color-text-destructive-disabled);
   --color-outline: var(--color-outline-destructive);
+
+  &:focus-visible {
+    --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-background-destructive-default);
+    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
+    outline: none;
+  }
 }
 
 .pds-button--secondary,

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -5,7 +5,7 @@
 
   --border-radius: var(--pine-border-radius-050);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
   --box-shadow-focus-invalid: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-red-200);
 
   --color-background: var(--pine-color-white);

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -6,7 +6,7 @@
   --border-radius: var(--pine-border-radius-050);
 
   --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
-  --box-shadow-focus-invalid: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-red-200);
+  --box-shadow-focus-invalid: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-red-200);
 
   --color-background: var(--pine-color-white);
   --color-background-disabled: var(--pine-color-grey-200);

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -5,8 +5,8 @@
 
   --border-radius: var(--pine-border-radius-050);
 
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
-  --box-shadow-focus-invalid: 0 0 0 2px var(--pine-color-red-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus-invalid: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-red-200);
 
   --color-background: var(--pine-color-white);
   --color-background-disabled: var(--pine-color-grey-200);

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -1,5 +1,5 @@
 :host {
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
   --border-radius: var(--pine-border-radius-200);
 
   --color-background-accent: var(--pine-color-purple-100);

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -1,5 +1,5 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
   --border-radius: var(--pine-border-radius-200);
 
   --color-background-accent: var(--pine-color-purple-100);

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -8,7 +8,7 @@
 
   --border-width-default: var(--pine-border-width-none);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-default: var(--pine-color-white);
   --color-border-interactive-hover: var(--pine-color-grey-400);

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -8,7 +8,7 @@
 
   --border-width-default: var(--pine-border-width-none);
 
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-default: var(--pine-color-white);
   --color-border-interactive-hover: var(--pine-color-grey-400);

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -1,6 +1,6 @@
 :host {
   --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-red-200);;
+  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-red-200);
 
   --color-text-default: var(--pine-color-grey-950);
   --color-background-disabled: var(--pine-color-grey-100);

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -1,6 +1,6 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
-  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-red-200);;
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-red-200);;
 
   --color-text-default: var(--pine-color-grey-950);
   --color-background-disabled: var(--pine-color-grey-100);

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -1,6 +1,6 @@
 :host {
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
-  --box-shadow-focus-error: 0 0 0 2px var(--pine-color-red-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-red-200);;
 
   --color-text-default: var(--pine-color-grey-950);
   --color-background-disabled: var(--pine-color-grey-100);

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -2,7 +2,7 @@
 
   --border-outline: 4px solid var(--pine-color-blue-200);
   --border-radius: var(--pine-border-radius-075);
-  --box-shadow-focus: inset 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-text-default: var(--pine-color-grey-900);
 

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -2,7 +2,7 @@
 
   --border-outline: 4px solid var(--pine-color-blue-200);
   --border-radius: var(--pine-border-radius-075);
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-text-default: var(--pine-color-grey-900);
 

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -2,8 +2,8 @@
   --border-interactive-default: var(--pine-border-width-thin) solid var( --pine-color-grey-400);
   --border-radius: 50%;
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus);
-  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-invalid-focus);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-focus);
+  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-invalid-focus);
 
   --color: var(--pine-color-grey-700);
   --color-background: var(--pine-color-white);

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -2,8 +2,8 @@
   --border-interactive-default: var(--pine-border-width-thin) solid var( --pine-color-grey-400);
   --border-radius: 50%;
 
-  --box-shadow-focus: 0 0 0 2px var(--color-focus);
-  --box-shadow-focus-error: 0 0 0 2px var(--color-invalid-focus);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus);
+  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-invalid-focus);
 
   --color: var(--pine-color-grey-700);
   --color-background: var(--pine-color-white);
@@ -13,7 +13,7 @@
   --color-border-disabled: var(--pine-color-grey-300);
   --color-checked: var(--pine-color-grey-950);
   --color-disabled: var(---pine-color-grey-500);
-  --color-focus: var(--pine-color-blue-200);
+  --color-focus: var(--pine-color-purple-300);
   --color-invalid: var(--pine-color-red-300);
   --color-invalid-focus: var(--pine-color-red-200);
 

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -1,8 +1,8 @@
 :host {
   --border-radius-input: var(--pine-border-radius-200);
 
-  --box-shadow-focus: 0 0 0 2px var(--color-outline-focus);
-  --box-shadow-focus-error: 0 0 0 2px var(--color-outline-focus-error);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-outline-focus);
+  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-outline-focus-error);
   --box-shadow-input-toggle: 0 2px 4px 0 rgba(0, 0, 0, 0.12), 0 0 2px 0 rgba(0, 0, 0, 0.08);
 
   --color-background-checked: var(--pine-color-grey-900);
@@ -12,7 +12,7 @@
   --color-background-input-default: var(--pine-color-grey-400);
   --color-input-toggle: var(--pine-color-white);
   --color-message-text: var(--pine-color-grey-700);
-  --color-outline-focus: var(--pine-color-blue-200);
+  --color-outline-focus: var(--pine-color-purple-300);
   --color-outline-focus-error: var(--pine-color-red-200);
   --color-text-default: var(--pine-color-grey-900);
   --color-text-disabled: var(--pine-color-grey-500);

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -1,8 +1,8 @@
 :host {
   --border-radius-input: var(--pine-border-radius-200);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-outline-focus);
-  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-outline-focus-error);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-outline-focus);
+  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-outline-focus-error);
   --box-shadow-input-toggle: 0 2px 4px 0 rgba(0, 0, 0, 0.12), 0 0 2px 0 rgba(0, 0, 0, 0.08);
 
   --color-background-checked: var(--pine-color-grey-900);

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -9,7 +9,7 @@
 }
 
 :host(:focus-visible) {
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
   // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
   box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
   outline: none;

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -9,7 +9,7 @@
 }
 
 :host(:focus-visible) {
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
   // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
   box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
   outline: none;

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -5,7 +5,7 @@ pds-tab {
   --border-radius-default: var(--pine-border-radius-125);
   --border-radius-none: var(--pine-border-radius-0);
 
-  --box-shadow-focus: 0 0 0 2px var(--pine-color-blue-200);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-active: var(--pine-color-grey-900);
   --color-background-availability: var(--pine-color-white);

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -5,7 +5,7 @@ pds-tab {
   --border-radius-default: var(--pine-border-radius-125);
   --border-radius-none: var(--pine-border-radius-0);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--pine-color-purple-300);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
 
   --color-background-active: var(--pine-color-grey-900);
   --color-background-availability: var(--pine-color-white);

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -1,8 +1,8 @@
 :host {
   --border-interactive-default: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
 
-  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus-visible-outline);
-  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus-visible-outline-error);
+  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-focus-visible-outline);
+  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--color-focus-visible-outline-error);
 
   --color: var(--pine-color-grey-900);
   --color-background: var(--pine-color-white);

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -1,8 +1,8 @@
 :host {
   --border-interactive-default: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
 
-  --box-shadow-focus: 0 0 0 2px var(--color-focus-visible-outline);
-  --box-shadow-focus-error: 0 0 0 2px var(--color-focus-visible-outline-error);
+  --box-shadow-focus: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus-visible-outline);
+  --box-shadow-focus-error: 0 0 0 1px #fff, 0 0 0 3px var(--color-focus-visible-outline-error);
 
   --color: var(--pine-color-grey-900);
   --color-background: var(--pine-color-white);
@@ -13,7 +13,7 @@
   --color-border-hover: var(--pine-color-grey-500);
   --color-disabled-default: var(--pine-color-grey-700);
   --color-error-default: var(--pine-color-red-300);
-  --color-focus-visible-outline: var(--pine-color-blue-200);
+  --color-focus-visible-outline: var(--pine-color-purple-300);
   --color-focus-visible-outline-error: var(--pine-color-red-200);
   --color-placeholder-default: var(--pine-color-grey-700);
 
@@ -51,8 +51,8 @@ label {
 
 .pds-textarea__field {
   background-color: var(--color-background);
-  border: var(--pine-border-interactive-default);
-  border-radius: var(--pine-border-radius-md);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--pine-border-radius-100);
   font-family: inherit;
   font-size: var(--font-size-field);
   font-weight: var(--font-weight-field);


### PR DESCRIPTION
# Description
Updates focus states to match new width and color

Fixes https://kajabi.atlassian.net/browse/DSS-857

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="337" alt="Screenshot 2024-09-04 at 10 45 25 AM" src="https://github.com/user-attachments/assets/3e5fc21a-e653-4c16-9146-34cf2242c0a0">|<img width="332" alt="Screenshot 2024-09-04 at 10 44 37 AM" src="https://github.com/user-attachments/assets/716b18fe-0db6-4940-b1df-5e25d7402051">|

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [ ] Styles only

# How Has This Been Tested?

Navigate to Storybook
Tab through or focus on interactive elements/components
Verify new focus width and color are displayed

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
