### PR TITLE
style(progress): update progress default fill to mercury 500

### DIFF
--- a/libs/core/src/components/pds-progress/pds-progress.scss
+++ b/libs/core/src/components/pds-progress/pds-progress.scss
@@ -1,5 +1,5 @@
 :host {
-  --color-progress-fill: var(--pine-color-blue-300);
+  --color-progress-fill: var(--pine-color-mercury-500);
 
   --sizing-progress-bar-height: 8px;
   --sizing-progress-bar-width: 100%;


### PR DESCRIPTION
# Description
With the rebrand, Design would like the progress fill color to be `mercury-500.`

Fixes #(issue)
https://kajabi.atlassian.net/browse/DSS-860

## Type of change
- [x] Style change no impact to code, just visual changes


# How Has This Been Tested?
- [x] tested manually
- [x] other: Storybook `?path=/docs/components-progress--docs`

|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/db2cf6c0-9abc-4cf8-94b3-542a59881c1f)|![image](https://github.com/user-attachments/assets/bde9ff08-40e8-4c29-af8e-7902276916cd)|
# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
