### PR TITLE
style: link and accordion focus 

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -75,6 +75,7 @@ summary {
     // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
     box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
     outline: none;
+    position: relative;
   }
 
   pds-icon {

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -33,6 +33,7 @@
     // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
     box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
     outline: none;
+    position: relative;
   }
 }
 


### PR DESCRIPTION
# Description
In the KP sidebar, the focus states currently overlap on links and accordion summary.
These style adjustments add relative positioning so the focus ring always appears on top.


Fixes https://kajabi.atlassian.net/browse/DSS-904

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Style (non-breaking change which fixes an issue)

### Screenshots
|  Before   |  After  |
|--------|--------|
|![2024-09-12 11 38 56](https://github.com/user-attachments/assets/a7c8fcf4-0a38-42d8-bf15-c66cf20dd83b)|![2024-09-12 11 39 28](https://github.com/user-attachments/assets/7d2fee31-ed50-4511-ba0b-48330b8fe255)|

# How Has This Been Tested?

Bridge KP & Pine
Test focus state no longer overlaps

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
