### PR TITLE
style(table): updates table font size to 14px

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
@@ -7,7 +7,7 @@
   --dimension-fixed-cell-position: 0;
   --dimension-max-width-truncated: 100px;
 
-  --font-size-cell-default: var(--pine-font-size-085);
+  --font-size-cell-default: var(--pine-font-size-100);
 
   --number-fixed-column-index: 0;
 

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
@@ -9,7 +9,7 @@
 
   --dimension-fixed-cell-position: 0;
 
-  --font-size-head-cell: var(--pine-font-size-085);
+  --font-size-head-cell: var(--pine-font-size-100);
   --font-weight-cell-default: var(--pine-font-weight-normal);
 
   --line-height-cell-default: var(--pine-line-height-125);


### PR DESCRIPTION
# Description

Updates Table font size to 14px to match Sage.

[DSS-1026](https://kajabi.atlassian.net/browse/DSS-1026)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Styles (adds, removes, or updates styles)

# How Has This Been Tested?

Before:
<img width="1041" alt="Screenshot 2024-09-30 at 3 23 24 PM" src="https://github.com/user-attachments/assets/d66d7907-e8ae-4eb0-bd22-4e6137d4211c">

After:
<img width="1034" alt="Screenshot 2024-09-30 at 3 19 30 PM" src="https://github.com/user-attachments/assets/faaf8606-071d-4190-8d3f-3c39eb61599b">


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1026]: https://kajabi.atlassian.net/browse/DSS-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ