### PR TITLE
style: updates Avatar color styles

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -4,7 +4,7 @@
 
 div {
   // These custom props are not reachable
-  --color-background-container: var(--pine-color-blue-100);
+  --color-background-container: var(--pine-color-mercury-050);
   --color-background-badge: var(--pine-color-white);
   --color-border-badge: var(--pine-color-white);
 

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -105,7 +105,7 @@ export class PdsAvatar {
     // Percentage is average size of icon in relation to total avatar size
     // of all preset sizes found in Figma.
     // Used to allow icons to scale to container size
-      && <pds-icon class="pds-avatar__badge" icon={checkCircleFilled} size="33.53%"></pds-icon>
+      && <pds-icon color="var(--pine-color-purple-600)" class="pds-avatar__badge" icon={checkCircleFilled} size="33.53%"></pds-icon>
   );
 
   private renderIconOrImage = () => (
@@ -114,7 +114,7 @@ export class PdsAvatar {
       // Percentage is average size of icon in relation to total avatar size
       // of all preset sizes found in Figma.
       // Used to allow icons to scale to container size
-      : <pds-icon color="var(--pine-color-blue-400)" icon={userFilled} size="33.53%"></pds-icon>
+      : <pds-icon color="var(--pine-color-mercury-500)" icon={userFilled} size="33.53%"></pds-icon>
   );
 
   private classNames = () => (

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -13,7 +13,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -30,7 +30,7 @@ describe('pds-avatar', () => {
       <pds-avatar component-id="test" id="test" class="pds-avatar" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -46,7 +46,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar pds-avatar--admin" size="lg" variant="admin">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -62,8 +62,8 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" badge="true" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-blue-400)"icon="${userFilled}" size="33.53%"></pds-icon>
-            <pds-icon class="pds-avatar__badge" icon="${checkCircleFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon class="pds-avatar__badge" color="var(--pine-color-purple-600)" icon="${checkCircleFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -79,7 +79,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="128px" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 128px; width: 128px">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -128,7 +128,7 @@ describe('pds-avatar', () => {
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px">
             <img alt="Customer Profile" src="https://placehold.co/64x64"/>
-            <pds-icon class="pds-avatar__badge" icon="${checkCircleFilled}" size="33.53%"></pds-icon>
+            <pds-icon class="pds-avatar__badge" color="var(--pine-color-purple-600)" icon="${checkCircleFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -144,7 +144,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" size="xl" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 64px; width: 64px;">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>
@@ -161,7 +161,7 @@ describe('pds-avatar', () => {
         <mock:shadow-root>
           <button aria-label="Avatar dropdown trigger" class="pds-avatar__button" type="button">
             <div part="asset-wrapper" style="height: 56px; width: 56px;">
-              <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+              <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
             </div>
           </button>
         </mock:shadow-root>
@@ -178,7 +178,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar" dropdown="false" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <pds-icon color="var(--pine-color-blue-400)" icon="${userFilled}" size="33.53%"></pds-icon>
+            <pds-icon color="var(--pine-color-mercury-500)" icon="${userFilled}" size="33.53%"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-avatar>


### PR DESCRIPTION
# Description
Updates color style of Avatar component for rebrand.

[DSS-1025](https://kajabi.atlassian.net/browse/DSS-1025)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Style (adds, updates, or removes component styling)

# How Has This Been Tested?
This should be tested with the Pine bridge on to check that the Avatar in the top bar's user dropdown is updated.

Before:
<img width="111" alt="Screenshot 2024-10-08 at 3 14 21 PM" src="https://github.com/user-attachments/assets/0151addc-8251-4004-97fa-cc47a2fa8304">

After:
<img width="122" alt="Screenshot 2024-10-08 at 3 08 37 PM" src="https://github.com/user-attachments/assets/b1a20ac3-e9e7-4833-8484-378e86677449">


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1025]: https://kajabi.atlassian.net/browse/DSS-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ