### PR TITLE
fix: adds tooltip max width prop and removes events

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -834,6 +834,11 @@ export namespace Components {
          */
         "htmlContent": boolean;
         /**
+          * Sets the maximum width of the tooltip content
+          * @defaultValue "352px"
+         */
+        "maxWidth": string;
+        /**
           * Determines whether or not the tooltip is visible
           * @defaultValue false
          */
@@ -911,10 +916,6 @@ export interface PdsTableRowCustomEvent<T> extends CustomEvent<T> {
 export interface PdsTextareaCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsTextareaElement;
-}
-export interface PdsTooltipCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLPdsTooltipElement;
 }
 declare global {
     interface HTMLPdsAccordionElement extends Components.PdsAccordion, HTMLStencilElement {
@@ -1230,19 +1231,7 @@ declare global {
         prototype: HTMLPdsTextareaElement;
         new (): HTMLPdsTextareaElement;
     };
-    interface HTMLPdsTooltipElementEventMap {
-        "pdsTooltipHide": any;
-        "pdsTooltipShow": any;
-    }
     interface HTMLPdsTooltipElement extends Components.PdsTooltip, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLPdsTooltipElementEventMap>(type: K, listener: (this: HTMLPdsTooltipElement, ev: PdsTooltipCustomEvent<HTMLPdsTooltipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLPdsTooltipElementEventMap>(type: K, listener: (this: HTMLPdsTooltipElement, ev: PdsTooltipCustomEvent<HTMLPdsTooltipElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLPdsTooltipElement: {
         prototype: HTMLPdsTooltipElement;
@@ -2153,13 +2142,10 @@ declare namespace LocalJSX {
          */
         "htmlContent"?: boolean;
         /**
-          * Emitted after a tooltip is closed
+          * Sets the maximum width of the tooltip content
+          * @defaultValue "352px"
          */
-        "onPdsTooltipHide"?: (event: PdsTooltipCustomEvent<any>) => void;
-        /**
-          * Emitted after a tooltip is shown
-         */
-        "onPdsTooltipShow"?: (event: PdsTooltipCustomEvent<any>) => void;
+        "maxWidth"?: string;
         /**
           * Determines whether or not the tooltip is visible
           * @defaultValue false

--- a/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
+++ b/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
@@ -112,6 +112,18 @@ By default the arrow is visible but it can be hidden by disabling it when `has-a
   <pds-tooltip content="this is tooltip content" has-arrow="false" placement="right">text</pds-tooltip>
 </DocCanvas>
 
+
+### Width/Sizing
+The `maxWidth` prop allows for adjust the maximum width for the tooltip content. The default max width is 352px, but it can be customized as needed by passing a new pixel value.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsTooltip content="This is long tooltip content to demonstrate how the max-width can be used to expand or narrow the width of the tooltip content to fit one\'s use case and content needs. This example uses 520px to create a bit more width for this amount of content." max-width="520px" placement="right">text</PdsTooltip>',
+    webComponent: '<pds-tooltip content="This is long tooltip content to demonstrate how the max-width can be used to expand or narrow the width of the tooltip content to fit one\'s use case and content needs. This example uses 520px to create a bit more width for this amount of content." max-width="520px" placement="right">text</pds-tooltip>'
+}}>
+  <pds-tooltip content="This is long tooltip content to demonstrate how the max-width can be used to expand or narrow the width of the tooltip content to fit one's use case and content needs. This example uses 520px to create a bit more width for this amount of content." max-width="520px" placement="right">text</pds-tooltip>
+</DocCanvas>
+
 ## Additional Resources
 
 [W3 Aria Tooltip Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/)

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.scss
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.scss
@@ -27,7 +27,7 @@
   ::slotted([slot="content"]) {
     display: block;
     white-space: normal;
-    width: var(--sizing-width-default);
+    max-width: var(--sizing-width-default);
   }
 }
 
@@ -42,6 +42,7 @@
   position: absolute;
   visibility: hidden;
   width: max-content;
+  max-width: var(--sizing-width-default);
 
   .pds-tooltip--is-open & {
     // TODO: need to use block / none but the tooltip content width and height are needed for calculations

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.scss
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.scss
@@ -26,8 +26,8 @@
 
   ::slotted([slot="content"]) {
     display: block;
-    white-space: normal;
     max-width: var(--sizing-width-default);
+    white-space: normal;
   }
 }
 
@@ -37,12 +37,12 @@
   box-shadow: var(--box-shadow-default);
   color: var(--color-text-default);
   // TODO: need to use block / none but the tooltip content width and height are needed for calculations
+  max-width: var(--sizing-width-default);
   opacity: 0;
   padding: var(--spacing-padding-overlay);
   position: absolute;
   visibility: hidden;
   width: max-content;
-  max-width: var(--sizing-width-default);
 
   .pds-tooltip--is-open & {
     // TODO: need to use block / none but the tooltip content width and height are needed for calculations

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, Host, Prop, State, h, EventEmitter, Method, Watch } from '@stencil/core';
+import { Component, Element, Host, Prop, State, h, Method, Watch } from '@stencil/core';
 import {
   positionTooltip
 } from '../../utils/overlay';

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
@@ -68,6 +68,12 @@ export class PdsTooltip {
     | 'left-end' = 'right';
 
   /**
+   * Sets the maximum width of the tooltip content
+   * @defaultValue "352px"
+   */
+  @Prop() maxWidth: string = '352px';
+
+  /**
    * Determines whether or not the tooltip is visible
    * @defaultValue false
    */
@@ -81,16 +87,6 @@ export class PdsTooltip {
       this.handleHide();
     }
   }
-
-  /**
-   * Emitted after a tooltip is closed
-   */
-  @Event() pdsTooltipHide: EventEmitter;
-
-  /**
-   * Emitted after a tooltip is shown
-   */
-  @Event() pdsTooltipShow: EventEmitter;
 
   componentWillLoad() {
     if (this.opened) {
@@ -129,12 +125,10 @@ export class PdsTooltip {
 
   private handleHide = () => {
     this.hideTooltip();
-    this.pdsTooltipHide.emit();
   };
 
   private handleShow = () => {
     this.showTooltip();
-    this.pdsTooltipShow.emit();
   };
 
   render() {
@@ -167,6 +161,7 @@ export class PdsTooltip {
             id={this.componentId}
             ref={(el) => (this.contentEl = el)}
             role="tooltip"
+            style={{ maxWidth: this.maxWidth }}
           >
             <slot
               name="content"

--- a/libs/core/src/components/pds-tooltip/readme.md
+++ b/libs/core/src/components/pds-tooltip/readme.md
@@ -13,16 +13,9 @@
 | `content`     | `content`      | Content for the tooltip. If HTML is required, use the content slot    | `string`                                                                                                                                                             | `undefined` |
 | `hasArrow`    | `has-arrow`    | Determines whether or not the tooltip has an arrow                    | `boolean`                                                                                                                                                            | `true`      |
 | `htmlContent` | `html-content` | Enable this option when using the content slot                        | `boolean`                                                                                                                                                            | `false`     |
+| `maxWidth`    | `max-width`    | Sets the maximum width of the tooltip content                         | `string`                                                                                                                                                             | `'352px'`   |
 | `opened`      | `opened`       | Determines whether or not the tooltip is visible                      | `boolean`                                                                                                                                                            | `false`     |
 | `placement`   | `placement`    | Determines the preferred position of the tooltip                      | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'right'`   |
-
-
-## Events
-
-| Event            | Description                       | Type               |
-| ---------------- | --------------------------------- | ------------------ |
-| `pdsTooltipHide` | Emitted after a tooltip is closed | `CustomEvent<any>` |
-| `pdsTooltipShow` | Emitted after a tooltip is shown  | `CustomEvent<any>` |
 
 
 ## Methods

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
@@ -8,17 +8,17 @@ export default {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['mouseEnter', 'pdsTooltipShow', 'mouseLeave', 'pdsTooltipHide'],
+      handles: [],
     },
   },
   title: 'components/Tooltip'
 }
 
 const BaseTemplate = (args) => html`
-  <pds-tooltip content=${args.content} has-arrow=${args.hasArrow} placement=${args.placement}>${args.slot}</pds-tooltip>`;
+  <pds-tooltip content=${args.content} max-width=${args.maxWidth} has-arrow=${args.hasArrow} placement=${args.placement}>${args.slot}</pds-tooltip>`;
 
 const HTMLContentTemplate = (args) => html`
-  <pds-tooltip has-arrow=${args.hasArrow} placement=${args.placement} html-content=${args.htmlContent}>
+  <pds-tooltip has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement=${args.placement} html-content=${args.htmlContent}>
     <div slot="content">
       <p><strong>This is a tooltip</strong></p>
       <p>Tooltips are used to describe or identify an element. In most scenarios, tooltips help the user understand the meaning, function or alt-text of an element.</p>
@@ -30,46 +30,46 @@ const PositionTemplate = (args) => html`
   <div class="demo-container" style="min-height: 50vh; width: 100%; display: flex; align-items: center; justify-content: center;">
     <div class="position-demo-grid">
       <div class="position-demo-grid-item">
-        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} placement="top-start" opened=${args.opened}>
+        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-start" opened=${args.opened}>
           <pds-button variant="accent">t</pds-button>
         </pds-tooltip>
-        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} placement="top" opened=${args.opened}>
+        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top" opened=${args.opened}>
           <pds-button variant="accent">t</pds-button>
         </pds-tooltip>
-        <pds-tooltip content="content 3" has-arrow=${args.hasArrow} placement="top-end" opened=${args.opened}>
+        <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-end" opened=${args.opened}>
           <pds-button variant="accent">te</pds-button>
         </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} placement="left-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-start" opened=${args.opened}>
             <pds-button variant="accent">ls</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} placement="left" opened=${args.opened}>
+          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left" opened=${args.opened}>
             <pds-button variant="accent">l</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} placement="left-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-end" opened=${args.opened}>
             <pds-button variant="accent">le</pds-button>
           </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} placement="bottom-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-start" opened=${args.opened}>
             <pds-button variant="accent">bs</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} placement="bottom" opened=${args.opened}>
+          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom" opened=${args.opened}>
             <pds-button variant="accent">b</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} placement="bottom-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-end" opened=${args.opened}>
             <pds-button variant="accent">be</pds-button>
           </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} placement="right-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-start" opened=${args.opened}>
             <pds-button variant="accent">rs</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} placement="right" opened=${args.opened}>
+          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right" opened=${args.opened}>
             <pds-button variant="accent">r</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} placement="right-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-end" opened=${args.opened}>
             <pds-button variant="accent">re</pds-button>
           </pds-tooltip>
       </div>

--- a/libs/core/src/components/pds-tooltip/test/pds-tooltip.spec.tsx
+++ b/libs/core/src/components/pds-tooltip/test/pds-tooltip.spec.tsx
@@ -17,7 +17,7 @@ describe('pds-tooltip', () => {
           <span class="pds-tooltip__trigger">
             <slot></slot>
           </span>
-          <div class="pds-tooltip__content" aria-hidden="true" aria-live="off" role="tooltip" style="top: 50%; left: calc(0px + 8px); transform: translateY(-50%);">
+          <div class="pds-tooltip__content" aria-hidden="true" aria-live="off" role="tooltip" style="max-width: 352px; top: 50%; left: calc(0px + 8px); transform: translateY(-50%);">
             <slot name="content"></slot>
           </div>
         </div>
@@ -175,4 +175,19 @@ describe('pds-tooltip', () => {
 
     expect(element?.shadowRoot?.querySelector('.pds-tooltip')).not.toHaveClass('pds-tooltip--is-open');
   })
+
+  it('should apply maxWidth to tooltip content', async () => {
+    const maxWidthValue = '400px';
+    const page = await newSpecPage({
+      components: [PdsTooltip],
+      html: `
+        <pds-tooltip max-width="${maxWidthValue}" content="Tooltip content">
+          <pds-button variant="secondary">Secondary</pds-button>
+        </pds-tooltip>`
+    });
+
+    const contentElement = page.root?.shadowRoot?.querySelector('.pds-tooltip__content') as HTMLElement;
+
+    expect(contentElement.style.maxWidth).toBe(maxWidthValue);
+  });
 });


### PR DESCRIPTION
# Description

This PR adds a `maxWidth` prop to the `pds-tooltip` component, allowing users to set a maximum width for the tooltip content. It also sets the default to 352px as defined by the design team.

In addition, as previously discussed by the team, events have been removed.


Fixes:
https://kajabi.atlassian.net/browse/DSS-1151
https://kajabi.atlassian.net/browse/DSS-1158

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Navigate to [tooltip](http://localhost:6006/?path=/docs/components-tooltip--docs)
- Verify `maxWidth` is applied properly when added.
- Verify UI changes as expected
- Verify documentation additions/updates are clear.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Design has QA'ed and approved this PR
