### PR TITLE
feat(text): adds new component

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -772,6 +772,16 @@ export namespace Components {
   | 'success'
   | 'warning';
         /**
+          * Set the bottom margin for the text.
+         */
+        "gutter"?: | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -798,7 +808,12 @@ export namespace Components {
         /**
           * Sets the font weight.
          */
-        "weight"?: 'regular' | 'medium' | 'semibold' | 'bold';
+        "weight"?: | 'extra-light'
+  | 'light'
+  | 'regular'
+  | 'medium'
+  | 'semibold'
+  | 'bold';
     }
     interface PdsTextarea {
         /**
@@ -2135,6 +2150,16 @@ declare namespace LocalJSX {
   | 'success'
   | 'warning';
         /**
+          * Set the bottom margin for the text.
+         */
+        "gutter"?: | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -2147,7 +2172,7 @@ declare namespace LocalJSX {
         /**
           * Determines what semantic text tag to render.
          */
-        "tag": | 'h1'
+        "tag"?: | 'h1'
   | 'h2'
   | 'h3'
   | 'h4'
@@ -2161,7 +2186,12 @@ declare namespace LocalJSX {
         /**
           * Sets the font weight.
          */
-        "weight"?: 'regular' | 'medium' | 'semibold' | 'bold';
+        "weight"?: | 'extra-light'
+  | 'light'
+  | 'regular'
+  | 'medium'
+  | 'semibold'
+  | 'bold';
     }
     interface PdsTextarea {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -755,6 +755,22 @@ export namespace Components {
          */
         "variant": 'primary' | 'availability' | 'filter';
     }
+    interface PdsText {
+        /**
+          * Sets the font size.
+         */
+        "size"?: | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
+        /**
+          * Determines what semantic text tag to render.
+         */
+        "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+    }
     interface PdsTextarea {
         /**
           * Specifies if and how the browser provides `autocomplete` assistance for the field.
@@ -1217,6 +1233,12 @@ declare global {
         prototype: HTMLPdsTabsElement;
         new (): HTMLPdsTabsElement;
     };
+    interface HTMLPdsTextElement extends Components.PdsText, HTMLStencilElement {
+    }
+    var HTMLPdsTextElement: {
+        prototype: HTMLPdsTextElement;
+        new (): HTMLPdsTextElement;
+    };
     interface HTMLPdsTextareaElementEventMap {
         "pdsTextareaChange": TextareaChangeEventDetail;
     }
@@ -1268,6 +1290,7 @@ declare global {
         "pds-table-row": HTMLPdsTableRowElement;
         "pds-tabpanel": HTMLPdsTabpanelElement;
         "pds-tabs": HTMLPdsTabsElement;
+        "pds-text": HTMLPdsTextElement;
         "pds-textarea": HTMLPdsTextareaElement;
         "pds-tooltip": HTMLPdsTooltipElement;
     }
@@ -2066,6 +2089,22 @@ declare namespace LocalJSX {
          */
         "variant": 'primary' | 'availability' | 'filter';
     }
+    interface PdsText {
+        /**
+          * Sets the font size.
+         */
+        "size"?: | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
+        /**
+          * Determines what semantic text tag to render.
+         */
+        "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+    }
     interface PdsTextarea {
         /**
           * Specifies if and how the browser provides `autocomplete` assistance for the field.
@@ -2202,6 +2241,7 @@ declare namespace LocalJSX {
         "pds-table-row": PdsTableRow;
         "pds-tabpanel": PdsTabpanel;
         "pds-tabs": PdsTabs;
+        "pds-text": PdsText;
         "pds-textarea": PdsTextarea;
         "pds-tooltip": PdsTooltip;
     }
@@ -2237,6 +2277,7 @@ declare module "@stencil/core" {
             "pds-table-row": LocalJSX.PdsTableRow & JSXBase.HTMLAttributes<HTMLPdsTableRowElement>;
             "pds-tabpanel": LocalJSX.PdsTabpanel & JSXBase.HTMLAttributes<HTMLPdsTabpanelElement>;
             "pds-tabs": LocalJSX.PdsTabs & JSXBase.HTMLAttributes<HTMLPdsTabsElement>;
+            "pds-text": LocalJSX.PdsText & JSXBase.HTMLAttributes<HTMLPdsTextElement>;
             "pds-textarea": LocalJSX.PdsTextarea & JSXBase.HTMLAttributes<HTMLPdsTextareaElement>;
             "pds-tooltip": LocalJSX.PdsTooltip & JSXBase.HTMLAttributes<HTMLPdsTooltipElement>;
         }

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -770,6 +770,10 @@ export namespace Components {
           * Determines what semantic text tag to render.
          */
         "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+        /**
+          * Sets the font weight.
+         */
+        "weight"?: 'regular' | 'medium' | 'semibold' | 'bold';
     }
     interface PdsTextarea {
         /**
@@ -2104,6 +2108,10 @@ declare namespace LocalJSX {
           * Determines what semantic text tag to render.
          */
         "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+        /**
+          * Sets the font weight.
+         */
+        "weight"?: 'regular' | 'medium' | 'semibold' | 'bold';
     }
     interface PdsTextarea {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -761,6 +761,17 @@ export namespace Components {
          */
         "align"?: 'start' | 'center' | 'end' | 'justify';
         /**
+          * Sets the text color.
+         */
+        "color"?: | 'primary'
+  | 'secondary'
+  | 'neutral'
+  | 'accent'
+  | 'danger'
+  | 'info'
+  | 'success'
+  | 'warning';
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -2102,6 +2113,17 @@ declare namespace LocalJSX {
           * Sets the text alignment.
          */
         "align"?: 'start' | 'center' | 'end' | 'justify';
+        /**
+          * Sets the text color.
+         */
+        "color"?: | 'primary'
+  | 'secondary'
+  | 'neutral'
+  | 'accent'
+  | 'danger'
+  | 'info'
+  | 'success'
+  | 'warning';
         /**
           * Sets the font size.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -784,7 +784,15 @@ export namespace Components {
         /**
           * Determines what semantic text tag to render.
          */
-        "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+        "tag": | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'code'
+  | 'pre';
         /**
           * Sets the font weight.
          */
@@ -2137,7 +2145,15 @@ declare namespace LocalJSX {
         /**
           * Determines what semantic text tag to render.
          */
-        "tag": 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+        "tag": | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'code'
+  | 'pre';
         /**
           * Sets the font weight.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -757,6 +757,10 @@ export namespace Components {
     }
     interface PdsText {
         /**
+          * Sets the text alignment.
+         */
+        "align"?: 'start' | 'center' | 'end' | 'justify';
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -2094,6 +2098,10 @@ declare namespace LocalJSX {
         "variant": 'primary' | 'availability' | 'filter';
     }
     interface PdsText {
+        /**
+          * Sets the text alignment.
+         */
+        "align"?: 'start' | 'center' | 'end' | 'justify';
         /**
           * Sets the font size.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -792,7 +792,9 @@ export namespace Components {
   | 'h6'
   | 'p'
   | 'code'
-  | 'pre';
+  | 'pre'
+  | 'strong'
+  | 'em';
         /**
           * Sets the font weight.
          */
@@ -2153,7 +2155,9 @@ declare namespace LocalJSX {
   | 'h6'
   | 'p'
   | 'code'
-  | 'pre';
+  | 'pre'
+  | 'strong'
+  | 'em';
         /**
           * Sets the font weight.
          */

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -3,13 +3,19 @@ import { components } from '../../../../dist/docs.json';
 
 # Text
 
-The Text component allows for a choice of common semantic tags used for headings or body text. This tag can be nested so `em` and `strong` can be used as well.
+The Text component allows for a choice of common semantic tags used for headings or body text. This tag can be nested to allow use of `em` and `strong`.
 
 ## Guidelines
 
 ### Accessibility
 
 Correct semantic tag usage is important for SEO as well as accessibility. Be sure to use the correct tag for semantic and hierarchical purposes and *not* for styling purposes. For example, if an `h2` needs to be bigger, use the `size` property to change the font size instead of changing the tag to `h1`. For more information, see the References section below.
+
+Be sure to not skip heading levels. Users of assitive technology rely on heading levels to determine page content. Skipping these levels may cause confusion.
+
+### `em` vs `strong`
+
+It's important to be aware of the semantic differences between the `em` and `strong` tags. `em` is used to emphasize a selection of text, while `strong` is used to indicate a selection of text is of strong importance or urgency. They should not be used interchangeably.
 
 ## Properties
 
@@ -43,10 +49,10 @@ Text can be aligned to the start, center, end, or justified.
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsText align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</PdsText>',
-    webComponent: '<pds-text align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</pds-text>'
+    react: '<PdsText align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</PdsText>',
+    webComponent: '<pds-text align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</pds-text>'
 }}>
-  <pds-text align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</pds-text>
+  <pds-text align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</pds-text>
 </DocCanvas>
 
 ## Color
@@ -127,6 +133,18 @@ Gutters, or margin spacing, can be added to the bottom of the component for spac
 }}>
   <pds-text gutter="lg" tag="h2">Title</pds-text>
   <pds-text tag="p">Body of text...</pds-text>
+</DocCanvas>
+
+## Italics
+
+The `em` element does not come italicized by default as it should not be used solely to italicize text. To italicize text, add the `italic` attribute to the component.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsText tag="p">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
+    webComponent: `<pds-text tag="p">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
+}}>
+  <pds-text tag="p" italic>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>
 
 ## Truncation

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -25,7 +25,9 @@ It's important to be aware of the semantic differences between the `em` and `str
 
 Each semantic tag provided comes with default styling. If no `tag` prop is provided, the default tag will be set to `p`.
 
-<DocCanvas client:only
+<DocCanvas
+  client:only
+  display="block"
   mdxSource={{
     react: `
       <PdsText tag="h1" gutter="xs">Title</PdsText>
@@ -47,7 +49,9 @@ Each semantic tag provided comes with default styling. If no `tag` prop is provi
 
 Text can be aligned to the start, center, end, or justified.
 
-<DocCanvas client:only
+<DocCanvas
+  client:only
+  display="block"
   mdxSource={{
     react: '<PdsText align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</PdsText>',
     webComponent: '<pds-text align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</pds-text>'
@@ -120,7 +124,9 @@ Font weight can be set to common font weight values.
 
 Gutters, or margin spacing, can be added to the bottom of the component for spacing between blocks of text.
 
-<DocCanvas client:only
+<DocCanvas
+  display="block"
+  client:only
   mdxSource={{
     react: `
       <PdsText gutter="lg" tag="h2">Title</PdsText>

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -1,0 +1,20 @@
+import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
+import { components } from '../../../../dist/docs.json';
+
+# Text
+
+TBD
+
+## Properties
+
+<DocArgsTable componentName="pds-text" docSource={components} />
+
+## Default
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsText tag="h1"></PdsText>',
+    webComponent: '<pds-text tag="h1"></pds-text>'
+}}>
+  <pds-text tag="h1" size="h2">Hello World!</pds-text>
+</DocCanvas>

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -5,6 +5,12 @@ import { components } from '../../../../dist/docs.json';
 
 The Text component allows for a choice of common semantic tags used for headings or body text. This tag can be nested so `em` and `strong` can be used as well.
 
+## Guidelines
+
+### Accessibility
+
+Correct semantic tag usage is important for SEO as well as accessibility. Be sure to use the correct tag for semantic and hierarchical purposes and *not* for styling purposes. For example, if an `h2` needs to be bigger, use the `size` property to change the font size instead of changing the tag to `h1`. For more information, see the References section below.
+
 ## Properties
 
 <DocArgsTable componentName="pds-text" docSource={components} />
@@ -40,7 +46,7 @@ Text color can align to our common variant/sentiment values.
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsText color="primary" tag="p">Zebstrika</PdsText>
+      <PdsText style="background-color: #33; padding-inline: 8px" color="primary" tag="p">Zebstrika</PdsText>
       <PdsText color="secondary" tag="p">Pangoro</PdsText>
       <PdsText color="neutral" tag="p">Urshifu</PdsText>
       <PdsText color="accent" tag="p">Sableye</PdsText>
@@ -50,7 +56,7 @@ Text color can align to our common variant/sentiment values.
       <PdsText color="warning" tag="p">Pikachu</PdsText>
     `,
     webComponent: `
-      <pds-text color="primary" tag="p">Zebstrika</pds-text>
+      <pds-text style="background-color: #333; padding-inline: 8px" color="primary" tag="p">Zebstrika</pds-text>
       <pds-text color="secondary" tag="p">Pangoro</pds-text>
       <pds-text color="neutral" tag="p">Urshifu</pds-text>
       <pds-text color="accent" tag="p">Sableye</pds-text>
@@ -77,7 +83,7 @@ Font size can be set to preset body text values.
 <DocCanvas client:only
   mdxSource={{
     react: '<PdsText size="2xl" tag="p">Hello World!</PdsText>',
-    webComponent: '<pds-text size="2xl"tag="p">Hello World!</pds-text>'
+    webComponent: '<pds-text size="2xl" tag="p">Hello World!</pds-text>'
 }}>
   <pds-text size="2xl" tag="p">Hello World!</pds-text>
 </DocCanvas>
@@ -94,9 +100,28 @@ Font weight can be set to common font weight values.
   <pds-text weight="bold" tag="p">Hello World!</pds-text>
 </DocCanvas>
 
+## Gutters
+
+Gutters, or margin spacing, can be added to the bottom of the component for spacing between blocks of text.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsText gutter="lg" tag="h2">Title</PdsText>
+      <PdsText tag="p">Body of text...</PdsText>
+    `,
+    webComponent: `
+      <pds-text gutter="lg" tag="h2">Title</pds-text>
+      <pds-text tag="p">Body of text...</pds-text>
+    `
+}}>
+  <pds-text gutter="lg" tag="h2">Title</pds-text>
+  <pds-text tag="p">Body of text...</pds-text>
+</DocCanvas>
+
 ## Truncation
 
-To truncate text, add the `truncate` attribute to the component.
+To truncate text, add the `truncate` attribute to the component. Text truncation will depend on the component's or parent container's width.
 
 <DocCanvas client:only
   mdxSource={{
@@ -105,3 +130,11 @@ To truncate text, add the `truncate` attribute to the component.
 }}>
   <pds-text style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>
+
+## References
+
+[MDN: Semantics](https://developer.mozilla.org/en-US/docs/Glossary/Semantics)
+
+[MDN: HTML Elements Reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element#text-level_semantics)
+
+[MDN: Heading Elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -17,7 +17,7 @@ Correct semantic tag usage is important for SEO as well as accessibility. Be sur
 
 ## Default
 
-A `tag` is required for this component. Each semantic tag comes with default styling.
+Each semantic tag provided comes with default styling. If no `tag` prop is provided, the default tag will be set to `p`.
 
 <DocCanvas client:only
   mdxSource={{

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -141,8 +141,8 @@ The `em` element does not come italicized by default as it should not be used so
 
 <DocCanvas client:only
   mdxSource={{
-    react: `<PdsText tag="p">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
-    webComponent: `<pds-text tag="p">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
+    react: `<PdsText tag="p" italic>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
+    webComponent: `<pds-text tag="p" italic>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
 }}>
   <pds-text tag="p" italic>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -3,7 +3,7 @@ import { components } from '../../../../dist/docs.json';
 
 # Text
 
-TBD
+The Text component allows for a choice of common semantic tags used for headings or body text. This tag can be nested so `em` and `strong` can be used as well.
 
 ## Properties
 
@@ -11,10 +11,97 @@ TBD
 
 ## Default
 
+A `tag` is required for this component. Each semantic tag comes with default styling.
+
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsText tag="h1"></PdsText>',
-    webComponent: '<pds-text tag="h1"></pds-text>'
+    react: '<PdsText tag="h1">Hello World!</PdsText>',
+    webComponent: '<pds-text tag="h1">Hello World!</pds-text>'
 }}>
   <pds-text tag="h1">Hello World!</pds-text>
+</DocCanvas>
+
+## Alignment
+
+Text can be aligned to the start, center, end, or justified.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsText align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</PdsText>',
+    webComponent: '<pds-text align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</pds-text>'
+}}>
+  <pds-text align="center" tag="em">"Had to be me. Someone else might have gotten it wrong."</pds-text>
+</DocCanvas>
+
+## Color
+
+Text color can align to our common variant/sentiment values.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsText color="primary" tag="p">Zebstrika</PdsText>
+      <PdsText color="secondary" tag="p">Pangoro</PdsText>
+      <PdsText color="neutral" tag="p">Urshifu</PdsText>
+      <PdsText color="accent" tag="p">Sableye</PdsText>
+      <PdsText color="danger" tag="p">Arcanine</PdsText>
+      <PdsText color="info" tag="p">Garchomp</PdsText>
+      <PdsText color="success" tag="p">Sceptile</PdsText>
+      <PdsText color="warning" tag="p">Pikachu</PdsText>
+    `,
+    webComponent: `
+      <pds-text color="primary" tag="p">Zebstrika</pds-text>
+      <pds-text color="secondary" tag="p">Pangoro</pds-text>
+      <pds-text color="neutral" tag="p">Urshifu</pds-text>
+      <pds-text color="accent" tag="p">Sableye</pds-text>
+      <pds-text color="danger" tag="p">Arcanine</pds-text>
+      <pds-text color="info" tag="p">Garchomp</pds-text>
+      <pds-text color="success" tag="p">Sceptile</pds-text>
+      <pds-text color="warning" tag="p">Pikachu</pds-text>
+    `
+}}>
+  <pds-text style={{backgroundColor: '#333', paddingInline: '8px'}} color="primary" tag="p">Zebstrika</pds-text>
+  <pds-text color="secondary" tag="p">Pangoro</pds-text>
+  <pds-text color="neutral" tag="p">Urshifu</pds-text>
+  <pds-text color="accent" tag="p">Sableye</pds-text>
+  <pds-text color="danger" tag="p">Arcanine</pds-text>
+  <pds-text color="info" tag="p">Garchomp</pds-text>
+  <pds-text color="success" tag="p">Sceptile</pds-text>
+  <pds-text color="warning" tag="p">Pikachu</pds-text>
+</DocCanvas>
+
+## Font Size
+
+Font size can be set to preset body text values.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsText size="2xl" tag="p">Hello World!</PdsText>',
+    webComponent: '<pds-text size="2xl"tag="p">Hello World!</pds-text>'
+}}>
+  <pds-text size="2xl" tag="p">Hello World!</pds-text>
+</DocCanvas>
+
+## Font Weight
+
+Font weight can be set to common font weight values.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsText weight="bold" tag="p">Hello World!</PdsText>',
+    webComponent: '<pds-text weight="bold" tag="p">Hello World!</pds-text>'
+}}>
+  <pds-text weight="bold" tag="p">Hello World!</pds-text>
+</DocCanvas>
+
+## Truncation
+
+To truncate text, add the `truncate` attribute to the component.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsText tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
+    webComponent: `<pds-text tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
+}}>
+  <pds-text style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -16,5 +16,5 @@ TBD
     react: '<PdsText tag="h1"></PdsText>',
     webComponent: '<pds-text tag="h1"></pds-text>'
 }}>
-  <pds-text tag="h1" size="h2">Hello World!</pds-text>
+  <pds-text tag="h1">Hello World!</pds-text>
 </DocCanvas>

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -21,10 +21,20 @@ A `tag` is required for this component. Each semantic tag comes with default sty
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsText tag="h1">Hello World!</PdsText>',
-    webComponent: '<pds-text tag="h1">Hello World!</pds-text>'
+    react: `
+      <PdsText tag="h1" gutter="xs">Title</PdsText>
+      <PdsText tag="h2" gutter="lg">Subtitle</PdsText>
+      <PdsText tag="p">Excepteur nulla veniam ullamco tempor culpa magna occaecat culpa. Sunt cupidatat proident tempor labore cupidatat labore mollit ullamco esse culpa. Dolor aute consequat aliqua excepteur cillum. Tempor deserunt eiusmod nulla qui anim incididunt et nulla ex consequat sit Lorem.</PdsText>
+    `,
+    webComponent: `
+      <pds-text tag="h1" gutter="xs">Title</pds-text>
+      <pds-text tag="h2" gutter="lg">Subtitle</pds-text>
+      <pds-text tag="p">Excepteur nulla veniam ullamco tempor culpa magna occaecat culpa. Sunt cupidatat proident tempor labore cupidatat labore mollit ullamco esse culpa. Dolor aute consequat aliqua excepteur cillum. Tempor deserunt eiusmod nulla qui anim incididunt et nulla ex consequat sit Lorem.</pds-text>
+    `
 }}>
-  <pds-text tag="h1">Hello World!</pds-text>
+  <pds-text tag="h1" gutter="xs">Hello World!</pds-text>
+  <pds-text tag="h2" gutter="lg">Subtitle</pds-text>
+  <pds-text tag="p">Excepteur nulla veniam ullamco tempor culpa magna occaecat culpa. Sunt cupidatat proident tempor labore cupidatat labore mollit ullamco esse culpa. Dolor aute consequat aliqua excepteur cillum. Tempor deserunt eiusmod nulla qui anim incididunt et nulla ex consequat sit Lorem.</pds-text>
 </DocCanvas>
 
 ## Alignment

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -4,6 +4,7 @@
 
 // TODO: Update all values to match new semantic tokens, if applicable
 
+/* stylelint-disable */
 h1 {
   font-family: "GreetStandard";
   font-size: 28px;
@@ -52,6 +53,7 @@ code, em, p, pre, strong {
   font-weight: 400;
   letter-spacing: -0.16px;
 }
+/* stylelint-enable */
 
 code, pre {
   font-family: monospace;
@@ -64,6 +66,12 @@ strong {
 
 h1, h2, h3, h4, h5, h6, p, code, pre {
   color: var(--pine-color-text-default);
+}
+
+:host([truncate]) > * {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -53,6 +53,7 @@ p {
   letter-spacing: -0.16px;
 }
 
+// Font Sizes
 $type-sizes: (
   2xl: 20px,
   xl: 18px,
@@ -73,6 +74,7 @@ $type-sizes: (
 
 @include generate-type-sizes($type-sizes);
 
+// Font Weights
 $type-weights: (
   regular: 400,
   medium: 500,
@@ -89,3 +91,21 @@ $type-weights: (
 }
 
 @include generate-type-weights($type-weights);
+
+// Text Alignment
+$type-alignments: (
+  start: start,
+  center: center,
+  end: end,
+  justify: justify,
+);
+
+@mixin generate-type-alignments($type-alignments) {
+  @each $key, $value in $type-alignments {
+    .pds-text--align-#{$key} {
+      text-align: $value;
+    }
+  }
+}
+
+@include generate-type-alignments($type-alignments);

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -10,6 +10,7 @@ h1 {
   font-size: 28px;
   font-weight: 600;
   letter-spacing: 0.26px;
+  line-height: 1.25;
 }
 
 h2 {
@@ -17,6 +18,7 @@ h2 {
   font-size: 26px;
   font-weight: 600;
   letter-spacing: 0.24px;
+  line-height: 1.25;
 }
 
 h3 {
@@ -24,6 +26,7 @@ h3 {
   font-size: 22px;
   font-weight: 600;
   letter-spacing: 0.22px;
+  line-height: 1.25;
 }
 
 h4 {
@@ -31,6 +34,7 @@ h4 {
   font-size: 20px;
   font-weight: 600;
   letter-spacing: 0.20px;
+  line-height: 1.25;
 }
 
 h5 {
@@ -38,6 +42,7 @@ h5 {
   font-size: 18px;
   font-weight: 500;
   letter-spacing: 0.18px;
+  line-height: 1.25;
 }
 
 h6 {
@@ -45,6 +50,7 @@ h6 {
   font-size: 16px;
   font-weight: 500;
   letter-spacing: 0.16px;
+  line-height: 1.25;
 }
 
 code, em, p, pre, strong {
@@ -52,12 +58,14 @@ code, em, p, pre, strong {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: -0.16px;
+  line-height: 1.425;
 }
 /* stylelint-enable */
 
 code, pre {
   font-family: monospace;
   letter-spacing: 0;
+  line-height: 1;
 }
 
 strong {

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -1,5 +1,5 @@
 :host {
-  display: block;
+  display: inline;
 }
 
 // TODO: Update all values to match new semantic tokens, if applicable
@@ -68,6 +68,10 @@ code, pre {
   line-height: 1;
 }
 
+em {
+  font-style: normal;
+}
+
 strong {
   font-weight: bolder;
 }
@@ -81,6 +85,10 @@ h1, h2, h3, h4, h5, h6, p, code, pre, em, strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+:host([italic]) > * {
+  font-style: italic
 }
 
 

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -72,3 +72,20 @@ $type-sizes: (
 }
 
 @include generate-type-sizes($type-sizes);
+
+$type-weights: (
+  regular: 400,
+  medium: 500,
+  semi-bold: 600,
+  bold: 700,
+);
+
+@mixin generate-type-weights($type-weights) {
+  @each $key, $value in $type-weights {
+    .pds-text--weight-#{$key} {
+      font-weight: $value;
+    }
+  }
+}
+
+@include generate-type-weights($type-weights);

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -72,8 +72,9 @@ strong {
   font-weight: bolder;
 }
 
-h1, h2, h3, h4, h5, h6, p, code, pre {
+h1, h2, h3, h4, h5, h6, p, code, pre, em, strong {
   color: var(--pine-color-text-default);
+  margin: 0;
 }
 
 :host([truncate]) > * {

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -53,6 +53,14 @@ p {
   letter-spacing: -0.16px;
 }
 
+code, pre {
+  font-family: monospace;
+}
+
+h1, h2, h3, h4, h5, h6, p, code, pre {
+  color: var(--pine-color-text-default);
+}
+
 // Colors/Variants/Sentiment
 $type-colors: (
   primary: var(--pine-color-white),

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -46,7 +46,7 @@ h6 {
   letter-spacing: 0.16px;
 }
 
-p {
+code, em, p, pre, strong {
   font-family: "Inter";
   font-size: 14px;
   font-weight: 400;
@@ -55,11 +55,17 @@ p {
 
 code, pre {
   font-family: monospace;
+  letter-spacing: 0;
+}
+
+strong {
+  font-weight: bolder;
 }
 
 h1, h2, h3, h4, h5, h6, p, code, pre {
   color: var(--pine-color-text-default);
 }
+
 
 // Colors/Variants/Sentiment
 $type-colors: (
@@ -108,7 +114,7 @@ $type-sizes: (
 $type-weights: (
   regular: 400,
   medium: 500,
-  semi-bold: 600,
+  semibold: 600,
   bold: 700,
 );
 

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -1,0 +1,90 @@
+:host {
+  display: block;
+}
+
+  // TODO: Consider making semantic tokens for each
+  // font property
+$type-sizes: (
+  h1: var(--pine-font-size-200),
+  h2: var(--pine-font-size-185),
+  h3: var(--pine-font-size-157),
+  h4: var(--pine-font-size-142),
+  h5: var(--pine-font-size-128),
+  h6: var(--pine-font-size-116),
+);
+
+@mixin generate-type-sizes($type-sizes) {
+  @each $key, $value in $type-sizes {
+    .pds-text--size-#{$key} {
+      font-size: $value;
+    }
+  }
+}
+
+@include generate-type-sizes($type-sizes);
+
+// TODO: Refactor with semantic type tokens
+
+// .pds-text--size-h1 {
+//   font-size: var(--pine-font-size-200);
+// }
+
+// .pds-text--size-h2 {
+//   font-size: var(--pine-font-size-185);
+// }
+
+// .pds-text--size-h3 {
+//   font-size: var(--pine-font-size-157);
+// }
+
+// .pds-text--size-h4 {
+//   font-size: var(--pine-font-size-142);
+// }
+
+// .pds-text--size-h5 {
+//   font-size: var(--pine-font-size-128);
+// }
+
+// .pds-text--size-h6 {
+//   font-size: var(--pine-font-size-116);
+// }
+
+// .pds-text--size-p {
+//   font-size: var(--pine-font-size-100);
+// }
+
+h1 {
+  letter-spacing: var(--pine-letter-spacing-185);
+  font: var(--pine-typography-heading-h1);
+}
+
+h2 {
+  letter-spacing: var(--pine-letter-spacing-171);
+  font: var(--pine-typography-heading-h2);
+}
+
+h3 {
+  letter-spacing: var(--pine-letter-spacing-157);
+  font: var(--pine-typography-heading-h3);
+}
+
+h4 {
+  letter-spacing: var(--pine-letter-spacing-142);
+  font: var(--pine-typography-heading-h4);
+}
+
+h5 {
+  letter-spacing: var(--pine-letter-spacing-128);
+  font: var(--pine-typography-heading-h5);
+}
+
+h6 {
+  letter-spacing: var(--pine-letter-spacing-114);
+  font: var(--pine-typography-heading-h6);
+}
+
+p {
+  letter-spacing: var(--pine-letter-spacing-100);
+  font: var(--pine-typography-body-md-default);
+}
+

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -2,15 +2,65 @@
   display: block;
 }
 
-  // TODO: Consider making semantic tokens for each
-  // font property
+// TODO: Update all values to match new semantic tokens
+
+h1 {
+  font-family: "GreetStandard";
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: 0.26px;
+}
+
+h2 {
+  font-family: "GreetStandard";
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: 0.24px;
+}
+
+h3 {
+  font-family: "GreetStandard";
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: 0.22px;
+}
+
+h4 {
+  font-family: "GreetStandard";
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.20px;
+}
+
+h5 {
+  font-family: "GreetStandard";
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0.18px;
+}
+
+h6 {
+  font-family: "GreetStandard";
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: 0.16px;
+}
+
+p {
+  font-family: "Inter";
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: -0.16px;
+}
+
 $type-sizes: (
-  h1: var(--pine-font-size-200),
-  h2: var(--pine-font-size-185),
-  h3: var(--pine-font-size-157),
-  h4: var(--pine-font-size-142),
-  h5: var(--pine-font-size-128),
-  h6: var(--pine-font-size-116),
+  2xl: 20px,
+  xl: 18px,
+  lg: 16px,
+  md: 14px,
+  sm: 12px,
+  xs: 10px,
+  2xs: 8px,
 );
 
 @mixin generate-type-sizes($type-sizes) {
@@ -22,69 +72,3 @@ $type-sizes: (
 }
 
 @include generate-type-sizes($type-sizes);
-
-// TODO: Refactor with semantic type tokens
-
-// .pds-text--size-h1 {
-//   font-size: var(--pine-font-size-200);
-// }
-
-// .pds-text--size-h2 {
-//   font-size: var(--pine-font-size-185);
-// }
-
-// .pds-text--size-h3 {
-//   font-size: var(--pine-font-size-157);
-// }
-
-// .pds-text--size-h4 {
-//   font-size: var(--pine-font-size-142);
-// }
-
-// .pds-text--size-h5 {
-//   font-size: var(--pine-font-size-128);
-// }
-
-// .pds-text--size-h6 {
-//   font-size: var(--pine-font-size-116);
-// }
-
-// .pds-text--size-p {
-//   font-size: var(--pine-font-size-100);
-// }
-
-h1 {
-  letter-spacing: var(--pine-letter-spacing-185);
-  font: var(--pine-typography-heading-h1);
-}
-
-h2 {
-  letter-spacing: var(--pine-letter-spacing-171);
-  font: var(--pine-typography-heading-h2);
-}
-
-h3 {
-  letter-spacing: var(--pine-letter-spacing-157);
-  font: var(--pine-typography-heading-h3);
-}
-
-h4 {
-  letter-spacing: var(--pine-letter-spacing-142);
-  font: var(--pine-typography-heading-h4);
-}
-
-h5 {
-  letter-spacing: var(--pine-letter-spacing-128);
-  font: var(--pine-typography-heading-h5);
-}
-
-h6 {
-  letter-spacing: var(--pine-letter-spacing-114);
-  font: var(--pine-typography-heading-h6);
-}
-
-p {
-  letter-spacing: var(--pine-letter-spacing-100);
-  font: var(--pine-typography-body-md-default);
-}
-

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -2,7 +2,7 @@
   display: block;
 }
 
-// TODO: Update all values to match new semantic tokens
+// TODO: Update all values to match new semantic tokens, if applicable
 
 h1 {
   font-family: "GreetStandard";
@@ -52,6 +52,28 @@ p {
   font-weight: 400;
   letter-spacing: -0.16px;
 }
+
+// Colors/Variants/Sentiment
+$type-colors: (
+  primary: var(--pine-color-white),
+  secondary: var(--pine-color-grey-800),
+  neutral: var(--pine-color-grey-900),
+  accent: var(--pine-color-purple-900),
+  danger: var(--pine-color-red-900),
+  info: var(--pine-color-blue-900),
+  success: var(--pine-color-green-900),
+  warning: var(--pine-color-yellow-900),
+);
+
+@mixin generate-type-colors($type-colors) {
+  @each $key, $value in $type-colors {
+    .pds-text--color-#{$key} {
+      color: $value;
+    }
+  }
+}
+
+@include generate-type-colors($type-colors);
 
 // Font Sizes
 $type-sizes: (

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -129,6 +129,8 @@ $type-sizes: (
 
 // Font Weights
 $type-weights: (
+  extra-light: 200,
+  light: 300,
   regular: 400,
   medium: 500,
   semibold: 600,
@@ -144,6 +146,27 @@ $type-weights: (
 }
 
 @include generate-type-weights($type-weights);
+
+// Gutter Sizes
+$type-gutters: (
+  2xl: 48px,
+  xl: 40px,
+  lg: 32px,
+  md: 24px,
+  sm: 16px,
+  xs: 8px,
+  2xs: 4px,
+);
+
+@mixin generate-type-gutters($type-gutters) {
+  @each $key, $value in $type-gutters {
+    .pds-text--gutter-#{$key} {
+      margin-block-end: $value;
+    }
+  }
+}
+
+@include generate-type-gutters($type-gutters);
 
 // Text Alignment
 $type-alignments: (

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -20,6 +20,11 @@ export class PdsText {
   | '2xs';
 
   /**
+   * Sets the font weight.
+   */
+  @Prop() weight?: 'regular' | 'medium' | 'semibold' | 'bold';
+
+  /**
    * Determines what semantic text tag to render.
    */
   @Prop() tag!: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
@@ -30,6 +35,7 @@ export class PdsText {
     const typeClasses = `
       pds-text
       ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
+      ${this.weight !== undefined && this.weight.trim() !== '' ? `pds-text--weight-${this.weight}` : ''}
     `;
 
     return (

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -45,7 +45,16 @@ export class PdsText {
   /**
    * Determines what semantic text tag to render.
    */
-  @Prop() tag!: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+  @Prop() tag!:
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'code'
+  | 'pre';
 
   render() {
     const Tag = this.tag;

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -26,6 +26,18 @@ export class PdsText {
   | 'warning';
 
   /**
+   * Set the bottom margin for the text.
+   */
+  @Prop() gutter?:
+  | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
+
+  /**
    * Sets the font size.
    */
   @Prop() size?:
@@ -40,12 +52,18 @@ export class PdsText {
   /**
    * Sets the font weight.
    */
-  @Prop() weight?: 'regular' | 'medium' | 'semibold' | 'bold';
+  @Prop() weight?:
+  | 'extra-light'
+  | 'light'
+  | 'regular'
+  | 'medium'
+  | 'semibold'
+  | 'bold';
 
   /**
    * Determines what semantic text tag to render.
    */
-  @Prop() tag!:
+  @Prop() tag:
   | 'h1'
   | 'h2'
   | 'h3'
@@ -56,7 +74,7 @@ export class PdsText {
   | 'code'
   | 'pre'
   | 'strong'
-  | 'em';
+  | 'em' = "p";
 
   render() {
     const Tag = this.tag;
@@ -65,6 +83,7 @@ export class PdsText {
       pds-text
       ${this.align !== undefined && this.align.trim() !== '' ? `pds-text--align-${this.align}` : ''}
       ${this.color !== undefined && this.color.trim() !== '' ? `pds-text--color-${this.color}` : ''}
+      ${this.gutter !== undefined && this.gutter.trim() !== '' ? `pds-text--gutter-${this.gutter}` : ''}
       ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
       ${this.weight !== undefined && this.weight.trim() !== '' ? `pds-text--weight-${this.weight}` : ''}
     `;

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -54,7 +54,9 @@ export class PdsText {
   | 'h6'
   | 'p'
   | 'code'
-  | 'pre';
+  | 'pre'
+  | 'strong'
+  | 'em';
 
   render() {
     const Tag = this.tag;

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -13,6 +13,19 @@ export class PdsText {
   @Prop() align?: 'start' | 'center' | 'end' | 'justify';
 
   /**
+   * Sets the text color.
+   */
+  @Prop() color?:
+  | 'primary'
+  | 'secondary'
+  | 'neutral'
+  | 'accent'
+  | 'danger'
+  | 'info'
+  | 'success'
+  | 'warning';
+
+  /**
    * Sets the font size.
    */
   @Prop() size?:
@@ -40,6 +53,7 @@ export class PdsText {
     const typeClasses = `
       pds-text
       ${this.align !== undefined && this.align.trim() !== '' ? `pds-text--align-${this.align}` : ''}
+      ${this.color !== undefined && this.color.trim() !== '' ? `pds-text--color-${this.color}` : ''}
       ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
       ${this.weight !== undefined && this.weight.trim() !== '' ? `pds-text--weight-${this.weight}` : ''}
     `;

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -1,0 +1,36 @@
+import { Component, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'pds-text',
+  styleUrl: 'pds-text.scss',
+  shadow: true,
+})
+export class PdsText {
+
+  /**
+   * Sets the font size.
+   */
+  @Prop() size!: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+
+  /**
+   * Determines what semantic text tag to render.
+   */
+  @Prop() tag!: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+
+  render() {
+    const Tag = this.tag;
+
+    const typeClasses = `
+      ${this.size !== undefined ? `pds-text--size-${this.size}` : ''}
+      ${this.size ? 'pds-box--auto' : ''}
+      pds-text
+    `;
+
+    return (
+      <Tag class={typeClasses}>
+        <slot />
+      </Tag>
+    );
+  }
+
+}

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -8,6 +8,11 @@ import { Component, h, Prop } from '@stencil/core';
 export class PdsText {
 
   /**
+   * Sets the text alignment.
+   */
+  @Prop() align?: 'start' | 'center' | 'end' | 'justify';
+
+  /**
    * Sets the font size.
    */
   @Prop() size?:
@@ -34,6 +39,7 @@ export class PdsText {
 
     const typeClasses = `
       pds-text
+      ${this.align !== undefined && this.align.trim() !== '' ? `pds-text--align-${this.align}` : ''}
       ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
       ${this.weight !== undefined && this.weight.trim() !== '' ? `pds-text--weight-${this.weight}` : ''}
     `;

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -10,7 +10,14 @@ export class PdsText {
   /**
    * Sets the font size.
    */
-  @Prop() size!: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
+  @Prop() size?:
+  | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs';
 
   /**
    * Determines what semantic text tag to render.
@@ -21,9 +28,8 @@ export class PdsText {
     const Tag = this.tag;
 
     const typeClasses = `
-      ${this.size !== undefined ? `pds-text--size-${this.size}` : ''}
-      ${this.size ? 'pds-box--auto' : ''}
       pds-text
+      ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
     `;
 
     return (
@@ -32,5 +38,4 @@ export class PdsText {
       </Tag>
     );
   }
-
 }

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -12,7 +12,7 @@
 | `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
 | `color`            | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
 | `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`                                               | `undefined` |
+| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"code" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre"`                            | `undefined` |
 | `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`                                                     | `undefined` |
 
 

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -12,7 +12,7 @@
 | `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
 | `color`            | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
 | `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"code" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre"`                            | `undefined` |
+| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `undefined` |
 | `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`                                                     | `undefined` |
 
 

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property            | Attribute | Description                                  | Type                                                  | Default     |
-| ------------------- | --------- | -------------------------------------------- | ----------------------------------------------------- | ----------- |
-| `size` _(required)_ | `size`    | Sets the font size.                          | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"` | `undefined` |
-| `tag` _(required)_  | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"` | `undefined` |
+| Property           | Attribute | Description                                  | Type                                                     | Default     |
+| ------------------ | --------- | -------------------------------------------- | -------------------------------------------------------- | ----------- |
+| `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `undefined` |
+| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`    | `undefined` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -1,0 +1,18 @@
+# pds-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property            | Attribute | Description                                  | Type                                                  | Default     |
+| ------------------- | --------- | -------------------------------------------- | ----------------------------------------------------- | ----------- |
+| `size` _(required)_ | `size`    | Sets the font size.                          | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"` | `undefined` |
+| `tag` _(required)_  | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"` | `undefined` |
+
+
+----------------------------------------------
+
+

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property           | Attribute | Description                                  | Type                                                     | Default     |
-| ------------------ | --------- | -------------------------------------------- | -------------------------------------------------------- | ----------- |
-| `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`              | `undefined` |
-| `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `undefined` |
-| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`    | `undefined` |
-| `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`          | `undefined` |
+| Property           | Attribute | Description                                  | Type                                                                                                | Default     |
+| ------------------ | --------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
+| `color`            | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
+| `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
+| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`                                               | `undefined` |
+| `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`                                                     | `undefined` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -11,6 +11,7 @@
 | ------------------ | --------- | -------------------------------------------- | -------------------------------------------------------- | ----------- |
 | `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `undefined` |
 | `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`    | `undefined` |
+| `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`          | `undefined` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property           | Attribute | Description                                  | Type                                                                                                | Default     |
-| ------------------ | --------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
-| `color`            | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
-| `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `undefined` |
-| `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`                                                     | `undefined` |
+| Property | Attribute | Description                                  | Type                                                                                                | Default     |
+| -------- | --------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| `align`  | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
+| `color`  | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
+| `gutter` | `gutter`  | Set the bottom margin for the text.          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
+| `size`   | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
+| `tag`    | `tag`     | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `"p"`       |
+| `weight` | `weight`  | Sets the font weight.                        | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                         | `undefined` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -9,6 +9,7 @@
 
 | Property           | Attribute | Description                                  | Type                                                     | Default     |
 | ------------------ | --------- | -------------------------------------------- | -------------------------------------------------------- | ----------- |
+| `align`            | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`              | `undefined` |
 | `size`             | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `undefined` |
 | `tag` _(required)_ | `tag`     | Determines what semantic text tag to render. | `"h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`    | `undefined` |
 | `weight`           | `weight`  | Sets the font weight.                        | `"bold" \| "medium" \| "regular" \| "semibold"`          | `undefined` |

--- a/libs/core/src/components/pds-text/stories/pds-text.docs.mdx
+++ b/libs/core/src/components/pds-text/stories/pds-text.docs.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+
+import Docs from '../docs/pds-text.mdx'
+
+import * as stories from './pds-text.stories.js';
+
+<Meta of={stories} />
+
+<Docs />
+
+# Playground
+
+<Canvas of={stories.Default} />
+
+<Controls of={stories.Default} />

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -9,6 +9,7 @@ export default {
 }
 
 const BaseTemplate = (args) => html`<pds-text
+  align="${args.align}"
   tag="${args.tag}"
   size="${args.size}"
   weight="${args.weight}"

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -10,6 +10,7 @@ export default {
 
 const BaseTemplate = (args) => html`<pds-text
   tag="${args.tag}"
+  size="${args.size}"
 >
   ${args.slot}
 </pds-text>`;
@@ -17,5 +18,5 @@ const BaseTemplate = (args) => html`<pds-text
 export const Default = BaseTemplate.bind();
 Default.args = {
   slot: 'Hello World',
-  tag: 'h1'
+  tag: 'h1',
 };

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -24,6 +24,34 @@ Default.args = {
   tag: 'h1',
 };
 
+export const Align = BaseTemplate.bind();
+Align.args = {
+  slot: '"Had to be me. Someone else might have gotten it wrong."',
+  align: 'center',
+  tag: 'em',
+};
+
+export const Color = BaseTemplate.bind();
+Color.args = {
+  slot: 'Hello World',
+  color: 'accent',
+  tag: 'p',
+};
+
+export const FontSize = BaseTemplate.bind();
+FontSize.args = {
+  slot: 'Hello World',
+  size: '2xl',
+  tag: 'p',
+};
+
+export const FontWeight = BaseTemplate.bind();
+FontWeight.args = {
+  slot: 'Hello World',
+  weight: 'bold',
+  tag: 'p',
+};
+
 const TruncateTemplate = (args) => html`<pds-text
   align="${args.align}"
   color="${args.color}"
@@ -37,6 +65,6 @@ const TruncateTemplate = (args) => html`<pds-text
 
 export const Truncate = TruncateTemplate.bind();
 Truncate.args = {
-  slot: 'loremId irure id magna ipsum voluptate irure esse eu nulla. Ullamco officia adipisicing qui nulla non sint. Mollit tempor veniam quis nisi aliqua duis elit eu laborum et incididunt ut sit irure. Nisi aute veniam sint do amet consectetur velit. Quis sunt enim mollit deserunt laboris dolor elit exercitation. Id labore deserunt sint consequat laboris nulla do ut magna. Aliquip labore esse sint consequat voluptate tempor consectetur sit sint culpa occaecat ut velit est.',
+  slot: 'Id irure id magna ipsum voluptate irure esse eu nulla. Ullamco officia adipisicing qui nulla non sint. Mollit tempor veniam quis nisi aliqua duis elit eu laborum et incididunt ut sit irure. Nisi aute veniam sint do amet consectetur velit. Quis sunt enim mollit deserunt laboris dolor elit exercitation. Id labore deserunt sint consequat laboris nulla do ut magna. Aliquip labore esse sint consequat voluptate tempor consectetur sit sint culpa occaecat ut velit est.',
   tag: 'p',
 };

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -10,6 +10,7 @@ export default {
 
 const BaseTemplate = (args) => html`<pds-text
   align="${args.align}"
+  color="${args.color}"
   tag="${args.tag}"
   size="${args.size}"
   weight="${args.weight}"

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -1,0 +1,21 @@
+import { html } from 'lit';
+
+import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+
+export default {
+  argTypes: extractArgTypes('pds-text'),
+  component: 'pds-text',
+  title: 'components/Text',
+}
+
+const BaseTemplate = (args) => html`<pds-text
+  tag="${args.tag}"
+>
+  ${args.slot}
+</pds-text>`;
+
+export const Default = BaseTemplate.bind();
+Default.args = {
+  slot: 'Hello World',
+  tag: 'h1'
+};

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -11,6 +11,7 @@ export default {
 const BaseTemplate = (args) => html`<pds-text
   tag="${args.tag}"
   size="${args.size}"
+  weight="${args.weight}"
 >
   ${args.slot}
 </pds-text>`;

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -8,7 +8,8 @@ export default {
   title: 'components/Text',
 }
 
-const BaseTemplate = (args) => html`<pds-text
+const BaseTemplate = (args) => html`
+<pds-text
   align="${args.align}"
   color="${args.color}"
   size="${args.size}"
@@ -52,7 +53,8 @@ FontWeight.args = {
   tag: 'p',
 };
 
-const GutterTemplate = (args) => html`<pds-text
+const GutterTemplate = (args) => html`
+<pds-text
   align="${args.align}"
   color="${args.color}"
   gutter="${args.gutter}"
@@ -72,7 +74,26 @@ Gutter.args = {
   tag: 'h2',
 };
 
-const TruncateTemplate = (args) => html`<pds-text
+const ItalicTemplate = (args) => html`
+<pds-text
+  align="${args.align}"
+  color="${args.color}"
+  size="${args.size}"
+  tag="${args.tag}"
+  weight="${args.weight}"
+  italic
+>
+  ${args.slot}
+</pds-text>`;
+
+export const Italic = ItalicTemplate.bind();
+Italic.args = {
+  slot: 'Id irure id magna ipsum voluptate irure esse eu nulla',
+  tag: 'p',
+};
+
+const TruncateTemplate = (args) => html`
+<pds-text
   align="${args.align}"
   color="${args.color}"
   size="${args.size}"

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -11,8 +11,8 @@ export default {
 const BaseTemplate = (args) => html`<pds-text
   align="${args.align}"
   color="${args.color}"
-  tag="${args.tag}"
   size="${args.size}"
+  tag="${args.tag}"
   weight="${args.weight}"
 >
   ${args.slot}
@@ -22,4 +22,21 @@ export const Default = BaseTemplate.bind();
 Default.args = {
   slot: 'Hello World',
   tag: 'h1',
+};
+
+const TruncateTemplate = (args) => html`<pds-text
+  align="${args.align}"
+  color="${args.color}"
+  size="${args.size}"
+  tag="${args.tag}"
+  weight="${args.weight}"
+  truncate
+>
+  ${args.slot}
+</pds-text>`;
+
+export const Truncate = TruncateTemplate.bind();
+Truncate.args = {
+  slot: 'loremId irure id magna ipsum voluptate irure esse eu nulla. Ullamco officia adipisicing qui nulla non sint. Mollit tempor veniam quis nisi aliqua duis elit eu laborum et incididunt ut sit irure. Nisi aute veniam sint do amet consectetur velit. Quis sunt enim mollit deserunt laboris dolor elit exercitation. Id labore deserunt sint consequat laboris nulla do ut magna. Aliquip labore esse sint consequat voluptate tempor consectetur sit sint culpa occaecat ut velit est.',
+  tag: 'p',
 };

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -52,6 +52,26 @@ FontWeight.args = {
   tag: 'p',
 };
 
+const GutterTemplate = (args) => html`<pds-text
+  align="${args.align}"
+  color="${args.color}"
+  gutter="${args.gutter}"
+  size="${args.size}"
+  tag="${args.tag}"
+  weight="${args.weight}"
+  truncate
+>
+  ${args.slot}
+</pds-text>
+<pds-text tag="p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed</pds-text>`;
+
+export const Gutter = GutterTemplate.bind();
+Gutter.args = {
+  slot: 'Title',
+  gutter: 'lg',
+  tag: 'h2',
+};
+
 const TruncateTemplate = (args) => html`<pds-text
   align="${args.align}"
   color="${args.color}"

--- a/libs/core/src/components/pds-text/test/pds-text.e2e.ts
+++ b/libs/core/src/components/pds-text/test/pds-text.e2e.ts
@@ -9,6 +9,15 @@ describe('pds-text', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('renders with italic style when attribute is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-text tag="p" italic></pds-text>');
+
+    const el = await page.find('pds-text >>> p');
+
+    expect((await el.getComputedStyle()).getPropertyValue('font-style')).toBe('italic');
+  });
+
   it('renders with truncate style when attribute is set', async () => {
     const page = await newE2EPage();
     await page.setContent('<pds-text tag="h1" truncate></pds-text>');

--- a/libs/core/src/components/pds-text/test/pds-text.e2e.ts
+++ b/libs/core/src/components/pds-text/test/pds-text.e2e.ts
@@ -8,4 +8,13 @@ describe('pds-text', () => {
     const element = await page.find('pds-text');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('renders with truncate style when attribute is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-text tag="h1" truncate></pds-text>');
+
+    const el = await page.find('pds-text >>> h1');
+
+    expect((await el.getComputedStyle()).getPropertyValue('text-overflow')).toBe('ellipsis');
+  });
 });

--- a/libs/core/src/components/pds-text/test/pds-text.e2e.ts
+++ b/libs/core/src/components/pds-text/test/pds-text.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pds-text', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-text></pds-text>');
+
+    const element = await page.find('pds-text');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -5,14 +5,70 @@ describe('pds-text', () => {
   it('renders', async () => {
     const page = await newSpecPage({
       components: [PdsText],
-      html: `<pds-text></pds-text>`,
+      html: `<pds-text tag="h1"></pds-text>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-text>
+      <pds-text tag="h1">
         <mock:shadow-root>
-          <slot></slot>
+          <h1 class="pds-text"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `);
+  });
+
+  it('renders with align class when prop is set', async ()=> {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="h1" align="center"></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text tag="h1" align="center">
+        <mock:shadow-root>
+          <h1 class="pds-text pds-text--align-center"><slot></slot></h1>
+        </mock:shadow-root>
+      </pds-text>
+    `);
+  })
+
+  it('renders with color class when prop is set', async ()=> {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="h1" color="accent"></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text tag="h1" color="accent">
+        <mock:shadow-root>
+          <h1 class="pds-text pds-text--color-accent"><slot></slot></h1>
+        </mock:shadow-root>
+      </pds-text>
+    `)
+  });
+
+  it('renders with size class when prop is set', async ()=> {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="h1" size="xl"></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text tag="h1" size="xl">
+        <mock:shadow-root>
+          <h1 class="pds-text pds-text--size-xl"><slot></slot></h1>
+        </mock:shadow-root>
+      </pds-text>
+    `)
+  });
+
+  it('renders with weight class when prop is set', async ()=> {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="h1" weight="bold"></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text tag="h1" weight="bold">
+        <mock:shadow-root>
+          <h1 class="pds-text pds-text--weight-bold"><slot></slot></h1>
+        </mock:shadow-root>
+      </pds-text>
+    `)
   });
 });

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PdsText } from '../pds-text';
+
+describe('pds-text', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </pds-text>
+    `);
+  });
+});

--- a/libs/doc-components/src/components/docCanvas/docCanvas.css
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.css
@@ -37,6 +37,26 @@
   padding: var(--doc-canvas-spacing);
 }
 
+.doc-canvas-preview.doc-canvas-preview--block {
+  display: block;
+}
+
+.doc-canvas-preview.doc-canvas-preview--inline {
+  display: inline;
+}
+
+.doc-canvas-preview.doc-canvas-preview--inline-block {
+  display: inline-block;
+}
+
+.doc-canvas-preview.doc-canvas-preview--flex {
+  display: flex;
+}
+
+.doc-canvas-preview.doc-canvas-preview--inline-flex {
+  display: inline-flex;
+}
+
 .doc-canvas-actions {
   color: var(--doc-canvas-color);
   display: flex;

--- a/libs/doc-components/src/components/docCanvas/docCanvas.tsx
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.tsx
@@ -18,6 +18,7 @@ interface SourceType {
 interface DocCanvasProps {
   activeTab: string
   children: React.ReactNode
+  display: string
   isMenuVisible: boolean
   mdxSource: SourceType
 }
@@ -25,6 +26,7 @@ interface DocCanvasProps {
 const docCanvas: React.FC<DocCanvasProps> = ({
   // activeTab = 'react',
   children,
+  display,
   // isMenuVisible = false,
   mdxSource
 }) => {
@@ -89,10 +91,11 @@ const docCanvas: React.FC<DocCanvasProps> = ({
       <> {buttons} </>
     )
   }
+
   return (
     <div className={`doc-canvas ${isMenuVisible ? 'doc-canvas--menu-visible' : ''}`}
       >
-        <div className="doc-canvas-preview">
+        <div className={`doc-canvas-preview ${display ? `doc-canvas-preview--${display}` : ''}`}>
         {children}
         </div>
         <div className="doc-canvas-actions">

--- a/libs/doc-components/src/components/docCanvas/docCanvas.tsx
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.tsx
@@ -18,7 +18,7 @@ interface SourceType {
 interface DocCanvasProps {
   activeTab: string
   children: React.ReactNode
-  display: string
+  display: 'inline' | 'block' | 'inline-block' | 'flex' | 'inline-flex'
   isMenuVisible: boolean
   mdxSource: SourceType
 }

--- a/libs/react/src/components/proxies.ts
+++ b/libs/react/src/components/proxies.ts
@@ -32,6 +32,7 @@ import { defineCustomElement as definePdsTableHeadCell } from '@pine-ds/core/com
 import { defineCustomElement as definePdsTableRow } from '@pine-ds/core/components/pds-table-row.js';
 import { defineCustomElement as definePdsTabpanel } from '@pine-ds/core/components/pds-tabpanel.js';
 import { defineCustomElement as definePdsTabs } from '@pine-ds/core/components/pds-tabs.js';
+import { defineCustomElement as definePdsText } from '@pine-ds/core/components/pds-text.js';
 import { defineCustomElement as definePdsTextarea } from '@pine-ds/core/components/pds-textarea.js';
 import { defineCustomElement as definePdsTooltip } from '@pine-ds/core/components/pds-tooltip.js';
 
@@ -62,5 +63,6 @@ export const PdsTableHeadCell = /*@__PURE__*/createReactComponent<JSX.PdsTableHe
 export const PdsTableRow = /*@__PURE__*/createReactComponent<JSX.PdsTableRow, HTMLPdsTableRowElement>('pds-table-row', undefined, undefined, definePdsTableRow);
 export const PdsTabpanel = /*@__PURE__*/createReactComponent<JSX.PdsTabpanel, HTMLPdsTabpanelElement>('pds-tabpanel', undefined, undefined, definePdsTabpanel);
 export const PdsTabs = /*@__PURE__*/createReactComponent<JSX.PdsTabs, HTMLPdsTabsElement>('pds-tabs', undefined, undefined, definePdsTabs);
+export const PdsText = /*@__PURE__*/createReactComponent<JSX.PdsText, HTMLPdsTextElement>('pds-text', undefined, undefined, definePdsText);
 export const PdsTextarea = /*@__PURE__*/createReactComponent<JSX.PdsTextarea, HTMLPdsTextareaElement>('pds-textarea', undefined, undefined, definePdsTextarea);
 export const PdsTooltip = /*@__PURE__*/createReactComponent<JSX.PdsTooltip, HTMLPdsTooltipElement>('pds-tooltip', undefined, undefined, definePdsTooltip);


### PR DESCRIPTION
# Description
Adds new Text component. This component is intended to be used for a core set of common semantic text elements with some limited options for typography settings without having to touch CSS. Line height and letter spacing were not included as they are not expected to be updated much.

Note: The Doc Canvas component has been updated in this ticket to include a prop that handles its display property. This fixes some odd component display.

[DSS-1148](https://kajabi.atlassian.net/browse/DSS-1148)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1148]: https://kajabi.atlassian.net/browse/DSS-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ