### PR TITLE
fix(textarea): update innerHTML to value

### DIFF
--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -85,7 +85,7 @@ export class PdsTextarea {
     isRequired(textarea, this);
 
     if (textarea) {
-      this.value = textarea.innerHTML;
+      this.value = textarea.value;
     }
 
     this.pdsTextareaChange.emit({value: this.value, event: ev});

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -252,22 +252,22 @@ describe('pds-textarea', () => {
     expect(pdsTextarea?.value).toBe('initial');
 
     const textarea = pdsTextarea?.shadowRoot?.querySelector<HTMLTextAreaElement>('textarea');
-    expect(textarea?.innerHTML.toString()).toBe('initial');
+    expect(textarea?.innerHTML).toBe('initial');
 
-    textarea.innerHTML = 'new value';
+    textarea.value = 'new value';
     textarea?.dispatchEvent(new Event('textareaInput'));
     await page.waitForChanges();
 
-    expect(textarea?.innerHTML.toString()).toBe('new value');
+    expect(textarea?.value).toBe('new value');
 
-    textarea.innerHTML = '';
+    textarea.value = '';
     textarea?.dispatchEvent(new Event('textareaInput'));
     await page.waitForChanges();
 
-    expect(textarea?.innerHTML.toString()).toBe('');
+    expect(textarea?.value).toBe('');
   });
 
-  it('onChange logic with valid `innerHTML` runs', async () => {
+  it('onChange logic with valid `value` runs', async () => {
     const page = await newSpecPage({
       components: [PdsTextarea],
       html: `<pds-textarea value="initial" required="true"></pds-textarea>`,
@@ -280,17 +280,17 @@ describe('pds-textarea', () => {
     expect(pdsTextarea?.value).toEqual('initial');
     expect(textarea?.innerHTML).toEqual('initial');
 
-    textarea.innerHTML += 'A';
+    textarea.value = 'A';
     textarea.checkValidity = jest.fn().mockReturnValue(true);
     textarea.dispatchEvent(new Event('change'));
     await page.waitForChanges();
 
-    expect(pdsTextarea?.value).toEqual('initialA');
-    expect(textarea?.innerHTML).toEqual('initialA');
+    expect(pdsTextarea?.value).toEqual('A');
+    expect(textarea?.innerHTML).toEqual('A');
     expect(eventSpy).toHaveBeenCalled();
   });
 
-  it('onChange logic with invalid `innerHTML` runs', async () => {
+  it('onChange logic with invalid `value` runs', async () => {
     const page = await newSpecPage({
       components: [PdsTextarea],
       html: `<pds-textarea value="initial" required="true"></pds-textarea>`,
@@ -305,13 +305,14 @@ describe('pds-textarea', () => {
     expect(pdsTextarea?.value).toEqual('initial');
     expect(textarea?.innerHTML).toEqual('initial');
 
-    textarea.innerHTML = '';
+    textarea.value = '';
     textarea.checkValidity = jest.fn().mockReturnValue(false);
     textarea.dispatchEvent(new Event('change'));
     await page.waitForChanges();
 
     expect(pdsTextarea?.value).toEqual('');
     expect(textarea?.innerHTML).toEqual('');
+    expect(textarea).toHaveClass('is-invalid');
     expect(eventSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Description

The textarea's value is not being set properly in the textarea component. This value is currently updated by `innerHTML` when `onTextareaChange` is triggered. 

Instead of `innerHTML`, we should use the recommended `textarea.value` to ensure the content matches what the user types.

Fixes https://kajabi.atlassian.net/browse/DSS-1165

🎩 :hattip to @ju-Skinner for the assist here.

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
