### PR TITLE
style(box): modify box css props to use semantic tokens

### DIFF
--- a/libs/core/src/components/pds-row/pds-row.scss
+++ b/libs/core/src/components/pds-row/pds-row.scss
@@ -1,6 +1,5 @@
 :host {
-  --border-default: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
-  --row-gap-y: calc(var(--pine-spacing-250) / 2);
+  --row-gap-y: 10px;
   --row-gap-x: 10px;
 
   display: block;
@@ -32,7 +31,7 @@
 }
 
 .pds-row--border {
-  border: var(--border-default);
+  border: var(--pine-border);
 }
 
 // Justify Content helpers


### PR DESCRIPTION
# Description
Removes most uses of CSS Custom Props in favor of semantic tokens

Fixes #(issue)

## Type of change
- [X] Visual Changes

# How Has This Been Tested?
- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: Storybook

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
