### PR TITLE
style(table): change css custom props to use semantic tokens

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
@@ -1,37 +1,24 @@
 :host {
   --box-shadow-fixed: 3px 3px 6px -2px rgba(0, 0, 0, 0.2);
 
-  --color-background-fixed: var(--pine-color-white);
-  --color-text-cell-default: var(--pine-color-grey-700);
-
-  --dimension-fixed-cell-position: 0;
-  --dimension-max-width-truncated: 100px;
-
-  --letter-spacing-default: var(--pine-letter-spacing-body-md);
-
-  --number-fixed-column-index: 0;
-
-  --spacing-line-height-cell-default: var(--pine-line-height-125);
-  --spacing-padding-cell-default: calc(var(--pine-spacing-300) / 2);
-  --spacing-padding-compact: var(--pine-spacing-050);
-
-  --typography-default: var(--pine-typography-body-md-default);
-
-  color: var(--color-text-cell-default);
+  color: var(--pine-color-text);
   display: table-cell;
-  font: var(--typography-default);
-  letter-spacing: var(--letter-spacing-default);
-  padding: var(--spacing-padding-cell-default);
+  font-family: var(--pine-font-family-body);
+  font-size: var(--pine-font-size);
+  font-weight: var(--pine-font-weight-regular);
+  letter-spacing: var(--pine-letter-spacing);
+  line-height: var(--pine-line-height-body);
+  padding: 12px;
   vertical-align: inherit;
 }
 
 :host(.is-compact) {
-  padding-block: var(--spacing-padding-compact);
+  padding-block: var(--pine-dimension-2xs)
 }
 
 :host(.is-fixed) {
-  background: var(--color-background-fixed);
-  left: var(--dimension-fixed-cell-position);
+  background: var(--pine-color-background-container);
+  left: 0;
   position: sticky;
   z-index: 1;
 }
@@ -42,7 +29,7 @@
 }
 
 :host(.is-truncated) {
-  max-width: var(--dimension-max-width-truncated);
+  max-width: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
@@ -3,38 +3,25 @@
 
   --box-shadow-default: 3px 3px 6px -2px rgba(0, 0, 0, 0.1);
 
-  --color-background-fixed: var(--pine-color-white);
-  --color-text-default: var(--pine-color-grey-800);
-  --color-text-active: var(--pine-color-grey-950);
-
-  --dimension-fixed-cell-position: 0;
-
-  --letter-spacing-default: var(--pine-letter-spacing-body-md);
-
-  --padding-cell-default: calc(var(--pine-spacing-300) / 2);
-
-  --spacing-margin-inline-start-arrow: var(--pine-spacing-050);
-  --spacing-padding-arrow: calc(var(--pine-spacing-050) / 2);
-  --spacing-padding-block-compact: var(--pine-spacing-050);
-
-  --typography-default: var(--pine-typography-body-md-medium);
-
   border-block-end: var(--border-head-cell-default);
-  color: var(--color-text-default);
+  color: var(--pine-color-text);
   display: table-cell;
-  font: var(--typography-default);
-  padding: var(--padding-cell-default);
+  font-family: var(--pine-font-family-body);
+  font-size: var(--pine-font-size);
+  font-weight: var(--pine-font-weight-regular);
+  line-height: var(--pine-line-height-body);
+  padding: 12px;
   text-align: start;
   vertical-align: inherit;
 }
 
 :host(.is-compact) {
-  padding-block: var(--spacing-padding-block-compact)
+  padding-block: var(--pine-dimension-2xs)
 }
 
 :host(.is-fixed) {
-  background: var(--color-background-fixed);
-  left: var(--dimension-fixed-cell-position);
+  background: var(--pine-color-background-container);
+  left: var(--pine-dimension-none);
   position: sticky;
   z-index: 1;
 }
@@ -48,13 +35,13 @@
   cursor: pointer;
 
   pds-icon {
-    margin-inline-start: var(--spacing-margin-inline-start-arrow);
-    padding-block-start: var(--spacing-padding-arrow);
+    margin-inline-start: var(--pine-dimension-2xs);
+    padding-block-start: 2px;
     position: absolute;
   }
 }
 
 :host(.is-sortable:hover),
 :host(.is-active) {
-  color: var(--color-text-active);
+  color: var(--pine-color-text-active);
 }

--- a/libs/core/src/components/pds-table/pds-table-head/pds-table-head.scss
+++ b/libs/core/src/components/pds-table/pds-table-head/pds-table-head.scss
@@ -1,8 +1,6 @@
 :host {
   --border-head-default: var(--pine-border-width-thin) solid var(--pine-color-grey-100);
 
-  --color-background-fixed: var(--pine-color-base-white);
-
   border-color: inherit;
   box-sizing: border-box;
   display: table-header-group;
@@ -11,7 +9,7 @@
   // used for pds-checkbox-cell
   // because it is in the ShadowDom
   &::part(checkbox-cell) {
-    background-color: var(--color-background-fixed);
+    background-color: var(--pine-color-background-container);
     left: 0;
     position: sticky;
     z-index: 1;

--- a/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
+++ b/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
@@ -1,5 +1,4 @@
 :host {
-  --color-background-fixed: var(--pine-color-white);
   --color-background-interactive: var(--pine-color-grey-200);
 
   border-color: inherit;
@@ -9,7 +8,7 @@
   // used for pds-checkbox-cell
   // because it is in the ShadowDom
   &::part(checkbox-cell) {
-    background-color: var(--color-background-fixed);
+    background-color: var(--pine-color-background-container);
     left: 0;
     position: sticky;
     z-index: 1;


### PR DESCRIPTION
# Description
Removes most uses of CSS Custom Props in favor of semantic tokens

Fixes #(issue)

## Type of change
- [X] Visual Changes

# How Has This Been Tested?
- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: Storybook

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
