### PR TITLE
fix(docArgsTable): displays a red asterisk when a prop is required

### DIFF
--- a/libs/doc-components/src/components/docArgsTable/docArgsTable.tsx
+++ b/libs/doc-components/src/components/docArgsTable/docArgsTable.tsx
@@ -85,6 +85,7 @@ const DocArgsTable: React.FC<DocArgsTableProps> = ({
       <div className='arg-table-row' key={`rowIndex-${idx}`}>
         <div className='arg-table-cell'>
           <strong>{prop.attr || prop.event || prop.name }</strong>
+          <span style={{ color: 'red', cursor: 'help' }} title="Required">{prop.required == true ? '*' : ''}</span>
         </div>
         <div className='arg-table-cell'>
           <Markdown>{prop.docs}</Markdown>


### PR DESCRIPTION
# Description
When pairing, I noticed that our custom Args Table didn't display which properties were required.


Screenshots
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/7e0e42dc-f4cd-4c9e-ab86-21d77761dddb)|![image](https://github.com/user-attachments/assets/923ca573-4ee4-4361-a488-199639317a76)|


## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [x] other:Storybook

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
