### PR TITLE
fix: updates checked property on switch update

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -653,11 +653,6 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
-          * Specifies the underlying input element type
-          * @defaultValue 'checkbox'
-         */
-        "type": 'checkbox' | 'radio';
-        /**
           * Provides input with a string submitted in form data, and can be used to distinguish radio inputs
          */
         "value": string;
@@ -1939,11 +1934,6 @@ declare namespace LocalJSX {
           * Determines the 'required' state of the input
          */
         "required"?: boolean;
-        /**
-          * Specifies the underlying input element type
-          * @defaultValue 'checkbox'
-         */
-        "type"?: 'checkbox' | 'radio';
         /**
           * Provides input with a string submitted in form data, and can be used to distinguish radio inputs
          */

--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -29,15 +29,14 @@ The default switch style uses a checkbox input.
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsSwitch componentId="pds-switch-default-example" label="Default Switch" name="pds-switch-default" type="checkbox" />',
-    webComponent: '<pds-switch component-id="pds-switch-default-example" label="Default Switch" name="pds-switch-default" type="checkbox"></pds-switch>'
+    react: '<PdsSwitch componentId="pds-switch-default-example" label="Default Switch" name="pds-switch-default" />',
+    webComponent: '<pds-switch component-id="pds-switch-default-example" label="Default Switch" name="pds-switch-default"></pds-switch>'
   }}>
   <div>
     <pds-switch
       component-id="pds-switch-default-example"
       label="Default Switch"
       name="pds-switch-default"
-      type="checkbox"
     ></pds-switch>
   </div>
 </DocCanvas>
@@ -48,15 +47,14 @@ Prevents user interaction on the input.
 
 <DocCanvas client:only
   mdxSource={{
-    react: `<PdsSwitch componentId="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled" type="checkbox"/>`,
-    webComponent: `<pds-switch component-id="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled" type="checkbox"></pds-switch>`
+    react: `<PdsSwitch componentId="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled"/>`,
+    webComponent: `<pds-switch component-id="pds-switch-disabled-example" disabled="true" label="Can't touch this" name="pds-switch-disabled"></pds-switch>`
 }}>
   <pds-switch
     component-id="pds-switch-disabled-example"
     disabled="true"
     label="Can't touch this"
     name="pds-switch-disabled"
-    type="checkbox"
   ></pds-switch>
 </DocCanvas>
 
@@ -66,8 +64,8 @@ Displays additional descriptive text underneath the main label.
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsSwitch componentId="pds-switch-helper-example" helperMessage="Save my login details for next time." label="Remember me" name="pds-switch-helper" type="checkbox" />',
-    webComponent: '<pds-switch component-id="pds-switch-helper-example" helper-message="Save my login details for next time." label="Remember me" name="pds-switch-helper" type="checkbox"></pds-switch>'
+    react: '<PdsSwitch componentId="pds-switch-helper-example" helperMessage="Save my login details for next time." label="Remember me" name="pds-switch-helper"/>',
+    webComponent: '<pds-switch component-id="pds-switch-helper-example" helper-message="Save my login details for next time." label="Remember me" name="pds-switch-helper"></pds-switch>'
   }}>
   <>
     <pds-switch
@@ -75,7 +73,6 @@ Displays additional descriptive text underneath the main label.
       helper-message="Save my login details for next time."
       label="Remember me"
       name="pds-switch-helper"
-      type="checkbox"
     ></pds-switch>
   </>
 </DocCanvas>
@@ -86,8 +83,8 @@ An optional error message can be displayed for additional instructions, displaye
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsSwitch componentId="pds-switch-invalid-example" errorMessage="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true" type="checkbox"/>',
-    webComponent: '<pds-switch component-id="pds-switch-invalid-example" error-message="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true" type="checkbox"></pds-switch>'
+    react: '<PdsSwitch componentId="pds-switch-invalid-example" errorMessage="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true"/>',
+    webComponent: '<pds-switch component-id="pds-switch-invalid-example" error-message="Terms and conditions must be accepted to continue" invalid="true" label="I agree to the terms and conditions" name="pds-switch-invalid" required="true"></pds-switch>'
 }}>
   <pds-switch
     component-id="pds-switch-invalid-example"
@@ -96,6 +93,5 @@ An optional error message can be displayed for additional instructions, displaye
     label="I agree to the terms and conditions"
     name="pds-switch-invalid"
     required="true"
-    type="checkbox"
   ></pds-switch>
 </DocCanvas>

--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -3,21 +3,14 @@ import { components } from '../../../../dist/docs.json';
 
 # Switch
 
-Checkbox or radio component styled to appear as a toggle.
+Checkbox component styled to appear as a toggle.
 
 ## Guidelines
 
 ### Usage
 
-- Radio Switches require a shared `name` for grouping.
-- Specify a unique `component-id` and `value` for **each** Radio variant. This will ensure the label and radio group selection (respectively) are correctly identified.
 - Use caution when enabling both `checked` and `disabled` on a control. Clearly describe why this item cannot be unselected.
-- `sageSwitchChange` is a custom event emitted on input change. View the browser console on this page for an example.
-
-#### Checkbox or Radio?
-
-When only one Switch is needed for users to turn on/off a value, use a `checkbox`. [From MDN:](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio)
-  > Note: Checkboxes are similar to radio buttons, but with an important distinction: radio buttons are designed for selecting one value out of a set, whereas checkboxes let you turn individual values on and off. Where multiple controls exist, radio buttons allow one to be selected out of them all, whereas checkboxes allow multiple values to be selected.
+- `pdsSwitchChange` is a custom event emitted on input change. View the browser console on this page for an example.
 
 ### Accessibility
 
@@ -47,25 +40,6 @@ The default switch style uses a checkbox input.
       type="checkbox"
     ></pds-switch>
   </div>
-</DocCanvas>
-
-
-### Radio
-
-Renders a switch using a radio button input. Just like a [standard radio button](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio), toggling a single value on/off requires (at minimum) a pair of inputs to represent each state.
-
-<DocCanvas client:only
-  mdxSource={{
-    react: '<PdsSwitch componentId="pds-switch-radio-example" label="Radio Switch" name="pds-switch-radio" type="radio" value="pds-switch-radio" />',
-    webComponent: '<pds-switch component-id="pds-switch-radio-example" label="Radio Switch" name="pds-switch-radio" type="radio" value="pds-switch-radio"></pds-switch>'
-}}>
-  <pds-switch
-    component-id="pds-switch-radio-example"
-    label="Radio Switch"
-    name="pds-switch-radio"
-    type="radio"
-    value="pds-switch-radio"
-  ></pds-switch>
 </DocCanvas>
 
 ### Disabled
@@ -102,7 +76,7 @@ Displays additional descriptive text underneath the main label.
       label="Remember me"
       name="pds-switch-helper"
       type="checkbox"
-   ></pds-switch>
+    ></pds-switch>
   </>
 </DocCanvas>
 

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -56,12 +56,6 @@ export class PdsSwitch {
   @Prop() required? = false;
 
   /**
-   * Specifies the underlying input element type
-   * @defaultValue 'checkbox'
-   */
-  @Prop() type: 'checkbox' | 'radio' = 'checkbox';
-
-  /**
    * Provides input with a string submitted in form data, and can be used to distinguish radio inputs
    */
   @Prop() value: string;
@@ -75,13 +69,7 @@ export class PdsSwitch {
     if (this.disabled) return;
 
     const input = e.target as HTMLInputElement;
-
-    if (this.type === 'checkbox') {
-      this.checked = input.checked; // For checkbox, update checked state
-    } else if (this.type === 'radio') {
-      this.checked = true; // For radio, set checked to true on selection
-    }
-
+    this.checked = input.checked;
     this.pdsSwitchChange.emit(e as InputEvent);
   };
 
@@ -113,7 +101,7 @@ export class PdsSwitch {
           name={this.name ? this.name : this.componentId}
           onChange={this.onSwitchUpdate}
           required={this.required}
-          type={this.type}
+          type="checkbox"
           value={this.value}
         />
         <PdsLabel classNames="pds-switch__label" htmlFor={this.componentId} text={this.label} />

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -18,7 +18,7 @@ export class PdsSwitch {
   /**
    * Determines the input 'checked' state
    */
-  @Prop() checked = false;
+  @Prop({ mutable: true }) checked = false;
 
   /**
    * Determines the input 'disabled' state, preventing user interaction
@@ -68,11 +68,20 @@ export class PdsSwitch {
 
   /**
    * Emits an event on input change
-  */
+   */
   @Event() pdsSwitchChange: EventEmitter<InputEvent>;
 
   private onSwitchUpdate = (e: Event) => {
     if (this.disabled) return;
+
+    const input = e.target as HTMLInputElement;
+
+    if (this.type === 'checkbox') {
+      this.checked = input.checked; // For checkbox, update checked state
+    } else if (this.type === 'radio') {
+      this.checked = true; // For radio, set checked to true on selection
+    }
+
     this.pdsSwitchChange.emit(e as InputEvent);
   };
 

--- a/libs/core/src/components/pds-switch/readme.md
+++ b/libs/core/src/components/pds-switch/readme.md
@@ -7,19 +7,18 @@
 
 ## Properties
 
-| Property                   | Attribute        | Description                                                                                         | Type                    | Default      |
-| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------- | ----------------------- | ------------ |
-| `checked`                  | `checked`        | Determines the input 'checked' state                                                                | `boolean`               | `false`      |
-| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute and the label `for` attribute. | `string`                | `undefined`  |
-| `disabled`                 | `disabled`       | Determines the input 'disabled' state, preventing user interaction                                  | `boolean`               | `false`      |
-| `errorMessage`             | `error-message`  | Displays message text describing an invalid state                                                   | `string`                | `undefined`  |
-| `helperMessage`            | `helper-message` | Displays help text for additional description of an input                                           | `string`                | `undefined`  |
-| `invalid`                  | `invalid`        | Determines the input 'invalid' state, signifying an error is present                                | `boolean`               | `false`      |
-| `label` _(required)_       | `label`          | Displays text to describe the input                                                                 | `string`                | `undefined`  |
-| `name`                     | `name`           | Identifies form data and unifies a group of radio inputs for toggling a single property/value       | `string`                | `undefined`  |
-| `required`                 | `required`       | Determines the 'required' state of the input                                                        | `boolean`               | `false`      |
-| `type`                     | `type`           | Specifies the underlying input element type                                                         | `"checkbox" \| "radio"` | `'checkbox'` |
-| `value`                    | `value`          | Provides input with a string submitted in form data, and can be used to distinguish radio inputs    | `string`                | `undefined`  |
+| Property                   | Attribute        | Description                                                                                         | Type      | Default     |
+| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `checked`                  | `checked`        | Determines the input 'checked' state                                                                | `boolean` | `false`     |
+| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute and the label `for` attribute. | `string`  | `undefined` |
+| `disabled`                 | `disabled`       | Determines the input 'disabled' state, preventing user interaction                                  | `boolean` | `false`     |
+| `errorMessage`             | `error-message`  | Displays message text describing an invalid state                                                   | `string`  | `undefined` |
+| `helperMessage`            | `helper-message` | Displays help text for additional description of an input                                           | `string`  | `undefined` |
+| `invalid`                  | `invalid`        | Determines the input 'invalid' state, signifying an error is present                                | `boolean` | `false`     |
+| `label` _(required)_       | `label`          | Displays text to describe the input                                                                 | `string`  | `undefined` |
+| `name`                     | `name`           | Identifies form data and unifies a group of radio inputs for toggling a single property/value       | `string`  | `undefined` |
+| `required`                 | `required`       | Determines the 'required' state of the input                                                        | `boolean` | `false`     |
+| `value`                    | `value`          | Provides input with a string submitted in form data, and can be used to distinguish radio inputs    | `string`  | `undefined` |
 
 
 ## Events

--- a/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
+++ b/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
@@ -47,19 +47,6 @@ Default.args = {
   type: 'checkbox',
 };
 
-export const Radio = BaseTemplate.bind({});
-
-Radio.args = {
-  checked: false,
-  disabled: false,
-  componentId: 'pds-switch-radio-example',
-  invalid: false,
-  label: 'radio switch',
-  name: 'pds-switch-radio',
-  required: false,
-  type: 'radio',
-};
-
 export const Disabled = BaseTemplate.bind({});
 
 Disabled.args = {

--- a/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
+++ b/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
@@ -229,4 +229,25 @@ describe('pds-switch', () => {
 
     expect(eventSpy).not.toHaveBeenCalled();
   });
+
+  it('sets checked to true for radio input on change', async () => {
+    const page = await newSpecPage({
+      components: [PdsSwitch],
+      html: `
+        <pds-switch
+          component-id="pds-switch-radio"
+          label="Switch radio"
+          type="radio"
+          value="on">
+        </pds-switch>
+      `
+    });
+
+    const component = page.root?.shadowRoot?.querySelector('input');
+
+    component?.dispatchEvent(new Event('change'));
+    await page.waitForChanges();
+
+    expect(component?.checked).toBe(true);
+  });
 });

--- a/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
+++ b/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
@@ -23,53 +23,6 @@ describe('pds-switch', () => {
     `);
   });
 
-  it('renders a radio input with label and name defaulting to id', async () => {
-    const page = await newSpecPage({
-      components: [PdsSwitch],
-      html: `
-        <pds-switch
-          component-id="pds-switch-radio"
-          label="Switch radio"
-          type="radio"
-          value="on">
-        </pds-switch>
-      `
-    });
-
-    expect(page.root).toEqualHtml(`
-      <pds-switch component-id="pds-switch-radio" class="pds-switch" label="Switch radio" type="radio" value="on">
-        <mock:shadow-root>
-          <input id="pds-switch-radio" class="pds-switch__input" type="radio" name="pds-switch-radio" value="on">
-          <label htmlFor="pds-switch-radio" class="pds-switch__label">Switch radio</label>
-        </mock:shadow-root>
-      </pds-switch>
-    `);
-  });
-
-  it('renders a radio input with label and associated group name', async () => {
-    const page = await newSpecPage({
-      components: [PdsSwitch],
-      html: `
-        <pds-switch
-          component-id="pds-switch-radio-id"
-          label="Switch radio"
-          type="radio"
-          name="pds-radio-group-name"
-          value="on">
-        </pds-switch>
-      `
-    });
-
-    expect(page.root).toEqualHtml(`
-      <pds-switch component-id="pds-switch-radio-id" class="pds-switch" label="Switch radio" type="radio" name="pds-radio-group-name" value="on">
-        <mock:shadow-root>
-          <input id="pds-switch-radio-id" class="pds-switch__input" type="radio" name="pds-radio-group-name" value="on">
-          <label htmlFor="pds-switch-radio-id" class="pds-switch__label">Switch radio</label>
-        </mock:shadow-root>
-      </pds-switch>
-    `);
-  });
-
   it('renders a disabled input', async () => {
     const page = await newSpecPage({
       components: [PdsSwitch],
@@ -230,24 +183,4 @@ describe('pds-switch', () => {
     expect(eventSpy).not.toHaveBeenCalled();
   });
 
-  it('sets checked to true for radio input on change', async () => {
-    const page = await newSpecPage({
-      components: [PdsSwitch],
-      html: `
-        <pds-switch
-          component-id="pds-switch-radio"
-          label="Switch radio"
-          type="radio"
-          value="on">
-        </pds-switch>
-      `
-    });
-
-    const component = page.root?.shadowRoot?.querySelector('input');
-
-    component?.dispatchEvent(new Event('change'));
-    await page.waitForChanges();
-
-    expect(component?.checked).toBe(true);
-  });
 });


### PR DESCRIPTION
# Description

The <pds-switch> component’s visual state correctly reflects the toggle (i.e., it appears to turn on or off), but the checked property is not properly updated when the switch is clicked.

Follow-up: These updates also remove the radio variant. The previous underlying code was not working as expected and we decided as a team that its use case was not a desired UX either.

We may revisit if needed in the future, but we will need to follow up with the design team. 

Fixes https://kajabi.atlassian.net/browse/DSS-1170

## Type of change
Updates .checked property on interaction with the `pds-switch`

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
