### PR TITLE
docs(icons): icons doc page fix

### DIFF
--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -7,19 +7,19 @@ const config = {
   ],
 
   addons: [
-    getAbsolutePath("@storybook/addon-essentials"),
-    getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@storybook/addon-a11y"),
-    getAbsolutePath("@storybook/addon-actions"),
-    getAbsolutePath("@pxtrn/storybook-addon-docs-stencil"),
-    getAbsolutePath("@storybook/addon-mdx-gfm"),
+    "@storybook/addon-essentials",
+    "@storybook/addon-links",
+    "@storybook/addon-a11y",
+    "@storybook/addon-actions",
+    "@pxtrn/storybook-addon-docs-stencil",
+    "@storybook/addon-mdx-gfm",
     "@chromatic-com/storybook"
   ],
 
   core: {},
 
   framework: {
-    name: getAbsolutePath("@storybook/web-components-vite"),
+    name: "@storybook/web-components-vite",
     options: {}
   },
 
@@ -30,6 +30,3 @@ const config = {
 
 export default config;
 
-function getAbsolutePath(value) {
-  return dirname(require.resolve(join(value, "package.json")));
-}

--- a/libs/core/src/components/pds-icon/docs/pds-icon.mdx
+++ b/libs/core/src/components/pds-icon/docs/pds-icon.mdx
@@ -11,11 +11,11 @@ categories: Actions and Features. In order to ensure that the icons are adding t
 and not creating confusion, we adhere to two principles.
 
 <DocCanvas client:only mdxSource={{
-  react: `<PdsIcon name="upload"></PdsIcon>`,
-  webComponent: `<pds-icon name="upload"></pds-icon>`
+  react: `<PdsIcon name="thumb-up-filled"></PdsIcon>`,
+  webComponent: `<pds-icon name="thumb-up-filled"></pds-icon>`
 }}>
   <>
-    <pds-icon name="upload"></pds-icon>
+    <pds-icon name="thumb-up-filled"></pds-icon>
   </>
 </DocCanvas>
 
@@ -28,22 +28,22 @@ The `color` property allows the icon to render in the specified color. This can 
 
 <DocCanvas client:only mdxSource={{
   react: `
-<PdsIcon name="upload" size="small"></PdsIcon>
-<PdsIcon name="upload" size="normal"></PdsIcon>
-<PdsIcon name="upload" size="medium"></PdsIcon>
-<PdsIcon name="upload" size="large"></PdsIcon>
+<PdsIcon name="bulb" size="small"></PdsIcon>
+<PdsIcon name="bulb" size="regular"></PdsIcon>
+<PdsIcon name="bulb" size="medium"></PdsIcon>
+<PdsIcon name="bulb" size="large"></PdsIcon>
 `,
   webComponent: `
-<pds-icon name="upload" size="small"></pds-icon>
-<pds-icon name="upload" size="normal"></pds-icon>
-<pds-icon name="upload" size="medium"></pds-icon>
-<pds-icon name="upload" size="large"></pds-icon>`
+<pds-icon name="bulb" size="small"></pds-icon>
+<pds-icon name="bulb" size="regular"></pds-icon>
+<pds-icon name="bulb" size="medium"></pds-icon>
+<pds-icon name="bulb" size="large"></pds-icon>`
 }}>
   <>
-    <pds-icon name="upload" size="small"></pds-icon>
-    <pds-icon name="upload" size="normal"></pds-icon>
-    <pds-icon name="upload" size="medium"></pds-icon>
-    <pds-icon name="upload" size="large"></pds-icon>
+    <pds-icon name="bulb" size="small"></pds-icon>
+    <pds-icon name="bulb" size="regular"></pds-icon>
+    <pds-icon name="bulb" size="medium"></pds-icon>
+    <pds-icon name="bulb" size="large"></pds-icon>
   </>
 </DocCanvas>
 
@@ -51,17 +51,17 @@ It also accepts any custom size attribute.
 
 <DocCanvas client:only mdxSource={{
   react: `
-<PdsIcon name="upload" size="60px"></PdsIcon>
-<PdsIcon name="upload" size="2rem"></PdsIcon>
+<PdsIcon name="danger" size="60px"></PdsIcon>
+<PdsIcon name="danger" size="2rem"></PdsIcon>
 `,
   webComponent: `
-<pds-icon name="upload" size="60px"></pds-icon>
-<pds-icon name="upload" size="2rem"></pds-icon>
+<pds-icon name="danger" size="60px"></pds-icon>
+<pds-icon name="danger" size="2rem"></pds-icon>
 `
 }}>
   <>
-    <pds-icon name="upload" size="60px"></pds-icon>
-    <pds-icon name="upload" size="2rem"></pds-icon>
+    <pds-icon name="danger" size="60px"></pds-icon>
+    <pds-icon name="danger" size="2rem"></pds-icon>
   </>
 </DocCanvas>
 

--- a/libs/core/src/components/pds-icon/stories/pds-icon.docs.mdx
+++ b/libs/core/src/components/pds-icon/stories/pds-icon.docs.mdx
@@ -1,5 +1,7 @@
 import { ArgTypes, Canvas, IconGallery, IconItem, Meta, Source } from '@storybook/blocks';
 
+import {DocCanvas} from '@pine-ds/doc-components'
+
 import pdsIconsJson from '@pine-ds/icons/dist/pds-icons.json';
 
 import * as stories from './pds-icon.stories.js';
@@ -12,14 +14,14 @@ import Docs from '../docs/pds-icon.mdx'
 
 # Icons
 
-<Canvas sourceState="none">
+<DocCanvas client:only mdxSource={{}}>
   <IconGallery>
     {
       Object.values(pdsIconsJson["icons"]).map((icon, index) => (
-        <IconItem key={`item-${index}`} name={icon.name}>
-          <pds-icon name={icon.name}></pds-icon>
+        <IconItem conItem key={`item-${index}`} name={icon.name}>
+          <pds-icon name={icon.name}>{icon.name}</pds-icon>
         </IconItem>
       ))
     }
   </IconGallery>
-</Canvas>
+</DocCanvas>

--- a/libs/core/src/components/pds-icon/stories/pds-icon.stories.js
+++ b/libs/core/src/components/pds-icon/stories/pds-icon.stories.js
@@ -12,5 +12,5 @@ const BaseTemplate = (args) => html`<pds-icon color=${args.color} name=${args.na
 
 export const Default = BaseTemplate.bind();
 Default.args = {
-  name: 'upload'
+  name: 'headset'
 };


### PR DESCRIPTION
# Description

An issue was discovered with the Icons doc page.  

In the previous version of Storybook `Canvas`, was a way to put things in a a container. The current version seems to have a bug, as it populates with the Story default story if no attributes are set.

To fix it, I swapped it out with our `DocCanvas` component.

|before|after|
|--|--|
|<img width="1062" alt="image" src="https://github.com/user-attachments/assets/244cb180-78e5-495e-9861-7f53f6c9e986">|<img width="1059" alt="image" src="https://github.com/user-attachments/assets/54bfcfa7-8e77-48c6-bd47-08271020933e">|



## Type of change

- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] other: Storybook

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
