### PR TITLE
fix: missing error icons and input styling adjustments

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -18,7 +18,7 @@
   --color-invalid: var(--pine-color-red-500);
   --color-invalid-hover: var(--pine-color-red-600);
   --color-text-disabled: var(--pine-color-grey-500);
-  --color-text-message: var(--pine-color-grey-800);
+  --color-text-message: var(--pine-color-grey-700);
 
   --sizing-input: var(--pine-font-size-116);
 
@@ -151,6 +151,7 @@ input {
 }
 
 label {
+  font-weight: var(--pine-font-weight-body-medium);
   margin-inline-start: 10px;
 }
 
@@ -172,4 +173,11 @@ label {
   margin-block-start: 6px;
   margin-inline-start: 26px;
   width: 100%;
+}
+
+.pds-checkbox__message--error {
+  align-items: center;
+  display: flex;
+  font-size: var(--pine-font-size-085);
+  gap: var(--pine-spacing-050);
 }

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -2,6 +2,7 @@ import { Component, h, Prop, Host, Event, EventEmitter, Watch } from '@stencil/c
 import { assignDescription, messageId } from '../../utils/form';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
 import { CheckboxChangeEventDetail } from './checkbox-interface';
+import { danger } from '@pine-ds/icons/icons';
 
 @Component({
   tag: 'pds-checkbox',
@@ -145,6 +146,7 @@ export class PdsCheckbox {
             id={messageId(this.componentId, 'error')}
             aria-live="assertive"
           >
+            <pds-icon icon={danger} size="small" />
             {this.errorMessage}
           </div>
         }

--- a/libs/core/src/components/pds-checkbox/readme.md
+++ b/libs/core/src/components/pds-checkbox/readme.md
@@ -38,9 +38,14 @@
  - [pds-table-head](../pds-table/pds-table-head)
  - [pds-table-row](../pds-table/pds-table-row)
 
+### Depends on
+
+- pds-icon
+
 ### Graph
 ```mermaid
 graph TD;
+  pds-checkbox --> pds-icon
   pds-table-head --> pds-checkbox
   pds-table-row --> pds-checkbox
   style pds-checkbox fill:#f9f,stroke:#333,stroke-width:4px

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsCheckbox } from '../pds-checkbox';
+import { danger } from '@pine-ds/icons/icons';
 
 describe('pds-checkbox', () => {
   it('renders', async () => {
@@ -130,7 +131,10 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <input aria-invalid="true" id="default" type="checkbox">
           <label htmlfor="default">Label text</label>
-          <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">This is a short error message.</div>
+          <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">
+            <pds-icon icon="${danger}" size="small"></pds-icon>
+            This is a short error message.
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -111,10 +111,10 @@ import { components } from '../../../../dist/docs.json';
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsInput componentId="pds-input-error-example" label="Name" type="email" errorMessage="Please provide a valid email address" value="Frank Dux"></PdsInput>',
-    webComponent: '<pds-input component-id="pds-input-error-example" label="Name" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>'
+    react: '<PdsInput componentId="pds-input-error-example" label="Email address" type="email" errorMessage="Please provide a valid email address" value="Frank Dux"></PdsInput>',
+    webComponent: '<pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>'
 }}>
-  <pds-input component-id="pds-input-error-example" label="Name" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>
+  <pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>
 </DocCanvas>
 
 ## Additional Resources

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -15,7 +15,7 @@
   --color-text-placeholder: var(--pine-color-grey-600);
   --color-text-placeholder-disabled: var(--pine-color-grey-400);
 
-  --font-size-helper-message: var(--pine-font-size-100);
+  --font-size-helper-message: var(--pine-font-size-085);
   --font-size-input-field: var(--pine-font-size-100);
   --font-size-label: var(--pine-font-size-100);
   --font-weight-helper-message: var(--pine-font-weight-normal);
@@ -30,6 +30,7 @@
   --spacing-input-field-padding-inline: var(--pine-spacing-200);
   --spacing-label-margin-block-end: var(--pine-spacing-100);
   --spacing-margin-top-helper-message: var(--pine-spacing-100);
+  --spacing-icon-error-message: var(--pine-spacing-050);
 
   display: inline;
 }
@@ -128,5 +129,9 @@ input {
 }
 
 .pds-input__error-message {
+  align-items: center;
   color: var(--color-text-error);
+  display: flex;
+  font-size: var(--font-size-helper-message);
+  gap: var(--spacing-icon-error-message);
 }

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
+import { danger } from '@pine-ds/icons/icons';
 
 @Component({
   tag: 'pds-input',
@@ -124,6 +125,7 @@ export class PdsInput {
               id={messageId(this.componentId, 'error')}
               aria-live="assertive"
             >
+              <pds-icon icon={danger} size="small" />
               {this.errorMessage}
             </p>
           }

--- a/libs/core/src/components/pds-input/readme.md
+++ b/libs/core/src/components/pds-input/readme.md
@@ -31,6 +31,19 @@
 | `pdsInput` | Emitted when a keyboard input occurred. | `CustomEvent<InputEvent>` |
 
 
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-input --> pds-icon
+  style pds-input fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -124,12 +124,20 @@ input {
 }
 
 label {
+  font-weight: var(--pine-font-weight-body-medium);
   margin-inline-start: 10px;
 }
 
 .pds-radio__message {
-  color: var(--pine-color-grey-800);
+  color: var(--pine-color-grey-700);
   margin-block-start: var(--sizing-margin-block-start);
   margin-inline-start: 26px;
   width: 100%;
+}
+
+.pds-radio__message--error {
+  align-items: center;
+  display: flex;
+  font-size: var(--pine-font-size-085);
+  gap: var(--pine-spacing-050);
 }

--- a/libs/core/src/components/pds-radio/pds-radio.tsx
+++ b/libs/core/src/components/pds-radio/pds-radio.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
+import { danger } from '@pine-ds/icons/icons';
 
 @Component({
   tag: 'pds-radio',
@@ -121,6 +122,7 @@ export class PdsRadio {
             id={messageId(this.componentId, 'error')}
             aria-live="assertive"
           >
+            <pds-icon icon={danger} size="small" />
             {this.errorMessage}
           </div>
         }

--- a/libs/core/src/components/pds-radio/readme.md
+++ b/libs/core/src/components/pds-radio/readme.md
@@ -28,6 +28,19 @@
 | `pdsRadioChange` | Emits a boolean indicating whether the checkbox is currently checked or unchecked. | `CustomEvent<boolean>` |
 
 
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-radio --> pds-icon
+  style pds-radio fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
+++ b/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsRadio } from '../pds-radio';
+import { danger } from '@pine-ds/icons/icons';
 
 describe('pds-radio', () => {
   it('renders', async () => {
@@ -88,7 +89,8 @@ describe('pds-radio', () => {
       <pds-radio component-id="default" label="Label text" helper-message="This is short message text.">
         <input aria-describedby="default__helper-message" id="default" type="radio">
         <label htmlfor="default">Label text</label>
-        <div class="pds-radio__message" id="default__helper-message">This is short message text.</div>
+        <div class="pds-radio__message" id="default__helper-message">
+        This is short message text.</div>
       </pds-radio>
     `);
   });
@@ -103,7 +105,10 @@ describe('pds-radio', () => {
       <pds-radio class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
         <input aria-invalid="true" id="default" type="radio">
         <label htmlfor="default">Label text</label>
-        <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">This is a short error message.</div>
+        <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">
+          <pds-icon icon="${danger}" size="small"></pds-icon>
+          This is a short error message.
+        </div>
       </pds-radio>
     `);
   });

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -29,7 +29,7 @@
 
   --spacing-label-gap-size: var(--pine-spacing-150);
   --spacing-input-toggle-offset: calc(var(--pine-spacing-050) / 2);
-  --spacing-message-block: var(--pine-spacing-050);
+  --spacing-message-block: calc(var(--pine-spacing-150) / 2);
   --spacing-message-inline: calc(var(--dimension-input-width) + var(--spacing-label-gap-size));
 
   --number-transition-timing: 0.15s ease-out;
@@ -54,6 +54,10 @@
 
   input:focus-visible:not(:disabled):not(:checked) {
     box-shadow: var(--box-shadow-focus-error);
+  }
+
+  label {
+    color: var(--color-text-error);
   }
 }
 
@@ -106,17 +110,17 @@ label {
 .pds-switch__message {
   color: var(--color-message-text);
   flex: 1 0 100%;
-  font-size: var(--pine-font-size-body-sm);
-  line-height: var(--pine-line-height-sm);
+  font-size: var(--pine-font-size-body-md);
+  margin-block-start: var(--spacing-message-block);
   margin-inline-start: var(--spacing-message-inline);
-
-  + .pds-switch__message {
-    margin-block-start: var(--spacing-message-block);
-  }
 }
 
 .pds-switch__message--error {
+  align-items: center;
   color: inherit;
+  display: flex;
+  font-size: var(--pine-font-size-085);
+  gap: var(--pine-spacing-050);
 }
 
 // Disabled state

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
+import { danger } from '@pine-ds/icons/icons';
 
 @Component({
   tag: 'pds-switch',
@@ -119,6 +120,7 @@ export class PdsSwitch {
             id={messageId(this.componentId, 'error')}
             aria-live="assertive"
           >
+            <pds-icon icon={danger} size="small" />
             {this.errorMessage}
           </div>
         }

--- a/libs/core/src/components/pds-switch/readme.md
+++ b/libs/core/src/components/pds-switch/readme.md
@@ -28,6 +28,19 @@
 | `pdsSwitchChange` | Emits an event on input change | `CustomEvent<InputEvent>` |
 
 
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-switch --> pds-icon
+  style pds-switch fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
+++ b/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
@@ -60,9 +60,9 @@ Disabled.args = {
   type: 'checkbox',
 };
 
-export const HelperMessage = BaseTemplate.bind({});
+export const WithMessage = BaseTemplate.bind({});
 
-HelperMessage.args = {
+WithMessage.args = {
   checked: true,
   disabled: false,
   componentId: 'pds-switch-helper-example',

--- a/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
+++ b/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsSwitch } from '../pds-switch';
+import { danger } from '@pine-ds/icons/icons';
 
 describe('pds-switch', () => {
   it('renders an input as a checkbox with label', async () => {
@@ -108,7 +109,10 @@ describe('pds-switch', () => {
         <mock:shadow-root>
           <input aria-invalid="true" id="pds-switch-err" name="pds-switch-err" class="pds-switch__input" type="checkbox">
           <label htmlFor="pds-switch-err" class="pds-switch__label">Switch error message</label>
-          <div aria-live="assertive" id="pds-switch-err__error-message"  class="pds-switch__message pds-switch__message--error">La croix blue bottle narwhal fam</div>
+          <div aria-live="assertive" id="pds-switch-err__error-message" class="pds-switch__message pds-switch__message--error">
+            <pds-icon icon="${danger}" size="small"></pds-icon>
+            La croix blue bottle narwhal fam
+          </div>
         </mock:shadow-root>
       </pds-switch>
     `);
@@ -134,7 +138,10 @@ describe('pds-switch', () => {
           <input aria-describedby="switch-with-description__error-message" aria-invalid="true" id="switch-with-description" name="switch-with-description" class="pds-switch__input" type="checkbox">
           <label htmlFor="switch-with-description" class="pds-switch__label">Switch with description</label>
           <div id="switch-with-description__helper-message"  class="pds-switch__message">This is a helper message</div>
-          <div aria-live="assertive" id="switch-with-description__error-message"  class="pds-switch__message pds-switch__message--error">This is an error message</div>
+          <div aria-live="assertive" id="switch-with-description__error-message" class="pds-switch__message pds-switch__message--error">
+            <pds-icon icon="${danger}" size="small"></pds-icon>
+            This is an error message
+          </div>
         </mock:shadow-root>
       </pds-switch>
     `);

--- a/libs/core/src/components/pds-table/pds-table-head/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head/readme.md
@@ -33,6 +33,7 @@ graph TD;
   pds-table-head --> pds-table-head-cell
   pds-table-head --> pds-checkbox
   pds-table-head-cell --> pds-icon
+  pds-checkbox --> pds-icon
   style pds-table-head fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/libs/core/src/components/pds-table/pds-table-row/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-row/readme.md
@@ -32,6 +32,7 @@
 graph TD;
   pds-table-row --> pds-table-cell
   pds-table-row --> pds-checkbox
+  pds-checkbox --> pds-icon
   style pds-table-row fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -51,10 +51,10 @@ You can also manually pass in an invalid state by setting the `invalid` property
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsTextarea name="Invalid" label="Name" errorMessage="Error" invalid="true" required="true" componentId="textarea-invalid"></PdsTextarea>',
-    webComponent: '<pds-textarea name="Invalid" label="Name" error-message="Error" invalid="true" required="true" component-id="textarea-invalid"></pds-textarea>'
+    react: '<PdsTextarea name="Invalid" label="Name" errorMessage="Field cannot be blank" invalid="true" required="true" componentId="textarea-invalid"></PdsTextarea>',
+    webComponent: '<pds-textarea name="Invalid" label="Name" error-message="Field cannot be blank" invalid="true" required="true" component-id="textarea-invalid"></pds-textarea>'
 }}>
-  <pds-textarea name="Invalid" label="Name" error-message="Error" invalid="true" required="true" component-id="textarea-invalid"></pds-textarea>
+  <pds-textarea name="Invalid" label="Name" error-message="Field cannot be blank" invalid="true" required="true" component-id="textarea-invalid"></pds-textarea>
 </DocCanvas>
 
 ### Helper Message

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -25,6 +25,7 @@
   --spacing-margin-block-start-helper-message: var(--pine-spacing-100);
   --spacing-padding-block-field: var(--pine-spacing-100);
   --spacing-padding-inline-field: var(--pine-spacing-200);
+  --spacing-icon-error-message: var(--pine-spacing-050);
 
   --typography-message-default: var(--pine-typography-body-sm-default);
 
@@ -84,5 +85,8 @@ label {
 }
 
 .pds-textarea__error-message {
+  align-items: center;
   color: var(--color-text-message-error-default);
+  display: flex;
+  gap: var(--spacing-icon-error-message);
 }

--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Host, h, Prop, Event, EventEmitter } from '@stencil
 import { assignDescription, isRequired, messageId } from '../../utils/form';
 import { TextareaChangeEventDetail } from './textarea-interface';
 import { PdsLabel } from '../_internal/pds-label/pds-label';
+import { danger } from '@pine-ds/icons/icons';
 
 @Component({
   tag: 'pds-textarea',
@@ -143,6 +144,7 @@ export class PdsTextarea {
               class="pds-textarea__error-message"
               id={messageId(this.componentId, 'error')}
             >
+              <pds-icon icon={danger} size="small" />
               {this.errorMessage}
             </p>
           }

--- a/libs/core/src/components/pds-textarea/readme.md
+++ b/libs/core/src/components/pds-textarea/readme.md
@@ -31,6 +31,19 @@
 | `pdsTextareaChange` | Event emitted whenever the value of the textarea changes | `CustomEvent<TextareaChangeEventDetail>` |
 
 
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-textarea --> pds-icon
+  style pds-textarea fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
@@ -94,8 +94,8 @@ Readonly.args = {
   value: 'Readonly Value'
 };
 
-export const Message = BaseTemplate.bind({});
-Message.args = {
+export const WithMessage = BaseTemplate.bind({});
+WithMessage.args = {
   componentId: 'pds-textarea-helper-example',
   helperMessage: 'Helper message text',
   label: 'Message',

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsTextarea } from '../pds-textarea';
+import { danger } from '@pine-ds/icons/icons';
 
 describe('pds-textarea', () => {
   it('renders default textarea', async () => {
@@ -47,7 +48,10 @@ describe('pds-textarea', () => {
         <mock:shadow-root>
           <div class="pds-textarea">
             <textarea aria-invalid="true" class="pds-textarea__field is-invalid" id="pds-textarea-error" name="pds-textarea-error"></textarea>
-            <p aria-live="assertive" class="pds-textarea__error-message" id="pds-textarea-error__error-message">error</p>
+            <p aria-live="assertive" class="pds-textarea__error-message" id="pds-textarea-error__error-message">
+              <pds-icon icon="${danger}" size="small"></pds-icon>
+              error
+            </p>
           </div>
         </mock:shadow-root>
       </pds-textarea>
@@ -251,6 +255,7 @@ describe('pds-textarea', () => {
               This is a helper message
             </p>
             <p aria-live="assertive" id="textarea-with-description__error-message" class="pds-textarea__error-message">
+              <pds-icon icon="${danger}" size="small"></pds-icon>
               This is an error message
             </p>
           </div>


### PR DESCRIPTION
# Description

Updates input components that are missing icons in error message text.

- Checkbox
- Radio
- Switch
- Input
- Textarea

In addition, adjusts styling for better alignment with design specs and instructions:
Updates include typography and color adjustments.

- Checkbox
- Radio
- Switch


Fixes https://kajabi.atlassian.net/browse/DSS-1203


### Screenshots
|  Component   |  Screenshot  |
|--------|--------|
|Checkbox|![Screenshot 2024-11-25 at 12 14 22 PM](https://github.com/user-attachments/assets/472f10cb-6fe8-420b-a4df-46bd0a3316ee)|
|Radio|![Screenshot 2024-11-25 at 12 14 10 PM](https://github.com/user-attachments/assets/489c3ad4-ff43-4267-9e17-312934e204ce)|
|Switch|![Screenshot 2024-11-25 at 12 13 54 PM](https://github.com/user-attachments/assets/50980264-20c9-476e-bbc4-c0c32bc30f00)|
|Input|![Screenshot 2024-11-25 at 12 22 01 PM](https://github.com/user-attachments/assets/bfdb1ad3-480f-4560-ad70-0ac43df72c96)|
|Textarea|![Screenshot 2024-11-25 at 12 23 34 PM](https://github.com/user-attachments/assets/6ab8310e-16c6-442a-9145-421ef30852d1)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Navigate to the components listed above.
Verify icon is displayed when the error message is present
Verify radio, checkbox, switch text sizing and colors align.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
