### PR TITLE
docs(events): fix the method name to match the example

### DIFF
--- a/libs/core/src/stories/events.docs.mdx
+++ b/libs/core/src/stories/events.docs.mdx
@@ -32,7 +32,7 @@ const handleChange = () => {
   console.log('changed!')
 }
 
-document.getElementById("example").addEventListener('pdsCheckboxChange', handleLdchange)
+document.getElementById("example").addEventListener('pdsCheckboxChange', handleChange)
 </script>
 ```
 


### PR DESCRIPTION
DSS-1155

# Description

Update the documentation for events

Fixes #(issue)
DSS-1155

