### PR TITLE
docs: updates Storybook font styles to match Pine

### DIFF
--- a/libs/core/.storybook/PineTheme.js
+++ b/libs/core/.storybook/PineTheme.js
@@ -12,6 +12,9 @@ export default create({
   appBorderColor: '#eceeef',
   appBorderRadius: 6,
 
+  // Typography
+  fontBase: '"Inter", sans-serif',
+
   // Text colors
   textColor: 'black',
   textInverseColor: 'rgba(255,255,255,0.9)',

--- a/libs/core/.storybook/manager-head.html
+++ b/libs/core/.storybook/manager-head.html
@@ -9,3 +9,4 @@
   type="image/png"
   href="images/favicon.ico"
 />
+<link rel="stylesheet" href="/pine-core/pine-core.css" />

--- a/libs/core/.storybook/preview-body.html
+++ b/libs/core/.storybook/preview-body.html
@@ -1,7 +1,86 @@
+ <!-- Adds sb-unstyled class to the body -->
+<body class="sb-unstyled"></body>
+
 <style>
-  body {
-    margin: 0px;
-    padding: 0px;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  /* Temp workaround because MDX2 broke styling in Storybook */
+  /* TODO: Use semantic tokens where necessary */
+  .sb-unstyled {
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol' !important;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: -0.16px;
+    line-height: 1.425;
+    color: #343332;
+
+    h1, h2, h3, h4, h5, h6 {
+      font-family: "GreetStandard";
+      margin-block: 0 8px;
+    }
+
+    h1 {
+      font-size: 28px;
+      font-weight: 600;
+      letter-spacing: 0.26px;
+      line-height: 1.25;
+    }
+
+    h2 {
+      font-size: 26px;
+      font-weight: 600;
+      letter-spacing: 0.24px;
+      line-height: 1.25;
+      border-bottom: 1px solid #e4e4e4; /* Grey 200 */
+      padding-block: 0 4px;
+    }
+
+    h3 {
+      font-size: 22px;
+      font-weight: 600;
+      letter-spacing: 0.22px;
+      line-height: 1.25;
+    }
+
+    h4 {
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: 0.20px;
+      line-height: 1.25;
+    }
+
+    h5 {
+      font-size: 18px;
+      font-weight: 500;
+      letter-spacing: 0.18px;
+      line-height: 1.25;
+    }
+
+    h6 {
+      font-size: 16px;
+      font-weight: 500;
+      letter-spacing: 0.16px;
+      line-height: 1.25;
+    }
+
+    code, pre {
+      font-family: monospace;
+      letter-spacing: 0;
+      line-height: 1;
+    }
+
+    div + h2, div + h3, div + h4 {
+      margin-block-start: 24px;
+    }
+
+    p {
+      margin-block: 16px;
+    }
+
+    ul {
+      margin-block: 16px;
+    }
+
+    li + li {
+      margin-block-start: 8px;
+    }
   }
 </style>

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -390,7 +390,7 @@ export namespace Components {
          */
         "componentId": string;
         /**
-          * Indicates whether or not the input field is disabled.
+          * Determines whether or not the input field is disabled.
          */
         "disabled"?: boolean;
         /**
@@ -402,7 +402,7 @@ export namespace Components {
          */
         "helperMessage"?: string;
         /**
-          * Indicates whether or not the input field is invalid or throws an error.
+          * Determines whether or not the input field is invalid or throws an error.
          */
         "invalid"?: boolean;
         /**
@@ -418,11 +418,11 @@ export namespace Components {
          */
         "placeholder"?: string;
         /**
-          * Indicates whether or not the input field is readonly.
+          * Determines whether or not the input field is readonly.
          */
         "readonly"?: boolean;
         /**
-          * Indicates whether or not the input field is required.
+          * Determines whether or not the input field is required.
          */
         "required"?: boolean;
         /**
@@ -916,7 +916,7 @@ export namespace Components {
          */
         "disabled": boolean;
         /**
-          * Specifies the error message and provides an error-themed treatment to the field.
+          * Displays an error message below the textarea field.
          */
         "errorMessage"?: string;
         /**
@@ -1860,7 +1860,7 @@ declare namespace LocalJSX {
          */
         "componentId": string;
         /**
-          * Indicates whether or not the input field is disabled.
+          * Determines whether or not the input field is disabled.
          */
         "disabled"?: boolean;
         /**
@@ -1872,7 +1872,7 @@ declare namespace LocalJSX {
          */
         "helperMessage"?: string;
         /**
-          * Indicates whether or not the input field is invalid or throws an error.
+          * Determines whether or not the input field is invalid or throws an error.
          */
         "invalid"?: boolean;
         /**
@@ -1892,11 +1892,11 @@ declare namespace LocalJSX {
          */
         "placeholder"?: string;
         /**
-          * Indicates whether or not the input field is readonly.
+          * Determines whether or not the input field is readonly.
          */
         "readonly"?: boolean;
         /**
-          * Indicates whether or not the input field is required.
+          * Determines whether or not the input field is required.
          */
         "required"?: boolean;
         /**
@@ -2427,7 +2427,7 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
-          * Specifies the error message and provides an error-themed treatment to the field.
+          * Displays an error message below the textarea field.
          */
         "errorMessage"?: string;
         /**

--- a/libs/core/src/components/pds-accordion/stories/pds-accordion.docs.mdx
+++ b/libs/core/src/components/pds-accordion/stories/pds-accordion.docs.mdx
@@ -8,7 +8,7 @@ import * as stories from './pds-accordion.stories.js';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-avatar/stories/pds-avatar.docs.mdx
+++ b/libs/core/src/components/pds-avatar/stories/pds-avatar.docs.mdx
@@ -8,7 +8,7 @@ import * as stories from './pds-avatar.stories.js';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-box/stories/pds-box.docs.mdx
+++ b/libs/core/src/components/pds-box/stories/pds-box.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-box.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-chip/stories/pds-chip.docs.mdx
+++ b/libs/core/src/components/pds-chip/stories/pds-chip.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-chip.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-divider/stories/pds-divider.docs.mdx
+++ b/libs/core/src/components/pds-divider/stories/pds-divider.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-divider.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-image/stories/pds-image.docs.mdx
+++ b/libs/core/src/components/pds-image/stories/pds-image.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-image.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-input/stories/pds-input.docs.mdx
+++ b/libs/core/src/components/pds-input/stories/pds-input.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-input.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Text} />
 

--- a/libs/core/src/components/pds-link/stories/pds-link.docs.mdx
+++ b/libs/core/src/components/pds-link/stories/pds-link.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-link.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.External} />
 

--- a/libs/core/src/components/pds-loader/stories/pds-loader.docs.mdx
+++ b/libs/core/src/components/pds-loader/stories/pds-loader.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-loader.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-popover/stories/pds-popover.docs.mdx
+++ b/libs/core/src/components/pds-popover/stories/pds-popover.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-popover.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} layout="centered" />
 

--- a/libs/core/src/components/pds-progress/stories/pds-progress.docs.mdx
+++ b/libs/core/src/components/pds-progress/stories/pds-progress.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-progress.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-radio/stories/pds-radio.docs.mdx
+++ b/libs/core/src/components/pds-radio/stories/pds-radio.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-radio.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-row/stories/pds-row.docs.mdx
+++ b/libs/core/src/components/pds-row/stories/pds-row.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-row.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-select/stories/pds-select.docs.mdx
+++ b/libs/core/src/components/pds-select/stories/pds-select.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-select.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.docs.mdx
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-sortable.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-switch/stories/pds-switch.docs.mdx
+++ b/libs/core/src/components/pds-switch/stories/pds-switch.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-switch.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-table/stories/pds-table.docs.mdx
+++ b/libs/core/src/components/pds-table/stories/pds-table.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-table.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-tabs/stories/pds-tabs.docs.mdx
+++ b/libs/core/src/components/pds-tabs/stories/pds-tabs.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-tabs.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -21,7 +21,7 @@ It's important to be aware of the semantic differences between the `em` and `str
 
 <DocArgsTable componentName="pds-text" docSource={components} />
 
-## Default
+### Default
 
 Each semantic tag provided comes with default styling. If no `tag` prop is provided, the default tag will be set to `p`.
 
@@ -45,7 +45,7 @@ Each semantic tag provided comes with default styling. If no `tag` prop is provi
   <pds-text tag="p">Excepteur nulla veniam ullamco tempor culpa magna occaecat culpa. Sunt cupidatat proident tempor labore cupidatat labore mollit ullamco esse culpa. Dolor aute consequat aliqua excepteur cillum. Tempor deserunt eiusmod nulla qui anim incididunt et nulla ex consequat sit Lorem.</pds-text>
 </DocCanvas>
 
-## Alignment
+### Alignment
 
 Text can be aligned to the start, center, end, or justified.
 
@@ -59,7 +59,7 @@ Text can be aligned to the start, center, end, or justified.
   <pds-text align="center" tag="p">"Had to be me. Someone else might have gotten it wrong."</pds-text>
 </DocCanvas>
 
-## Color
+### Color
 
 Text color can align to our common variant/sentiment values.
 
@@ -96,7 +96,7 @@ Text color can align to our common variant/sentiment values.
   <pds-text color="warning" tag="p">Pikachu</pds-text>
 </DocCanvas>
 
-## Font Size
+### Font Size
 
 Font size can be set to preset body text values.
 
@@ -108,7 +108,7 @@ Font size can be set to preset body text values.
   <pds-text size="2xl" tag="p">Hello World!</pds-text>
 </DocCanvas>
 
-## Font Weight
+### Font Weight
 
 Font weight can be set to common font weight values.
 
@@ -120,7 +120,7 @@ Font weight can be set to common font weight values.
   <pds-text weight="bold" tag="p">Hello World!</pds-text>
 </DocCanvas>
 
-## Gutters
+### Gutters
 
 Gutters, or margin spacing, can be added to the bottom of the component for spacing between blocks of text.
 
@@ -141,7 +141,7 @@ Gutters, or margin spacing, can be added to the bottom of the component for spac
   <pds-text tag="p">Body of text...</pds-text>
 </DocCanvas>
 
-## Italics
+### Italics
 
 The `em` element does not come italicized by default as it should not be used solely to italicize text. To italicize text, add the `italic` attribute to the component.
 
@@ -153,7 +153,7 @@ The `em` element does not come italicized by default as it should not be used so
   <pds-text tag="p" italic>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>
 
-## Truncation
+### Truncation
 
 To truncate text, add the `truncate` attribute to the component. Text truncation will depend on the component's or parent container's width.
 

--- a/libs/core/src/components/pds-text/stories/pds-text.docs.mdx
+++ b/libs/core/src/components/pds-text/stories/pds-text.docs.mdx
@@ -8,7 +8,7 @@ import * as stories from './pds-text.stories.js';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.docs.mdx
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-textarea.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} />
 

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.docs.mdx
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.docs.mdx
@@ -8,7 +8,7 @@ import Docs from '../docs/pds-tooltip.mdx';
 
 <Docs />
 
-# Playground
+## Playground
 
 <Canvas of={stories.Default} layout="centered" />
 

--- a/libs/doc-components/src/components/docArgsTable/docArgsTable.css
+++ b/libs/doc-components/src/components/docArgsTable/docArgsTable.css
@@ -9,7 +9,7 @@
 
   .args-table-header {
     color: rgba(46,52,56,0.6);
-    font-family: "Nunito Sans",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: "Inter",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 13px;
     font-weight: 700;
     padding: 10px;
@@ -34,7 +34,7 @@
 
 .arg-table-cell {
   color: #2E3438;
-  font-family: "Nunito Sans",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "Inter",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 13px;;
   padding-inline-start: 10px;
 

--- a/libs/doc-components/src/components/docCanvas/docCanvas.css
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.css
@@ -66,10 +66,10 @@
 
 .doc-canvas-action {
   background: none;
-  border: none;
+  border: 0;
   color: inherit;
   cursor: pointer;
-  font-family: "Nunito Sans",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "Inter",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 11px;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -146,7 +146,7 @@
   code {
     border-radius: var(--doc-canvas-radius-sm);
     direction: ltr;
-    font-family: "Nunito Sans",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: monospace;
     font-size: 14px;
     padding: 4px;
   }


### PR DESCRIPTION
# Description

Updates Storybook font styles to match Pine. This PR is a bit of a workaround as it was discovered that MDX2 is affecting/breaking Storybook styling. Sources: [1](https://github.com/storybookjs/storybook/issues/17533) [2](https://github.com/storybookjs/storybook/issues/20600) [3](https://github.com/storybookjs/storybook/pull/19958)

|  Before  |  After  |
|--------|--------|
<img width="1066" alt="Screenshot 2024-12-16 at 11 11 57 AM" src="https://github.com/user-attachments/assets/44b683ed-86b8-4be8-9f22-b27c3827a89c" />|<img width="1069" alt="Screenshot 2024-12-16 at 11 10 01 AM" src="https://github.com/user-attachments/assets/f8cba634-1647-4d8b-b17a-b79994d21426" />
<img width="1077" alt="Screenshot 2024-12-16 at 11 12 06 AM" src="https://github.com/user-attachments/assets/c0816dcd-f708-4305-963d-ca37ce4fd5e9" />|<img width="1039" alt="Screenshot 2024-12-16 at 11 10 12 AM" src="https://github.com/user-attachments/assets/0c8505c0-5bd3-4392-9591-5644c7277a1e" />



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:
