### PR TITLE
style: adjusts minor styling for docs

### DIFF
--- a/libs/core/.storybook/preview-body.html
+++ b/libs/core/.storybook/preview-body.html
@@ -1,6 +1,5 @@
  <!-- Adds sb-unstyled class to the body -->
 <body class="sb-unstyled"></body>
-<td class="test"></td>
 
 <style>
   /* Temp workaround because MDX2 broke styling in Storybook */

--- a/libs/core/.storybook/preview-body.html
+++ b/libs/core/.storybook/preview-body.html
@@ -1,5 +1,6 @@
  <!-- Adds sb-unstyled class to the body -->
 <body class="sb-unstyled"></body>
+<td class="test"></td>
 
 <style>
   /* Temp workaround because MDX2 broke styling in Storybook */
@@ -59,6 +60,10 @@
       font-weight: 500;
       letter-spacing: 0.16px;
       line-height: 1.25;
+    }
+
+    button {
+      font-family: inherit;
     }
 
     code, pre {

--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -2,6 +2,7 @@ import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
 
 # Box
+
 Box is our primitive layout component. It is intended to be used as a building block for more complex layouts. It allows for custom sizing, colors, padding, and alignment while still adhering to Pine tokens and brand guidelines.
 
 ## Properties
@@ -15,26 +16,10 @@ By default Box has no border. Use `border` to add a border to the box. Use `bord
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        border="true"
-      >
-        Border
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        border="true"
-      >
-        Border
-      </pds-box>
-    `
+    react: `<PdsBox border="true">Border</PdsBox>`,
+    webComponent: `<pds-box border="true">Border</pds-box>`
 }}>
-  <pds-box
-    border="true"
-  >
-    Border
-  </pds-box>
+  <pds-box border="true">Border</pds-box>
 </DocCanvas>
 
 ### Border Color
@@ -42,80 +27,19 @@ Please refer to the color brand guidelines for the appropriate color to use. Use
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        border="true"
-      >
-        Border Color
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-color="#0072EF"
-      >
-        Border Color
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-color="#CF3C32"
-      >
-        Border Color
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-color="#FFC505"
-      >
-        Border Color
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        border="true"
-      >
-        Border Color
-      </pds-box>
-      <pds-box
-        border="true"
-        border-color="#0072EF"
-      >
-        Border Color
-      </pds-box>
-      <pds-box
-        border="true"
-        border-color="#CF3C32"
-      >
-        Border Color
-      </pds-box>
-      <pds-box
-        border="true"
-        border-color="#FFC505"
-      >
-        Border Color
-      </pds-box>
-    `
+    react: `<PdsBox border="true">Border Color</PdsBox>
+<PdsBox border="true" border-color="#0072EF">Border Color</PdsBox>
+<PdsBox border="true" border-color="#CF3C32">Border Color</PdsBox>
+<PdsBox border="true" border-color="#FFC505">Border Color</PdsBox>`,
+    webComponent: `<pds-box border="true">Border Color</pds-box>
+<pds-box border="true" border-color="#0072EF">Border Color</pds-box>
+<pds-box border="true" border-color="#CF3C32">Border Color</pds-box>
+<pds-box border="true" border-color="#FFC505">Border Color</pds-box>`
 }}>
-  <pds-box
-    border="true"
-  >
-    Border Color
-  </pds-box>
-  <pds-box
-    border="true"
-    border-color="#0072EF"
-  >
-    Border Color
-  </pds-box>
-  <pds-box
-    border="true"
-    border-color="#CF3C32"
-  >
-    Border Color
-  </pds-box>
-  <pds-box
-    border="true"
-    border-color="#FFC505"
-  >
-    Border Color
-  </pds-box>
+  <pds-box border="true">Border Color</pds-box>
+  <pds-box border="true" border-color="#0072EF">Border Color</pds-box>
+  <pds-box border="true" border-color="#CF3C32">Border Color</pds-box>
+  <pds-box border="true" border-color="#FFC505">Border Color</pds-box>
 </DocCanvas>
 
 ### Border Radius
@@ -123,155 +47,39 @@ By default Box has no border radius. Use `borderRadius` to change the rounding o
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        border="true"
-        border-radius="xs"
-      >
-        xs border radius
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-radius="sm"
-      >
-        sm border radius
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-radius="md"
-      >
-        md border radius
-      </PdsBox>
-      <PdsBox
-        border="true"
-        border-radius="lg"
-      >
-        lg border radius
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        border="true"
-        border-radius="xs"
-      >
-        xs border radius
-      </pds-box>
-      <pds-box
-        border="true"
-        border-radius="sm"
-      >
-        sm border radius
-      </pds-box>
-      <pds-box
-        border="true"
-        border-radius="md"
-      >
-        md border radius
-      </pds-box>
-      <pds-box
-        border="true"
-        border-radius="lg"
-      >
-        lg border radius
-      </pds-box>
-    `
+    react: `<PdsBox border="true" border-radius="xs">xs border radius</PdsBox>
+<PdsBox border="true" border-radius="sm">sm border radius</PdsBox>
+<PdsBox border="true" border-radius="md">md border radius</PdsBox>
+<PdsBox border="true" border-radius="lg">lg border radius</PdsBox>`,
+    webComponent: `<pds-box border="true" border-radius="xs">xs border radius</pds-box>
+<pds-box border="true" border-radius="sm">sm border radius</pds-box>
+<pds-box border="true" border-radius="md">md border radius</pds-box>
+<pds-box border="true" border-radius="lg">lg border radius</pds-box>`
 }}>
-  <pds-box
-    border="true"
-    border-radius="xs"
-  >
-    xs border radius
-  </pds-box>
-  <pds-box
-    border="true"
-    border-radius="sm"
-  >
-    sm border radius
-  </pds-box>
-  <pds-box
-    border="true"
-    border-radius="md"
-  >
-    md border radius
-  </pds-box>
-  <pds-box
-    border="true"
-    border-radius="lg"
-  >
-    lg border radius
-  </pds-box>
+  <pds-box border="true" border-radius="xs">xs border radius</pds-box>
+  <pds-box border="true" border-radius="sm">sm border radius</pds-box>
+  <pds-box border="true" border-radius="md">md border radius</pds-box>
+  <pds-box border="true" border-radius="lg">lg border radius</pds-box>
 </DocCanvas>
 
 ### Shadow
-By default Box has no shadow. Use `shadow` to add a shadow to the box. 
+By default Box has no shadow. Use `shadow` to add a shadow to the box.
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        shadow="xs"
-      >
-        Shadow xs
-      </PdsBox>
-      <PdsBox
-        shadow="sm"
-      >
-        Shadow sm
-      </PdsBox>
-      <PdsBox
-        shadow="md"
-      >
-        Shadow md
-      </PdsBox>
-      <PdsBox
-        shadow="lg"
-      >
-        Shadow lg
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        shadow="xs"
-      >
-        Shadow xs
-      </pds-box>
-      <pds-box
-        shadow="sm"
-      >
-        Shadow sm
-      </pds-box>
-      <pds-box
-        shadow="md"
-      >
-        Shadow md
-      </pds-box>
-      <pds-box
-        shadow="lg"
-      >
-        Shadow lg
-      </pds-box>
-    `
+    react: `<PdsBox shadow="xs">Shadow xs</PdsBox>
+<PdsBox shadow="sm">Shadow sm</PdsBox>
+<PdsBox shadow="md">Shadow md</PdsBox>
+<PdsBox shadow="lg">Shadow lg</PdsBox>`,
+    webComponent: `<pds-box shadow="xs">Shadow xs</pds-box>
+<pds-box shadow="sm">Shadow sm</pds-box>
+<pds-box shadow="md">Shadow md</pds-box>
+<pds-box shadow="lg">Shadow lg</pds-box>`
 }}>
-  <pds-box
-    shadow="xs"
-  >
-    Shadow xs
-  </pds-box>
-  <pds-box
-    shadow="sm"
-  >
-    Shadow sm
-  </pds-box>
-  <pds-box
-    shadow="md"
-  >
-    Shadow md
-  </pds-box>
-  <pds-box
-    shadow="lg"
-  >
-    Shadow lg
-  </pds-box>
+  <pds-box shadow="xs">Shadow xs</pds-box>
+  <pds-box shadow="sm">Shadow sm</pds-box>
+  <pds-box shadow="md">Shadow md</pds-box>
+  <pds-box shadow="lg">Shadow lg</pds-box>
 </DocCanvas>
 
 ### Padding
@@ -279,155 +87,28 @@ By default Box has no padding. Use `padding` to add padding to the box.
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        border="true"
-        padding="xxs"
-      >
-        Padding xxs
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="xxs"
-      >
-        Padding xs
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="xs"
-      >
-        Padding xxs
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="sm"
-      >
-        Padding sm
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="md"
-      >
-        Padding md
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="lg"
-      >
-        Padding lg
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="xl"
-      >
-        Padding xl
-      </PdsBox>
-      <PdsBox
-        border="true"
-        padding="xxl"
-      >
-        Padding xxl
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        border="true"
-        padding="xxs"
-      >
-        Padding xxs
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="xxs"
-      >
-        Padding xs
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="xs"
-      >
-        Padding xxs
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="sm"
-      >
-        Padding sm
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="md"
-      >
-        Padding md
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="lg"
-      >
-        Padding lg
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="xl"
-      >
-        Padding xl
-      </pds-box>
-      <pds-box
-        border="true"
-        padding="xxl"
-      >
-        Padding xxl
-      </pds-box>
-    `
+    react: `<PdsBox border="true" padding="xxs">Padding xxs</PdsBox>
+<PdsBox border="true" padding="xs">Padding xs</PdsBox>
+<PdsBox border="true" padding="sm">Padding sm</PdsBox>
+<PdsBox border="true" padding="md">Padding md</PdsBox>
+<PdsBox border="true" padding="lg">Padding lg</PdsBox>
+<PdsBox border="true" padding="xl">Padding xl</PdsBox>
+<PdsBox border="true" padding="xxl">Padding xxl</PdsBox>`,
+    webComponent: `<pds-box border="true" padding="xxs">Padding xxs</pds-box>
+<pds-box border="true" padding="xs">Padding xs</pds-box>
+<pds-box border="true" padding="sm">Padding sm</pds-box>
+<pds-box border="true" padding="md">Padding md</pds-box>
+<pds-box border="true" padding="lg">Padding lg</pds-box>
+<pds-box border="true" padding="xl">Padding xl</pds-box>
+<pds-box border="true" padding="xxl">Padding xxl</pds-box>`
 }}>
-  <pds-box
-    border="true"
-    padding="xxs"
-  >
-    Padding xxs
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="xxs"
-  >
-    Padding xs
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="xs"
-  >
-    Padding xxs
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="sm"
-  >
-    Padding sm
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="md"
-  >
-    Padding md
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="lg"
-  >
-    Padding lg
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="xl"
-  >
-    Padding xl
-  </pds-box>
-  <pds-box
-    border="true"
-    padding="xxl"
-  >
-    Padding xxl
-  </pds-box>
+  <pds-box border="true" padding="xxs">Padding xxs</pds-box>
+  <pds-box border="true" padding="xs">Padding xs</pds-box>
+  <pds-box border="true" padding="sm">Padding sm</pds-box>
+  <pds-box border="true" padding="md">Padding md</pds-box>
+  <pds-box border="true" padding="lg">Padding lg</pds-box>
+  <pds-box border="true" padding="xl">Padding xl</pds-box>
+  <pds-box border="true" padding="xxl">Padding xxl</pds-box>
 </DocCanvas>
 
 ### Display
@@ -438,47 +119,28 @@ By default Box is `flex-direction: row`. Use `direction` to change the direction
 
 <DocCanvas client:only
   mdxSource={{
-    react: `
-      <PdsBox
-        border="true"
-      >
-        <span>Item 1</span>
-        <span>Item 2</span>
-      </PdsBox>
-      <PdsBox
-        border="true"
-        direction="column"
-      >
-        <span>Item 1</span>
-        <span>Item 2</span>
-      </PdsBox>
-    `,
-    webComponent: `
-      <pds-box
-        border="true"
-      >
-        <span>Item 1</span>
-        <span>Item 2</span>
-      </pds-box>
-      <pds-box
-        border="true"
-        direction="column"
-      >
-        <span>Item 1</span>
-        <span>Item 2</span>
-      </pds-box>
-    `
+    react: `<PdsBox border="true">
+  <span>Item 1</span>
+  <span>Item 2</span>
+</PdsBox>
+<PdsBox border="true" direction="column">
+  <span>Item 1</span>
+  <span>Item 2</span>
+</PdsBox>`,
+    webComponent: `<pds-box border="true">
+  <span>Item 1</span>
+  <span>Item 2</span>
+</pds-box>
+<pds-box border="true" direction="column">
+  <span>Item 1</span>
+  <span>Item 2</span>
+</pds-box>`
 }}>
-  <pds-box
-    border="true"
-  >
+  <pds-box border="true">
     <span>Item 1</span>
     <span>Item 2</span>
   </pds-box>
-  <pds-box
-    border="true"
-    direction="column"
-  >
+  <pds-box border="true" direction="column">
     <span>Item 1</span>
     <span>Item 2</span>
   </pds-box>

--- a/libs/core/src/stories/layout.docs.mdx
+++ b/libs/core/src/stories/layout.docs.mdx
@@ -6,6 +6,7 @@ import image from '../stories/assets/offers.png';
 <Meta title="components/Layout"/>
 
 # Layout
+
 The layout system is a flexible and customizable framework based on the `pds-box` and `pds-row` components,
 designed to create responsive, adaptable, and aesthetically pleasing grid layouts. This system leverages a 12-column
 grid, intuitive alignment properties, and powerful nesting capabilities to support a wide variety of use cases, from
@@ -121,7 +122,7 @@ Use `pds-row` for Multi-Column Layouts:
 
 #### Make it responsive
 
-Add side modifiers to your child `pds-box` for responsive design
+Add size modifiers to your child `pds-box` for responsive design
 
 <DocCanvas client:only
   mdxSource={{
@@ -153,6 +154,7 @@ Add side modifiers to your child `pds-box` for responsive design
 ## Examples
 
 ### Form Edit view
+
 <DocCanvas client:only
   mdxSource={{
     react: `
@@ -596,6 +598,7 @@ Add side modifiers to your child `pds-box` for responsive design
 </DocCanvas>
 
 ### Creating a 12-Column Grid System
+
 By combining the `pds-box` and `pds-row` components, you can easily create a 12-column grid system. Here's an example of how to structure your layout:
 
 <DocCanvas client:only
@@ -627,12 +630,8 @@ By combining the `pds-box` and `pds-row` components, you can easily create a 12-
 }}>
   <pds-box display="block">
     <pds-row>
-      <pds-box border>
-        Content for column 1
-      </pds-box>
-      <pds-box border>
-        Content for column 2
-      </pds-box>
+      <pds-box border>Content for column 1</pds-box>
+      <pds-box border>Content for column 2</pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -669,17 +668,14 @@ This creates a two-column layout, and you can customize the `size` and arrangeme
 }}>
   <pds-box display="block">
     <pds-row>
-      <pds-box border size="4">
-        Content for column 1
-      </pds-box>
-      <pds-box border size="8">
-        Content for column 2
-      </pds-box>
+      <pds-box border size="4">Content for column 1</pds-box>
+      <pds-box border size="8">Content for column 2</pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
 
 ## Responsive Design
+
 Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior for you `pds-box`. The layout components are designed to be responsive, allowing you to create layouts that adapt to different screen sizes. Take advantage of properties like `size-xs`, `offset-sm`, etc., to customize the layout for specific breakpoints. Be sure to optimize your layout for mobile devices, as well as larger screens.
 
 <DocCanvas client:only
@@ -714,6 +710,7 @@ Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior f
 
 
 ### Visible / Hidden Columns
+
 `size` and `offset` can be used to hide or show columns at different breakpoints. Values from 1 - 12 show the column, 0 hides the column.
 
 <DocCanvas client:only
@@ -744,6 +741,7 @@ Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior f
 </DocCanvas>
 
 ### Offsetting Columns
+
 Use the `offset` property to offset columns to the right. The `offset` property accepts values from 1 - 11. For example, `offset="1"` will offset the column by one column width. Adding size modifiers such as `offset-md="1"` will offset the column by one column width on medium screens and larger.
 
 <DocCanvas client:only
@@ -795,6 +793,7 @@ Use the `offset` property to offset columns to the right. The `offset` property 
 </DocCanvas>
 
 ### Alignment
+
 Adding either `flex` **`display`** property to the box will initiate alignment values. Use `align-items` to change the vertical alignment of the box. Use `justify-content` to change the horizontal alignment of the box.
 
 <DocCanvas client:only
@@ -877,27 +876,21 @@ Adding either `flex` **`display`** property to the box will initiate alignment v
         justify-content="center"
         min-height="200px"
         padding="sm"
-      >
-        Content 1
-      </pds-box>
+      >Content 1</pds-box>
       <pds-box
         align-items="center"
         border="true"
         display="flex"
         justify-content="center"
         padding="sm"
-      >
-        Content2
-      </pds-box>
+      >Content2</pds-box>
       <pds-box
         align-items="end"
         border="true"
         display="flex"
         justify-content="end"
         padding="sm"
-      >
-        Content 3
-      </pds-box>
+      >Content 3</pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -981,32 +974,27 @@ Note - using **`min-height`** on the `Box` or the parent `Row` is recommended to
         display="flex"
         justify-content="center"
         padding="sm"
-      >
-        Content 1
-      </pds-box>
+      >Content 1</pds-box>
       <pds-box
         align-items="center"
         border="true"
         display="flex"
         justify-content="center"
         padding="sm"
-      >
-        Content2
-      </pds-box>
+      >Content2</pds-box>
       <pds-box
         align-items="end"
         border="true"
         display="flex"
         justify-content="end"
         padding="sm"
-      >
-        Content 3
-      </pds-box>
+      >Content 3</pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
 
 ## Nested Layouts
+
 You can nest `pds-row` and `pds-box` components to create more complex layouts.
 
 <DocCanvas client:only
@@ -1075,19 +1063,14 @@ You can nest `pds-row` and `pds-box` components to create more complex layouts.
         display="flex"
         size-md="4"
       >
-        <pds-box
-          display="flex"
-          align-items="center"
-          justify-content="center"
-        >
-          Column 2
-        </pds-box>
+        <pds-box display="flex" align-items="center" justify-content="center">Column 2</pds-box>
       </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
 
 ### Gaps / Gutters
+
 When a gap or gutter is needed between the columns, an additional child `pds-box` must be used to ensure correct spacing between the columns and rows
 
 <DocCanvas client:only
@@ -1131,18 +1114,10 @@ When a gap or gutter is needed between the columns, an additional child `pds-box
 }}>
   <pds-row col-gap="sm">
     <pds-box size-sm="4">
-      <pds-box
-        border-radius="sm"
-        padding="sm"
-        shadow="sm"
-      >
-        Item 1
-      </pds-box>
+      <pds-box border-radius="sm" padding="sm" shadow="sm">Item 1</pds-box>
     </pds-box>
     <pds-box size-sm="8">
-      <pds-box padding="sm" shadow="sm">
-        Item 2
-      </pds-box>
+      <pds-box padding="sm" shadow="sm">Item 2</pds-box>
     </pds-box>
   </pds-row>
 </DocCanvas>

--- a/libs/doc-components/src/components/docArgsTable/docArgsTable.css
+++ b/libs/doc-components/src/components/docArgsTable/docArgsTable.css
@@ -11,7 +11,7 @@
     color: rgba(46,52,56,0.6);
     font-family: "Inter",-apple-system,".SFNSText-Regular","San Francisco",BlinkMacSystemFont,"Segoe UI","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 13px;
-    font-weight: 700;
+    font-weight: 600;
     padding: 10px;
     text-align: left;
   }
@@ -38,9 +38,17 @@
   font-size: 13px;;
   padding-inline-start: 10px;
 
+  .args-type {
+    margin-block-start: 4px;
+  }
+
   span,
   strong {
     font-size: 13px;
+  }
+
+  strong {
+    font-weight: 600;
   }
 
   code {

--- a/libs/doc-components/src/components/docCanvas/docCanvas.css
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.css
@@ -96,7 +96,7 @@
   background-color: var(--doc-canvas-green);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5);
   color: var(--doc-canvas-color-light);
-  font-weight: 700;
+  font-weight: 600;
   opacity: 1;
 }
 


### PR DESCRIPTION
# Description

Adjusts minor styling for Storybook:

- Fixes formatting on Box stories to remove unintentional `<p>` tags rendering
- Changes font-weight for table props and docCanvas active button to 600
- Adds top margin to table code block

## Type of change

- [x] Style (Style updates)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other: