### PR TITLE
feature: decoration prop for pds text

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -858,6 +858,11 @@ export namespace Components {
   | 'success'
   | 'warning';
         /**
+          * Sets the text decoration.
+         */
+        "decoration"?: | 'strikethrough'
+  | 'underline-dotted';
+        /**
           * Set the bottom margin for the text.
          */
         "gutter"?: | '2xl'
@@ -2368,6 +2373,11 @@ declare namespace LocalJSX {
   | 'info'
   | 'success'
   | 'warning';
+        /**
+          * Sets the text decoration.
+         */
+        "decoration"?: | 'strikethrough'
+  | 'underline-dotted';
         /**
           * Set the bottom margin for the text.
          */

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -96,6 +96,25 @@ Text color can align to our common variant/sentiment values.
   <pds-text color="warning" tag="p">Pikachu</pds-text>
 </DocCanvas>
 
+### Decoration
+
+Text decoration can be set to underline-dotted or strikethrough.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsText tag="p" decoration="strikethrough">Pangoro</PdsText>
+      <PdsText tag="p" decoration="underline-dotted">Sceptile</PdsText>
+    `,
+    webComponent: `
+      <pds-text tag="p" decoration="strikethrough">Pangoro</pds-text>
+      <pds-text tag="p" decoration="underline-dotted">Sceptile</pds-text>
+    `
+}}>
+  <pds-text tag="p" decoration="strikethrough">Pangoro</pds-text>
+  <pds-text tag="p" decoration="underline-dotted">Sceptile</pds-text>
+</DocCanvas>
+
 ### Font Size
 
 Font size can be set to preset body text values.

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -7,7 +7,7 @@
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-decoration-thickness: 12%;
-  text-underline-offset: 0.25rem;
+  text-underline-offset: 0.3rem;
   text-underline-position: under;
 }
 

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -2,6 +2,16 @@
   display: inline;
 }
 
+:host([decoration="underline-dotted"]) > * {
+  text-decoration: underline dotted var(--pine-color-grey-600);
+  text-decoration-thickness: 12%;
+  text-underline-offset: 25%;
+}
+
+:host([decoration="strikethrough"])>* {
+  text-decoration: line-through;
+}
+
 // TODO: Update all values to match new semantic tokens, if applicable
 
 /* stylelint-disable */

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -7,7 +7,8 @@
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-decoration-thickness: 12%;
-  text-underline-offset: 25%;
+  text-underline-offset: 0.25rem;
+  text-underline-position: under;
 }
 
 :host([decoration="strikethrough"])>* {

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -3,7 +3,9 @@
 }
 
 :host([decoration="underline-dotted"]) > * {
-  text-decoration: underline dotted var(--pine-color-grey-600);
+  text-decoration-color: var(--pine-color-grey-600);
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
   text-decoration-thickness: 12%;
   text-underline-offset: 25%;
 }

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -26,6 +26,13 @@ export class PdsText {
   | 'warning';
 
   /**
+   * Sets the text decoration.
+   */
+  @Prop() decoration?:
+  | 'strikethrough'
+  | 'underline-dotted';
+
+  /**
    * Set the bottom margin for the text.
    */
   @Prop() gutter?:
@@ -86,6 +93,7 @@ export class PdsText {
       ${this.gutter !== undefined && this.gutter.trim() !== '' ? `pds-text--gutter-${this.gutter}` : ''}
       ${this.size !== undefined && this.size.trim() !== '' ? `pds-text--size-${this.size}` : ''}
       ${this.weight !== undefined && this.weight.trim() !== '' ? `pds-text--weight-${this.weight}` : ''}
+      ${this.decoration !== undefined && this.decoration.trim() !== '' ? `pds-text--decoration-${this.decoration}` : ''}
     `;
 
     return (

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property | Attribute | Description                                  | Type                                                                                                | Default     |
-| -------- | --------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| `align`  | `align`   | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
-| `color`  | `color`   | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
-| `gutter` | `gutter`  | Set the bottom margin for the text.          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `size`   | `size`    | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `tag`    | `tag`     | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `"p"`       |
-| `weight` | `weight`  | Sets the font weight.                        | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                         | `undefined` |
+| Property     | Attribute    | Description                                  | Type                                                                                                | Default     |
+| ------------ | ------------ | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| `align`      | `align`      | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
+| `color`      | `color`      | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
+| `decoration` | `decoration` | Sets the text decoration.                    | `"strikethrough" \| "underline-dotted"`                                                             | `undefined` |
+| `gutter`     | `gutter`     | Set the bottom margin for the text.          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
+| `size`       | `size`       | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
+| `tag`        | `tag`        | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `"p"`       |
+| `weight`     | `weight`     | Sets the font weight.                        | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                         | `undefined` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-text/stories/pds-text.stories.js
+++ b/libs/core/src/components/pds-text/stories/pds-text.stories.js
@@ -15,6 +15,7 @@ const BaseTemplate = (args) => html`
   size="${args.size}"
   tag="${args.tag}"
   weight="${args.weight}"
+  decoration="${args.decoration}"
 >
   ${args.slot}
 </pds-text>`;
@@ -37,6 +38,13 @@ Color.args = {
   slot: 'Hello World',
   color: 'accent',
   tag: 'p',
+};
+
+export const Decoration = BaseTemplate.bind();
+Decoration.args = {
+  slot: 'Hello World',
+  tag: 'p',
+  decoration: 'underline-dotted',
 };
 
 export const FontSize = BaseTemplate.bind();

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -80,7 +80,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="p" decoration="underline-dotted">
         <mock:shadow-root>
-          <p class="pds-text pds-text--underline-dotted"><slot></slot></p>
+          <p class="pds-text pds-text--decoration-underline-dotted"><slot></slot></p>
         </mock:shadow-root>
       </pds-text>
     `)

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -71,4 +71,18 @@ describe('pds-text', () => {
       </pds-text>
     `)
   });
+
+  it('renders with decoration class when prop is set', async ()=> {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="p" decoration="underline-dotted"></pds-text>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-text tag="p" decoration="underline-dotted">
+        <mock:shadow-root>
+          <p class="pds-text pds-text--underline-dotted"><slot></slot></p>
+        </mock:shadow-root>
+      </pds-text>
+    `)
+  });
 });


### PR DESCRIPTION
# Description

Adds a new decoration prop to `pds-text` to allow for strikethrough and dotted underline to be added to the text.

Fixes [#(DSS-1247)](https://kajabi.atlassian.net/browse/DSS-1247)

![Screenshot 2025-01-29 at 4 02 23 PM](https://github.com/user-attachments/assets/7cb4a1ff-bef8-4d72-9a00-cc9371b9fe1a)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Navigate to pds-text, see demos and stories

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
