### PR TITLE
style: add pointer cursor

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -15,6 +15,7 @@
   border-color: var(--color-border-default);
   border-radius: var(--pine-border-radius-full);
   color: var(--color-text-default); // Set in the variant classes below
+  cursor: pointer;
   display: flex;
   font-family: var(--pine-font-family-greet);
   font-size: var(--pine-font-size-body-md);
@@ -46,6 +47,7 @@
     background-color: var(--color-background-disabled);
     border-color: var(--color-border-disabled);
     color: var(--color-text-disabled);
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
# Description
We intentionally chose not to include `cursor: pointer` with the Pine implementation of the button. After further research across the industry and to keep alignment with every other button in the system, we'll need to add the rules

Fixes #(issue)

|  Before  |  After  |
|--------|--------|
|![buttonHoversBefore](https://github.com/user-attachments/assets/50285a7b-bcb0-44ab-8815-9341b761d23c)|![buttonHovers](https://github.com/user-attachments/assets/a48355e7-1061-4a53-aa94-430f95ec5970)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers: Chrom, Safari, FF
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
