### PR TITLE
style: fixes incorrect token for box padding-xs

### DIFF
--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -270,7 +270,7 @@ $pine-spacing-tokens: (
 }
 
 .pds-padding-xs {
-  padding: var(--spacing-gap-xxs);
+  padding: var(--spacing-gap-xs);
 }
 
 .pds-padding-sm {


### PR DESCRIPTION
# Description
Fixes issue with `<pds-box>` padding-xs using incorrect token.

Before:
<img width="182" alt="Screenshot 2025-02-07 at 1 28 19 PM" src="https://github.com/user-attachments/assets/f89e4749-e3d0-4201-b0ae-bfcb6a638a64" />

After:
<img width="191" alt="Screenshot 2025-02-07 at 1 18 33 PM" src="https://github.com/user-attachments/assets/484144ff-cac0-4c5c-8bf3-e48a30e6b4c8" />


[DSS-1272](https://kajabi.atlassian.net/browse/DSS-1272)

## Type of change

- [x] Style (adds, updates, or removes component styling)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1272]: https://kajabi.atlassian.net/browse/DSS-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ