### PR TITLE
style: adjust background color values for secondary and disclosure

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -18,6 +18,7 @@
   --color-outline-primary: var(--pine-color-purple-300);
 
   // secondary
+  --color-background-secondary-default: var(--pine-color-white);
   --color-background-secondary-hover: var(--pine-color-grey-050);
   --color-border-secondary-default: var(--pine-color-grey-400);
   --color-border-secondary-disabled: var(--pine-color-grey-300);
@@ -128,9 +129,9 @@
 
 .pds-button--secondary,
 .pds-button--disclosure {
-  --color-background-default: transparent;
-  --color-background-hover: transparent;
-  --color-background-disabled: transparent;
+  --color-background-default: var(--color-background-secondary-default);
+  --color-background-hover: var(--color-background-secondary-hover);
+  --color-background-disabled: var(--color-background-secondary-disabled);
   --color-border-disabled: var(--color-border-secondary-disabled);
   --color-border-focus: var(--color-border-secondary-focus);
   --color-border-hover: var(--color-border-secondary-hover);

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -20,6 +20,8 @@
   // secondary
   --color-background-secondary-default: var(--pine-color-white);
   --color-background-secondary-hover: var(--pine-color-grey-050);
+  --color-background-secondary-disabled: var(--pine-color-white);
+  --color-background-secondary-disabled-hover: var(--pine-color-white);
   --color-border-secondary-default: var(--pine-color-grey-400);
   --color-border-secondary-disabled: var(--pine-color-grey-300);
   --color-border-secondary-focus: var(--pine-color-grey-300);


### PR DESCRIPTION
# Description

Secondary and disclosure buttons currently have a transparent bg color set.
The color should be updated to match the design spec.
This PR updates the appropriate styles.

Fixes [#(DSS-1273)](https://kajabi.atlassian.net/browse/DSS-1273)

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2025-02-07 at 12 16 48 PM](https://github.com/user-attachments/assets/533ec690-1be8-45ce-9302-4e6927dc08e4)|![Screenshot 2025-02-07 at 12 22 23 PM](https://github.com/user-attachments/assets/3725eefc-6477-4abf-b3b0-04f12b2ae15e)|

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
