### PR TITLE
fix: tooltip visibility issue on ios safari back navigation

### DIFF
--- a/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
@@ -99,14 +99,10 @@ export class PdsTooltip {
 
   componentDidLoad() {
     // fix for Safari iOS back button issue
-    const handlePageShow = () => {
-      this.opened = false;
-    };
-
-    window.addEventListener('pageshow', handlePageShow);
+    window.addEventListener('pageshow', this.handlePageShow);
 
     return () => {
-      window.removeEventListener('pageshow', handlePageShow);
+      window.removeEventListener('pageshow', this.handlePageShow);
     };
   }
 
@@ -142,6 +138,10 @@ export class PdsTooltip {
 
   private handleShow = () => {
     this.showTooltip();
+  };
+
+  private handlePageShow = () => {
+    this.opened = false;
   };
 
   render() {

--- a/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
+++ b/libs/core/src/components/pds-tooltip/pds-tooltip.tsx
@@ -97,6 +97,19 @@ export class PdsTooltip {
     this.el.addEventListener('focus', this.handleShow, true);
   }
 
+  componentDidLoad() {
+    // fix for Safari iOS back button issue
+    const handlePageShow = () => {
+      this.opened = false;
+    };
+
+    window.addEventListener('pageshow', handlePageShow);
+
+    return () => {
+      window.removeEventListener('pageshow', handlePageShow);
+    };
+  }
+
   componentDidUpdate() {
     if (this.opened) {
       this.showTooltip();


### PR DESCRIPTION
# Description

When a tooltip is visible on-page navigation, clicking the back button in Safari on iOS navigates back, but the tooltip remains visible.

Fixes https://kajabi.atlassian.net/browse/DSS-1282


### Screenshots
|  Before   |  After  |
|--------|--------|
|![2025-02-18 10 01 26](https://github.com/user-attachments/assets/fb57aea1-5d70-478f-add4-eb11067a68e9)|![2025-02-18 10 02 06](https://github.com/user-attachments/assets/62a94390-5861-43e4-bfa0-3ac5367f3152)|

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
