### PR TITLE
style(accordion): fix misspelling for summary padding

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -41,8 +41,8 @@ summary {
   letter-spacing: var(--pine-letter-spacing);
   line-height: var(--pine-line-height-body);
   padding-block: calc(var(--pine-dimension-2xs) * 1.5);
-  padding-inline-end: var(var(--pine-dimension-2xs));
-  padding-inline-start: var(var(--pine-dimension-xs));
+  padding-inline-end: var(--pine-dimension-2xs);
+  padding-inline-start: var(--pine-dimension-xs);
 
   // Removes marker on Firefox/Chrome
   /* stylelint-disable-next-line */


### PR DESCRIPTION
# Description

CSS variables werent coming through  due to a double use of `var()`

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
