### PR TITLE
fix: remove box min-height

### DIFF
--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -12,7 +12,6 @@ pds-box {
   background-color: var(--color-background-box);
   box-sizing: border-box;
   display: inline-flex;
-  min-height: var(--pine-dimension-none);
   min-width: var(--pine-dimension-none);
 
   // The immediate child of the row will fit the width of the row


### PR DESCRIPTION
# Description
Resolves an issue with the box component collapsing due to the `min-height` after token update

Found in QEINBOX-4202

## Screenshot

|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-02-20 at 7 09 56 PM](https://github.com/user-attachments/assets/c1ad6ea5-884c-4c4c-ae57-813ae706c2cc)|![Screenshot 2025-02-20 at 7 10 12 PM](https://github.com/user-attachments/assets/acceb731-d2cc-4055-a38e-d24cd9003f8b)|
## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
