### PR TITLE
style(accordion): adjust summary colors

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -34,7 +34,7 @@ details[open] {
 summary {
   background-color: var(--pine-color-background-container);
   border-radius: var(--pine-dimension-xs);
-  color: var(--pine-color-text);
+  color: var(--pine-color-text-readonly);
   font-family: var(--pine-font-family-body);
   font-size: var(--pine-font-size-body-md);
   font-weight: var(--pine-font-weight-medium);
@@ -56,7 +56,7 @@ summary {
 
   &:hover {
     background: var(--pine-color-background-container-hover);
-    color: var(--color-text-hover);
+    color: var(--pine-color-text);
     cursor: pointer;
   }
 


### PR DESCRIPTION
# Description
Accordion summary default and hover colors were incorrect.
This adjusts the color to match app sidebar.

Fixes #(issue)

## Type of change
- [x] Style only

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
