### PR TITLE
fix: update input invalid state styles

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -436,7 +436,7 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
         /**
-          * Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`
+          * Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`, `'url'`
           * @defaultValue "text"
          */
         "type": string;
@@ -1945,7 +1945,7 @@ declare namespace LocalJSX {
          */
         "required"?: boolean;
         /**
-          * Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`
+          * Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`, `'url'`
           * @defaultValue "text"
          */
         "type"?: string;

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -21,13 +21,17 @@ label {
   margin-block-end: var(--pine-dimension-xs);
 }
 
-input {
+.pds-input__field {
   border: 1px solid var(--pine-color-border);
   border-radius: 10px;
   color: var(--pine-color-text-active);
   font: var(--pine-typography-body);
   letter-spacing: var(--pine-letter-spacing);
   padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
+
+  &:hover:not(:disabled, .is-invalid) {
+    border: var(--pine-border-hover);
+  }
 
   &:disabled {
     background-color: var(--pine-color-background-container-disabled);
@@ -80,18 +84,16 @@ input {
   &:-ms-input-placeholder {
     color: var(--pine-color-text-placeholder);
   }
+  /* stylelint-enable */
 
-  &:has(~.pds-input__error-message) {
-
+  &.is-invalid {
     background-color: var(--pine-input-color-background-danger);
     border-color: var(--pine-color-border-danger);
 
     &:focus-visible {
       box-shadow: var(--box-shadow-focus-error);
-      outline: none;
     }
   }
-  /* stylelint-enable */
 }
 
 .pds-input__error-message,

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -122,7 +122,7 @@ export class PdsInput {
 
   /**
    * Determines the type of control that will be displayed
-   * `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`
+   * `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`, `'url'`
    * @defaultValue "text"
    */
   @Prop() type = 'text';
@@ -239,6 +239,16 @@ export class PdsInput {
     this.debounceChanged();
   }
 
+  private inputClassNames() {
+    const classNames = ['pds-input__field'];
+
+    if (this.invalid && this.invalid === true) {
+      classNames.push('is-invalid');
+    }
+
+    return classNames.join('  ');
+  }
+
   render() {
     return (
       <Host
@@ -247,7 +257,8 @@ export class PdsInput {
       >
         <div class="pds-input">
           <label htmlFor={this.componentId}>{this.label}</label>
-          <input class="pds-input__field"
+          <input
+            class={this.inputClassNames()}
             ref={(input) => this.nativeInput = input}
             aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
             aria-invalid={this.invalid ? "true" : undefined}

--- a/libs/core/src/components/pds-input/readme.md
+++ b/libs/core/src/components/pds-input/readme.md
@@ -7,22 +7,22 @@
 
 ## Properties
 
-| Property                   | Attribute        | Description                                                                                                  | Type               | Default     |
-| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ | ------------------ | ----------- |
-| `autocomplete`             | `autocomplete`   | Specifies if and how the browser provides `autocomplete` assistance for the field.                           | `string`           | `undefined` |
-| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                                        | `string`           | `undefined` |
-| `debounce`                 | `debounce`       | Sets the number of milliseconds to wait before updating the value.                                           | `number`           | `undefined` |
-| `disabled`                 | `disabled`       | Determines whether or not the input field is disabled.                                                       | `boolean`          | `undefined` |
-| `errorMessage`             | `error-message`  | Specifies the error message and provides an error-themed treatment to the field.                             | `string`           | `undefined` |
-| `helperMessage`            | `helper-message` | Displays a message or hint below the input field.                                                            | `string`           | `undefined` |
-| `invalid`                  | `invalid`        | Determines whether or not the input field is invalid or throws an error.                                     | `boolean`          | `undefined` |
-| `label`                    | `label`          | Text to be displayed as the input label.                                                                     | `string`           | `undefined` |
-| `name`                     | `name`           | Specifies the name. Submitted with the form name/value pair.                                                 | `string`           | `undefined` |
-| `placeholder`              | `placeholder`    | Specifies a short hint that describes the expected value of the input field.                                 | `string`           | `undefined` |
-| `readonly`                 | `readonly`       | Determines whether or not the input field is readonly.                                                       | `boolean`          | `undefined` |
-| `required`                 | `required`       | Determines whether or not the input field is required.                                                       | `boolean`          | `undefined` |
-| `type`                     | `type`           | Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'` | `string`           | `'text'`    |
-| `value`                    | `value`          | The value of the input.                                                                                      | `number \| string` | `''`        |
+| Property                   | Attribute        | Description                                                                                                           | Type               | Default     |
+| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- |
+| `autocomplete`             | `autocomplete`   | Specifies if and how the browser provides `autocomplete` assistance for the field.                                    | `string`           | `undefined` |
+| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                                                 | `string`           | `undefined` |
+| `debounce`                 | `debounce`       | Sets the number of milliseconds to wait before updating the value.                                                    | `number`           | `undefined` |
+| `disabled`                 | `disabled`       | Determines whether or not the input field is disabled.                                                                | `boolean`          | `undefined` |
+| `errorMessage`             | `error-message`  | Specifies the error message and provides an error-themed treatment to the field.                                      | `string`           | `undefined` |
+| `helperMessage`            | `helper-message` | Displays a message or hint below the input field.                                                                     | `string`           | `undefined` |
+| `invalid`                  | `invalid`        | Determines whether or not the input field is invalid or throws an error.                                              | `boolean`          | `undefined` |
+| `label`                    | `label`          | Text to be displayed as the input label.                                                                              | `string`           | `undefined` |
+| `name`                     | `name`           | Specifies the name. Submitted with the form name/value pair.                                                          | `string`           | `undefined` |
+| `placeholder`              | `placeholder`    | Specifies a short hint that describes the expected value of the input field.                                          | `string`           | `undefined` |
+| `readonly`                 | `readonly`       | Determines whether or not the input field is readonly.                                                                | `boolean`          | `undefined` |
+| `required`                 | `required`       | Determines whether or not the input field is required.                                                                | `boolean`          | `undefined` |
+| `type`                     | `type`           | Determines the type of control that will be displayed `'email'`, `'number'`, `'password'`, `'tel'`, `'text'`, `'url'` | `string`           | `'text'`    |
+| `value`                    | `value`          | The value of the input.                                                                                               | `number \| string` | `''`        |
 
 
 ## Events

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -126,7 +126,7 @@ describe('pds-input', () => {
           <label htmlFor="pds-input-invalid">
             Name
           </label>
-          <input aria-invalid="true" id="pds-input-invalid" class="pds-input__field" type="text" value="Frank Dux" />
+          <input aria-invalid="true" id="pds-input-invalid" class="is-invalid pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
     </pds-input>


### PR DESCRIPTION
# Description

- [x] update invalid styles
- [x] add type `url` to docs

|  Before  |  After  |
|--------|--------|
|![invalid-input-before](https://github.com/user-attachments/assets/f996a29c-615f-42fe-9150-db9b8d7cafdd)|![invalid-input-after](https://github.com/user-attachments/assets/75fc728d-0c3c-4e70-afc9-d97ae5389a69)|

Fixes [DSS-1299](https://kajabi.atlassian.net/browse/DSS-1299)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Styles only

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1299]: https://kajabi.atlassian.net/browse/DSS-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ