### PR TITLE
style: adds background color to secondary and disclosure buttons

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -90,9 +90,9 @@
 
 .pds-button--secondary,
 .pds-button--disclosure {
-  --color-background-default: transparent;
-  --color-background-hover: transparent;
-  --color-background-disabled: transparent;
+  --color-background-default: var(--pine-color-secondary);
+  --color-background-hover: var(--pine-color-secondary-hover);
+  --color-background-disabled: var(--pine-color-secondary-disabled);
   --color-border-disabled: var(--pine-color-border-disabled);
   --color-border-focus: var(--pine-color-border);
   --color-border-hover: var(--pine-color-border-hover);


### PR DESCRIPTION
# Description
Fixes Secondary and Disclosure Buttons not having a set background color

## Type of change

- [x] Style (adds, removes, or changes component styling)

Before:
<img width="229" alt="Screenshot 2025-02-25 at 10 50 22 AM" src="https://github.com/user-attachments/assets/09343f51-ed33-4dec-bf11-7913698f5bca" />

After:
<img width="229" alt="Screenshot 2025-02-25 at 10 50 51 AM" src="https://github.com/user-attachments/assets/b0d37f14-679d-4259-9bef-369b90768e20" />


# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other: