### PR TITLE
fix: removes unneeded label margin

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -17,10 +17,6 @@
   flex-direction: column;
 }
 
-label {
-  margin-block-end: var(--pine-dimension-xs);
-}
-
 .pds-input__field {
   border: 1px solid var(--pine-color-border);
   border-radius: 10px;


### PR DESCRIPTION
# Description
Removes unneeded label margin on Input

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc: