### PR TITLE
style(checkbox): resolve wrapping issue

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -133,7 +133,6 @@ input {
 
 label {
   display: flex;
-  flex-direction: row-reverse;
   gap: var(--pine-dimension-xs);
 }
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -132,11 +132,10 @@ input {
 }
 
 label {
-  margin-inline-start: 10px;
-}
-
-.pds-checkbox__container {
   display: flex;
+  flex-direction: row-reverse;
+  gap: var(--pine-dimension-xs);
+  margin-inline-start: 10px;
 }
 
 .visually-hidden {
@@ -155,7 +154,7 @@ label {
 .pds-checkbox__message {
   color: var(--pine-color-text-message);
   margin-block-start: 6px;
-  margin-inline-start: 26px;
+  margin-inline-start: 34px;
   width: 100%;
 }
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -135,7 +135,6 @@ label {
   display: flex;
   flex-direction: row-reverse;
   gap: var(--pine-dimension-xs);
-  margin-inline-start: 10px;
 }
 
 .visually-hidden {
@@ -154,7 +153,7 @@ label {
 .pds-checkbox__message {
   color: var(--pine-color-text-message);
   margin-block-start: 6px;
-  margin-inline-start: 34px;
+  margin-inline-start: var(--pine-dimension-md);
   width: 100%;
 }
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -65,8 +65,10 @@ input {
   background-color: var(--pine-color-secondary);
   border: var(--pine-border);
   border-radius: var(--pine-dimension-2xs);
+  flex: none;
   height: var(--pine-dimension-sm);
   margin: 0;
+  margin-block-start: var(--pine-dimension-025);
   position: relative;
   width: var(--pine-dimension-sm);
 
@@ -131,6 +133,10 @@ input {
 
 label {
   margin-inline-start: 10px;
+}
+
+.pds-checkbox__container {
+  display: flex;
 }
 
 .visually-hidden {

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -117,7 +117,6 @@ export class PdsCheckbox {
     return (
       <Host class={this.classNames()}>
         <label htmlFor={this.componentId}>
-          {this.label}
           <input
             type="checkbox"
             aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
@@ -132,6 +131,7 @@ export class PdsCheckbox {
             onChange={this.handleCheckboxChange}
             onInput={this.handleInput}
           />
+          {this.label}
         </label>
         {this.helperMessage &&
           <div

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -117,21 +117,23 @@ export class PdsCheckbox {
   render() {
     return (
       <Host class={this.classNames()}>
-        <input
-          type="checkbox"
-          aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
-          aria-invalid={this.invalid ? "true" : undefined}
-          id={this.componentId}
-          indeterminate={this.indeterminate}
-          name={this.name}
-          value={this.value}
-          checked={this.checked}
-          required={this.required}
-          disabled={this.disabled}
-          onChange={this.handleCheckboxChange}
-          onInput={this.handleInput}
-        />
-        <PdsLabel htmlFor={this.componentId} text={this.label} classNames={this.labelHidden ? 'visually-hidden' : ''} />
+        <div class="pds-checkbox__container">
+          <input
+            type="checkbox"
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+            aria-invalid={this.invalid ? "true" : undefined}
+            id={this.componentId}
+            indeterminate={this.indeterminate}
+            name={this.name}
+            value={this.value}
+            checked={this.checked}
+            required={this.required}
+            disabled={this.disabled}
+            onChange={this.handleCheckboxChange}
+            onInput={this.handleInput}
+          />
+          <PdsLabel htmlFor={this.componentId} text={this.label} classNames={this.labelHidden ? 'visually-hidden' : ''} />
+        </div>
         {this.helperMessage &&
           <div
             class={'pds-checkbox__message'}

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -1,6 +1,5 @@
 import { Component, h, Prop, Host, Event, EventEmitter, Watch } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
-import { PdsLabel } from '../_internal/pds-label/pds-label';
 import { CheckboxChangeEventDetail } from './checkbox-interface';
 import { danger } from '@pine-ds/icons/icons';
 
@@ -117,7 +116,8 @@ export class PdsCheckbox {
   render() {
     return (
       <Host class={this.classNames()}>
-        <div class="pds-checkbox__container">
+        <label htmlFor={this.componentId}>
+          {this.label}
           <input
             type="checkbox"
             aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
@@ -132,8 +132,7 @@ export class PdsCheckbox {
             onChange={this.handleCheckboxChange}
             onInput={this.handleInput}
           />
-          <PdsLabel htmlFor={this.componentId} text={this.label} classNames={this.labelHidden ? 'visually-hidden' : ''} />
-        </div>
+        </label>
         {this.helperMessage &&
           <div
             class={'pds-checkbox__message'}

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -12,10 +12,9 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox>
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label>
             <input type="checkbox">
-            <label></label>
-          </div>
+          </label>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -30,10 +29,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="Label text">
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input type="checkbox" id="default">
-            <label htmlfor="default">Label text</label>
-          </div>
+            Label text
+          </label>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -68,10 +67,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-invalid" component-id="default" label="Label text" invalid>
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input aria-invalid="true" type="checkbox" id="default">
-            <label htmlfor="default">Label text</label>
-          </div>
+            Label text
+          </label>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -86,10 +85,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-indeterminate" component-id="default" label="Label text" indeterminate>
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input indeterminate="" type="checkbox" id="default">
-            <label htmlfor="default">Label text</label>
-          </div>
+            Label text
+          </label>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -104,10 +103,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="This is label text">
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input type="checkbox" id="default">
-            <label htmlfor="default">This is label text</label>
-          </div>
+            This is label text
+          </label>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -122,10 +121,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="Label text" helper-message="This is short message text.">
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input aria-describedby="default__helper-message" type="checkbox" id="default">
-            <label htmlfor="default">Label text</label>
-          </div>
+            Label text
+          </label>
           <div class="pds-checkbox__message" id="default__helper-message">This is short message text.</div>
         </mock:shadow-root>
       </pds-checkbox>
@@ -141,10 +140,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
         <mock:shadow-root>
-          <div class="pds-checkbox__container">
+          <label htmlfor="default">
             <input aria-invalid="true" id="default" type="checkbox">
-            <label htmlfor="default">Label text</label>
-          </div>
+            Label text
+          </label>
           <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">
             <pds-icon icon="${danger}" size="small"></pds-icon>
             This is a short error message.

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -12,8 +12,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox>
         <mock:shadow-root>
-          <input type="checkbox">
-          <label></label>
+          <div class="pds-checkbox__container">
+            <input type="checkbox">
+            <label></label>
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -28,8 +30,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="Label text">
         <mock:shadow-root>
-          <input type="checkbox" id="default">
-          <label htmlfor="default">Label text</label>
+          <div class="pds-checkbox__container">
+            <input type="checkbox" id="default">
+            <label htmlfor="default">Label text</label>
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -64,8 +68,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-invalid" component-id="default" label="Label text" invalid>
         <mock:shadow-root>
-          <input aria-invalid="true" type="checkbox" id="default">
-          <label htmlfor="default">Label text</label>
+          <div class="pds-checkbox__container">
+            <input aria-invalid="true" type="checkbox" id="default">
+            <label htmlfor="default">Label text</label>
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -80,8 +86,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-indeterminate" component-id="default" label="Label text" indeterminate>
         <mock:shadow-root>
-          <input indeterminate="" type="checkbox" id="default">
-          <label htmlfor="default">Label text</label>
+          <div class="pds-checkbox__container">
+            <input indeterminate="" type="checkbox" id="default">
+            <label htmlfor="default">Label text</label>
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -96,8 +104,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="This is label text">
         <mock:shadow-root>
-          <input type="checkbox" id="default">
-          <label htmlfor="default">This is label text</label>
+          <div class="pds-checkbox__container">
+            <input type="checkbox" id="default">
+            <label htmlfor="default">This is label text</label>
+          </div>
         </mock:shadow-root>
       </pds-checkbox>
     `);
@@ -112,8 +122,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox component-id="default" label="Label text" helper-message="This is short message text.">
         <mock:shadow-root>
-          <input aria-describedby="default__helper-message" type="checkbox" id="default">
-          <label htmlfor="default">Label text</label>
+          <div class="pds-checkbox__container">
+            <input aria-describedby="default__helper-message" type="checkbox" id="default">
+            <label htmlfor="default">Label text</label>
+          </div>
           <div class="pds-checkbox__message" id="default__helper-message">This is short message text.</div>
         </mock:shadow-root>
       </pds-checkbox>
@@ -129,8 +141,10 @@ describe('pds-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <pds-checkbox class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
         <mock:shadow-root>
-          <input aria-invalid="true" id="default" type="checkbox">
-          <label htmlfor="default">Label text</label>
+          <div class="pds-checkbox__container">
+            <input aria-invalid="true" id="default" type="checkbox">
+            <label htmlfor="default">Label text</label>
+          </div>
           <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">
             <pds-icon icon="${danger}" size="small"></pds-icon>
             This is a short error message.


### PR DESCRIPTION
# Description
- [x] resolve checkbox misalignment when label wraps

|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-02-27 at 1 06 58 PM](https://github.com/user-attachments/assets/a1323fba-169f-4af2-9fff-da4836615b6d)|![Screenshot 2025-02-27 at 1 06 02 PM](https://github.com/user-attachments/assets/2b288491-fa5b-468b-8e12-a1cea4bb53b7)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit the Checkbox page
- Add enough text to cause wrapping
- Verify

- [x] unit tests

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
