### PR TITLE
fix(radio): add inner shadow wrapper

### DIFF
--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -114,7 +114,7 @@ label {
 .pds-radio__message {
   color: var(--pine-color-text-message);
   margin-block-start: var(--sizing-margin-block-start);
-  margin-inline-start: 24px;
+  margin-inline-start: var(--pine-dimension-md);
   width: 100%;
 }
 

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -106,17 +106,15 @@ input {
 }
 
 label {
-  margin-inline-start: 10px;
-}
-
-.pds-radio__container {
   display: flex;
+  flex-direction: row-reverse;
+  gap: var(--pine-dimension-xs);
 }
 
 .pds-radio__message {
   color: var(--pine-color-text-message);
   margin-block-start: var(--sizing-margin-block-start);
-  margin-inline-start: 26px;
+  margin-inline-start: 24px;
   width: 100%;
 }
 

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -40,8 +40,10 @@ input {
   appearance: none;
   border: var(--pine-border);
   border-radius: var(--pine-border-radius-full);
+  flex: none;
   height: var(--sizing-input-size);
   margin: 0;
+  margin-block-start: var(--pine-dimension-025);
   position: relative;
   width: var(--sizing-input-size);
 
@@ -105,6 +107,10 @@ input {
 
 label {
   margin-inline-start: 10px;
+}
+
+.pds-radio__container {
+  display: flex;
 }
 
 .pds-radio__message {

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -107,7 +107,6 @@ input {
 
 label {
   display: flex;
-  flex-direction: row-reverse;
   gap: var(--pine-dimension-xs);
 }
 

--- a/libs/core/src/components/pds-radio/pds-radio.tsx
+++ b/libs/core/src/components/pds-radio/pds-radio.tsx
@@ -95,7 +95,6 @@ export class PdsRadio {
     return (
       <Host class={this.classNames()}>
         <label htmlFor={this.componentId}>
-          {this.label}
           <input
             aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
@@ -108,6 +107,7 @@ export class PdsRadio {
             disabled={this.disabled}
             onChange={this.handleRadioChange}
           />
+          {this.label}
         </label>
         {this.helperMessage &&
           <div

--- a/libs/core/src/components/pds-radio/pds-radio.tsx
+++ b/libs/core/src/components/pds-radio/pds-radio.tsx
@@ -95,19 +95,21 @@ export class PdsRadio {
   render() {
     return (
       <Host class={this.classNames()}>
-        <input
-          aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
-          aria-invalid={this.invalid ? "true" : undefined}
-          type="radio"
-          id={this.componentId}
-          name={this.name}
-          value={this.value}
-          checked={this.checked}
-          required={this.required}
-          disabled={this.disabled}
-          onChange={this.handleRadioChange}
-        />
-        <PdsLabel htmlFor={this.componentId} text={this.label} />
+        <div class="pds-radio__container">
+          <input
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+            aria-invalid={this.invalid ? "true" : undefined}
+            type="radio"
+            id={this.componentId}
+            name={this.name}
+            value={this.value}
+            checked={this.checked}
+            required={this.required}
+            disabled={this.disabled}
+            onChange={this.handleRadioChange}
+          />
+          <PdsLabel htmlFor={this.componentId} text={this.label} />
+        </div>
         {this.helperMessage &&
           <div
             class={'pds-radio__message'}

--- a/libs/core/src/components/pds-radio/pds-radio.tsx
+++ b/libs/core/src/components/pds-radio/pds-radio.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, h, Prop, Event, EventEmitter } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
-import { PdsLabel } from '../_internal/pds-label/pds-label';
 import { danger } from '@pine-ds/icons/icons';
 
 @Component({
@@ -95,7 +94,8 @@ export class PdsRadio {
   render() {
     return (
       <Host class={this.classNames()}>
-        <div class="pds-radio__container">
+        <label htmlFor={this.componentId}>
+          {this.label}
           <input
             aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
@@ -108,8 +108,7 @@ export class PdsRadio {
             disabled={this.disabled}
             onChange={this.handleRadioChange}
           />
-          <PdsLabel htmlFor={this.componentId} text={this.label} />
-        </div>
+        </label>
         {this.helperMessage &&
           <div
             class={'pds-radio__message'}

--- a/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
+++ b/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
@@ -11,8 +11,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio>
-        <input type="radio">
-        <label></label>
+        <div class="pds-radio__container">
+          <input type="radio">
+          <label></label>
+        </div>
       </pds-radio>
     `);
   });
@@ -25,8 +27,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="Label text">
-        <input type="radio" id="default">
-        <label htmlfor="default">Label text</label>
+        <div class="pds-radio__container">
+          <input type="radio" id="default">
+          <label htmlfor="default">Label text</label>
+        </div>
       </pds-radio>
     `);
   });
@@ -59,8 +63,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio class="is-invalid" component-id="default" label="Label text" invalid>
-        <input aria-invalid="true" id="default" type="radio">
-        <label htmlfor="default">Label text</label>
+        <div class="pds-radio__container">
+          <input aria-invalid="true" id="default" type="radio">
+          <label htmlfor="default">Label text</label>
+        </div>
       </pds-radio>
     `);
   });
@@ -73,8 +79,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="This is label text">
-        <input type="radio" id="default">
-        <label htmlfor="default">This is label text</label>
+        <div class="pds-radio__container">
+          <input type="radio" id="default">
+          <label htmlfor="default">This is label text</label>
+        </div>
       </pds-radio>
     `);
   });
@@ -87,10 +95,13 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="Label text" helper-message="This is short message text.">
-        <input aria-describedby="default__helper-message" id="default" type="radio">
-        <label htmlfor="default">Label text</label>
+        <div class="pds-radio__container">
+          <input aria-describedby="default__helper-message" id="default" type="radio">
+          <label htmlfor="default">Label text</label>
+        </div>
         <div class="pds-radio__message" id="default__helper-message">
-        This is short message text.</div>
+          This is short message text.
+        </div>
       </pds-radio>
     `);
   });
@@ -103,8 +114,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
-        <input aria-invalid="true" id="default" type="radio">
-        <label htmlfor="default">Label text</label>
+        <div class="pds-radio__container">
+          <input aria-invalid="true" id="default" type="radio">
+          <label htmlfor="default">Label text</label>
+        </div>
         <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">
           <pds-icon icon="${danger}" size="small"></pds-icon>
           This is a short error message.

--- a/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
+++ b/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
@@ -11,10 +11,9 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio>
-        <div class="pds-radio__container">
+        <label>
           <input type="radio">
-          <label></label>
-        </div>
+        </label>
       </pds-radio>
     `);
   });
@@ -27,10 +26,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="Label text">
-        <div class="pds-radio__container">
-          <input type="radio" id="default">
-          <label htmlfor="default">Label text</label>
-        </div>
+        <label htmlfor="default">
+          <input id="default" type="radio">
+          Label text
+        </label>
       </pds-radio>
     `);
   });
@@ -63,10 +62,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio class="is-invalid" component-id="default" label="Label text" invalid>
-        <div class="pds-radio__container">
+        <label htmlfor="default">
           <input aria-invalid="true" id="default" type="radio">
-          <label htmlfor="default">Label text</label>
-        </div>
+          Label text
+        </label>
       </pds-radio>
     `);
   });
@@ -79,10 +78,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="This is label text">
-        <div class="pds-radio__container">
-          <input type="radio" id="default">
-          <label htmlfor="default">This is label text</label>
-        </div>
+        <label htmlfor="default">
+          <input id="default" type="radio">
+          This is label text
+        </label>
       </pds-radio>
     `);
   });
@@ -95,10 +94,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio component-id="default" label="Label text" helper-message="This is short message text.">
-        <div class="pds-radio__container">
+        <label htmlfor="default">
           <input aria-describedby="default__helper-message" id="default" type="radio">
-          <label htmlfor="default">Label text</label>
-        </div>
+          Label text
+        </label>
         <div class="pds-radio__message" id="default__helper-message">
           This is short message text.
         </div>
@@ -114,10 +113,10 @@ describe('pds-radio', () => {
 
     expect(page.root).toEqualHtml(`
       <pds-radio class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
-        <div class="pds-radio__container">
+        <label htmlfor="default">
           <input aria-invalid="true" id="default" type="radio">
-          <label htmlfor="default">Label text</label>
-        </div>
+          Label text
+        </label>
         <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">
           <pds-icon icon="${danger}" size="small"></pds-icon>
           This is a short error message.


### PR DESCRIPTION
# Description
- [x] resolve radio misalignment when label wraps

|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-02-27 at 1 21 18 PM](https://github.com/user-attachments/assets/d2696554-ed6d-4eb4-9e0e-b7245e065a43)|![Screenshot 2025-02-27 at 1 20 41 PM](https://github.com/user-attachments/assets/d7abba24-0767-468f-a412-fcdf899bdc2a)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit the Radio page
- Add enough text to cause wrapping
- Verify

- [x] unit tests

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
