### PR TITLE
ci: getDX Deployments and Service identification

### DIFF
--- a/.github/workflows/getdx-service-identification.yml
+++ b/.github/workflows/getdx-service-identification.yml
@@ -1,0 +1,18 @@
+name: "GetDX Service Identification"
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - 'main'
+
+jobs:
+  identify-services:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Identify Services
+        uses: Kajabi/getdx-monorepo-service-identifier-action@main
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -237,3 +237,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Report pine production deployment to GetDX
+        if: ${{ success() }}
+        uses: Kajabi/getdx-deployment-identifier-action@main
+        env:
+          POSTFIX: ${{ needs.setup.outputs.postfix }}
+        with:
+          getdx-instance-name: 'kajabi'
+          getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}
+          service-name: 'pine'

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -241,8 +241,6 @@ jobs:
       - name: Report pine production deployment to GetDX
         if: ${{ success() }}
         uses: Kajabi/getdx-deployment-identifier-action@main
-        env:
-          POSTFIX: ${{ needs.setup.outputs.postfix }}
         with:
           getdx-instance-name: 'kajabi'
           getdx-token: ${{ secrets.GETDX_DEPLOYMENT_TOKEN }}

--- a/libs/doc-components/catalog-info.yaml
+++ b/libs/doc-components/catalog-info.yaml
@@ -1,12 +1,12 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: pine-react
-  description: The React library for the Pine design system
+  name: pine-doc-components
+  description: The Documentation Components library for the Pine design system
   tags:
     - javascript
     - typescript
-    - react
+    - documentation
 spec:
   type: library
   lifecycle: production

--- a/libs/doc-components/catalog-info.yaml
+++ b/libs/doc-components/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pine-react
+  description: The React library for the Pine design system
+  tags:
+    - javascript
+    - typescript
+    - react
+spec:
+  type: library
+  lifecycle: production
+  owner: design-system-services
+  system: pine
+  subcomponentOf: pine


### PR DESCRIPTION
https://github.com/Kajabi/sage-lib/pull/2073

Refer to that PR above as it goes over most of the details. This just ensures we report deployments and services via PRs to GetDX