### PR TITLE
style: update pill tabs styles

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -7,6 +7,10 @@ pds-tab {
   align-items: center;
   display: inline-flex;
   position: relative;
+
+  .pds-tabs--pill & {
+    flex: 1;
+  }
 }
 
 ///
@@ -182,14 +186,15 @@ pds-tab {
     background-color: var(--color-background-tab);
     border: var(--pine-border-width-thin) solid transparent;
     border-radius: var(--pine-dimension-xs);
-    color: var(--color-text-default);
+    color: var(--pine-color-text-readonly);
+    flex: 1;
     height: 34px;
+    justify-content: center;
 
     .pds-tab__content {
       align-items: center;
       display: flex;
       justify-content: center;
-      min-width: 90px;
       padding-block-end: 0;
     }
 
@@ -198,6 +203,7 @@ pds-tab {
       --color-background-tab: var(--pine-color-white);
       border-color: var(--pine-color-border);
       box-shadow: var(--pine-box-shadow-100);
+      color: var(--pine-color-text-active);
       z-index: 1;
 
       &:focus-visible {

--- a/libs/core/src/components/pds-tabs/pds-tabs.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabs.scss
@@ -32,6 +32,7 @@
   border: var(--pine-border-width-thin) solid var(--pine-color-grey-200);
   border-radius: var(--pine-dimension-100);
   display: inline-flex;
+  display: flex;
   gap: 0;
   height: var(--pine-dimension-450);
 }


### PR DESCRIPTION
# Description
The Pill tabs are being used in a sidebar which requires updating the tab to not rely on a `min-width`, but instead be equal width. 

- [x] resolve pill tabs wrapping
- [x] update pill tabs layout for parent awareness

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any new dependencies or updates that are required for this change.

Fixes #(issue)
|  Before  |  After  |
|--------|--------|
|![tabs-before](https://github.com/user-attachments/assets/8b3df242-063e-4fbc-89fb-726a37a35997)|![tabs-after](https://github.com/user-attachments/assets/8fb8ffeb-3564-4e40-81b7-3f59406b6e79)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


Visit the Pill tabs page to verify the changed

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
