### PR TITLE
style: add conditional label for input and select

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -669,7 +669,7 @@ export namespace Components {
         /**
           * Text to be displayed as the select label.
          */
-        "label": string;
+        "label"?: string;
         /**
           * Indicates whether multiple options can be selected.
           * @defaultValue false

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -17,7 +17,7 @@
   flex-direction: column;
 }
 
-label {
+.pds-input__label {
   margin-block-end: var(--pine-dimension-2xs)
 }
 

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -15,7 +15,10 @@
 .pds-input {
   display: flex;
   flex-direction: column;
-  gap: var(--pine-dimension-2xs);
+}
+
+label {
+  margin-block-end: var(--pine-dimension-2xs)
 }
 
 .pds-input__field {
@@ -97,7 +100,7 @@
 .pds-input__helper-message {
   font: var(--pine-typography-body-sm-medium);
   margin-block-end: 0;
-  margin-block-start: 0;
+  margin-block-start: var(--pine-dimension-2xs)
 }
 
 .pds-input__error-message {

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -15,6 +15,7 @@
 .pds-input {
   display: flex;
   flex-direction: column;
+  gap: var(--pine-dimension-2xs);
 }
 
 .pds-input__field {
@@ -96,7 +97,7 @@
 .pds-input__helper-message {
   font: var(--pine-typography-body-sm-medium);
   margin-block-end: 0;
-  margin-block-start: var(--pine-dimension-xs);
+  margin-block-start: 0;
 }
 
 .pds-input__error-message {

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -256,7 +256,9 @@ export class PdsInput {
         aria-readonly={this.readonly ? 'true' : null}
       >
         <div class="pds-input">
-          <label htmlFor={this.componentId}>{this.label}</label>
+          {this.label &&
+            <label htmlFor={this.componentId}>{this.label}</label>
+          }
           <input
             class={this.inputClassNames()}
             ref={(input) => this.nativeInput = input}

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -257,7 +257,7 @@ export class PdsInput {
       >
         <div class="pds-input">
           {this.label &&
-            <label htmlFor={this.componentId}>{this.label}</label>
+            <label class="pds-input__label" htmlFor={this.componentId}>{this.label}</label>
           }
           <input
             class={this.inputClassNames()}

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -11,8 +11,6 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
@@ -49,8 +47,6 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" placeholder="placeholder text" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input placeholder="placeholder text" id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
@@ -68,8 +64,6 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" required="true" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input required id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
@@ -86,8 +80,6 @@ describe('pds-input', () => {
     <pds-input aria-disabled="true" component-id="field-1" disabled="true" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input disabled id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
@@ -105,8 +97,6 @@ describe('pds-input', () => {
     <pds-input aria-readonly="true" component-id="field-1" readonly="true" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input readonly id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
         </div>
       </mock:shadow-root>
@@ -143,8 +133,6 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" value="Frank Dux" autocomplete="given-name">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
-          </label>
           <input id="field-1" class="pds-input__field" type="text" value="Frank Dux" autocomplete="given-name" />
         </div>
       </mock:shadow-root>

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -27,7 +27,7 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" label="Name" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="field-1">
+          <label class="pds-input__label" htmlFor="field-1">
             Name
           </label>
           <input id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
@@ -113,7 +113,7 @@ describe('pds-input', () => {
     <pds-input component-id="pds-input-invalid" invalid="true" label="Name" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label htmlFor="pds-input-invalid">
+          <label class="pds-input__label" htmlFor="pds-input-invalid">
             Name
           </label>
           <input aria-invalid="true" id="pds-input-invalid" class="is-invalid pds-input__field" type="text" value="Frank Dux" />

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -11,6 +11,7 @@
 .pds-select {
   display: grid;
   flex-direction: column;
+  gap: var(--pine-dimension-2xs);
   grid-template-areas:
     'label label'
     'field field'
@@ -23,7 +24,6 @@
 
 label {
   grid-area: label;
-  margin-block-end: var(--pine-dimension-2xs);
 }
 
 select {
@@ -82,7 +82,7 @@ select {
 .pds-select__helper-message {
   font: var(--pine-typography-body-sm-medium);
   margin-block-end: 0;
-  margin-block-start: var(--pine-dimension-xs);
+  margin-block-start: 0;
 }
 
 .pds-select__error-message {

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -11,7 +11,6 @@
 .pds-select {
   display: grid;
   flex-direction: column;
-  gap: var(--pine-dimension-2xs);
   grid-template-areas:
     'label label'
     'field field'
@@ -24,6 +23,7 @@
 
 label {
   grid-area: label;
+  margin-block-end: var(--pine-dimension-2xs);
 }
 
 select {
@@ -82,7 +82,7 @@ select {
 .pds-select__helper-message {
   font: var(--pine-typography-body-sm-medium);
   margin-block-end: 0;
-  margin-block-start: 0;
+  margin-block-start: var(--pine-dimension-2xs);
 }
 
 .pds-select__error-message {

--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -46,7 +46,7 @@ export class PdsSelect {
   /**
    * Text to be displayed as the select label.
    */
-  @Prop() label: string;
+  @Prop() label?: string;
 
   /**
    * Indicates whether multiple options can be selected.

--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -1,6 +1,5 @@
 import { Component, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
 import { messageId } from '../../utils/form';
-import { PdsLabel } from '../_internal/pds-label/pds-label';
 import { danger, enlarge } from '@pine-ds/icons/icons';
 
 @Component({
@@ -201,18 +200,20 @@ export class PdsSelect {
     return (
       <Host aria-disabled={this.disabled ? 'true' : null} class={this.classNames()}>
         <div class="pds-select">
-          <PdsLabel htmlFor={this.componentId} text={this.label} />
-            <select
-              autocomplete={this.autocomplete || undefined}
-              class="pds-select__field"
-              disabled={this.disabled}
-              id={this.componentId}
-              multiple={this.multiple}
-              name={this.name}
-              onChange={this.onSelectUpdate}
-              required={this.required}
-              ref={(el) => (this.selectEl = el as HTMLSelectElement)}
-            ></select>
+          {this.label &&
+            <label htmlFor={this.componentId}>{this.label}</label>
+          }
+          <select
+            autocomplete={this.autocomplete || undefined}
+            class="pds-select__field"
+            disabled={this.disabled}
+            id={this.componentId}
+            multiple={this.multiple}
+            name={this.name}
+            onChange={this.onSelectUpdate}
+            required={this.required}
+            ref={(el) => (this.selectEl = el as HTMLSelectElement)}
+          ></select>
           <div aria-hidden="true" class="hidden" ref={(el) => (this.slotContainer = el)}>
             <slot onSlotchange={this.handleSlotChange}></slot>
           </div>

--- a/libs/core/src/components/pds-select/test/pds-select.spec.tsx
+++ b/libs/core/src/components/pds-select/test/pds-select.spec.tsx
@@ -12,7 +12,6 @@ describe('pds-select', () => {
       <pds-select component-id="field-1">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlFor="field-1"></label>
             <select class="pds-select__field" id="field-1">
             </select>
             <div aria-hidden="true" class="hidden">
@@ -112,16 +111,16 @@ describe('pds-select', () => {
   it('renders with disabled attribute and class', async () => {
     const page = await newSpecPage({
       components: [PdsSelect],
-      html: `<pds-select aria-disabled="true" component-id="field-1" disabled></pds-select>`,
+      html: `<pds-select aria-disabled="true" component-id="field-1" disabled label="Disabled"></pds-select>`,
     });
 
     await page.waitForChanges(); // Ensures component fully renders
 
     expect(page.root).toEqualHtml(`
-      <pds-select aria-disabled="true" class="is-disabled" component-id="field-1" disabled="">
+      <pds-select aria-disabled="true" class="is-disabled" component-id="field-1" label="Disabled" disabled="">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1"></label>
+            <label htmlfor="field-1">Disabled</label>
             <select class="pds-select__field" disabled="" id="field-1">
               <slot></slot>
             </select>
@@ -147,7 +146,6 @@ describe('pds-select', () => {
       <pds-select class="is-invalid" component-id="field-1" invalid="true">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1"></label>
             <select class="pds-select__field" id="field-1">
               <slot></slot>
             </select>
@@ -215,7 +213,6 @@ describe('pds-select', () => {
       <pds-select component-id="field-1" multiple="">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlFor="field-1"></label>
             <select class="pds-select__field" id="field-1" multiple="">
             </select>
             <div aria-hidden="true" class="hidden">


### PR DESCRIPTION
# Description
There are uses of the input in which the label is not visible. In those cases the spacing properties assigned to the label remain as an artifact

- [x] Input - update conditional label element when prop not preset
- [x] Select - update conditional label element when prop not preset

Fixes #(issue)

#### Input 
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-03-04 at 1 18 01 PM](https://github.com/user-attachments/assets/9282692b-e9d0-432f-924f-47e9fee732d0)|![Screenshot 2025-03-04 at 1 16 59 PM](https://github.com/user-attachments/assets/7a25ed93-8a20-482d-9a87-2e3cdaea01e9)|

#### Select
|  Before  |  After  |
|--------|--------|
|![Screenshot 2025-03-04 at 1 10 50 PM](https://github.com/user-attachments/assets/ff39b94f-3a8a-4d74-9d5c-f44b037aeba8)|![Screenshot 2025-03-04 at 1 13 00 PM](https://github.com/user-attachments/assets/8abdf9f2-028c-44b0-ba10-9d7090249bfe)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit either the Input or Select page
- In the `Playground`, remove the `label`
- Inspect the element and verify that the empty `<label>` element is no longer present

`Textarea` already has this structure

- [x] unit tests
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
