### PR TITLE
feat: adds more font size values and adds italics and truncate to doc…

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -893,6 +893,10 @@ export namespace Components {
   | 'xs'
   | '2xs';
         /**
+          * If set or `true`, the text will be italic.
+         */
+        "italic"?: boolean;
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -901,7 +905,13 @@ export namespace Components {
   | 'md'
   | 'sm'
   | 'xs'
-  | '2xs';
+  | '2xs'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6';
         /**
           * Determines what semantic text tag to render.
          */
@@ -916,6 +926,10 @@ export namespace Components {
   | 'pre'
   | 'strong'
   | 'em';
+        /**
+          * If set or `true`, the text will be truncated. Must add a `width` to the element.
+         */
+        "truncate"?: boolean;
         /**
           * Sets the font weight.
          */
@@ -2449,6 +2463,10 @@ declare namespace LocalJSX {
   | 'xs'
   | '2xs';
         /**
+          * If set or `true`, the text will be italic.
+         */
+        "italic"?: boolean;
+        /**
           * Sets the font size.
          */
         "size"?: | '2xl'
@@ -2457,7 +2475,13 @@ declare namespace LocalJSX {
   | 'md'
   | 'sm'
   | 'xs'
-  | '2xs';
+  | '2xs'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6';
         /**
           * Determines what semantic text tag to render.
          */
@@ -2472,6 +2496,10 @@ declare namespace LocalJSX {
   | 'pre'
   | 'strong'
   | 'em';
+        /**
+          * If set or `true`, the text will be truncated. Must add a `width` to the element.
+         */
+        "truncate"?: boolean;
         /**
           * Sets the font weight.
          */

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -178,8 +178,8 @@ To truncate text, add the `truncate` attribute to the component. Text truncation
 
 <DocCanvas client:only
   mdxSource={{
-    react: `<PdsText tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
-    webComponent: `<pds-text tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
+    react: `<PdsText style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</PdsText>`,
+    webComponent: `<pds-text style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>`
 }}>
   <pds-text style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>

--- a/libs/core/src/components/pds-text/pds-text.scss
+++ b/libs/core/src/components/pds-text/pds-text.scss
@@ -15,42 +15,40 @@
   text-decoration: line-through;
 }
 
-// TODO: Update all values to match new semantic tokens, if applicable
-
 /* stylelint-disable */
 h1 {
   font: var(--pine-typography-heading-1);
-  letter-spacing: 0.26px;
+  letter-spacing: var(--pine-letter-spacing-heading-1);
 }
 
 h2 {
   font: var(--pine-typography-heading-2);
-  letter-spacing: 0.24px;
+  letter-spacing: var(--pine-letter-spacing-heading-2);
 }
 
 h3 {
   font: var(--pine-typography-heading-3);
-  letter-spacing: 0.22px;
+  letter-spacing: var(--pine-letter-spacing-heading-3);
 }
 
 h4 {
   font: var(--pine-typography-heading-4);
-  letter-spacing: 0.20px;
+  letter-spacing: var(--pine-letter-spacing-heading-4);
 }
 
 h5 {
   font: var(--pine-typography-heading-5);
-  letter-spacing: 0.18px;
+  letter-spacing: var(--pine-letter-spacing-heading-5);
 }
 
 h6 {
   font: var(--pine-typography-heading-6);
-  letter-spacing: 0.16px;
+  letter-spacing: var(--pine-letter-spacing-heading-6);
 }
 
 code, em, p, pre, strong {
   font: var(--pine-typography-body);
-  letter-spacing: -0.16px;
+  letter-spacing: var(--pine-letter-spacing-body);
 }
 /* stylelint-enable */
 
@@ -115,6 +113,12 @@ $type-sizes: (
   sm: var(--pine-font-size-body-sm),
   xs: var(--pine-font-size-body-xs),
   2xs: var(--pine-font-size-body-2xs),
+  h1: var(--pine-font-size-heading-1),
+  h2: var(--pine-font-size-heading-2),
+  h3: var(--pine-font-size-heading-3),
+  h4: var(--pine-font-size-heading-4),
+  h5: var(--pine-font-size-heading-5),
+  h6: var(--pine-font-size-heading-6),
 );
 
 @mixin generate-type-sizes($type-sizes) {

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -45,6 +45,11 @@ export class PdsText {
   | '2xs';
 
   /**
+   * If set or `true`, the text will be italic.
+   */
+  @Prop() italic?: boolean;
+
+  /**
    * Sets the font size.
    */
   @Prop() size?:
@@ -54,7 +59,13 @@ export class PdsText {
   | 'md'
   | 'sm'
   | 'xs'
-  | '2xs';
+  | '2xs'
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6';
 
   /**
    * Sets the font weight.
@@ -82,6 +93,11 @@ export class PdsText {
   | 'pre'
   | 'strong'
   | 'em' = "p";
+
+  /**
+   * If set or `true`, the text will be truncated. Must add a `width` to the element.
+   */
+  @Prop() truncate?: boolean;
 
   render() {
     const Tag = this.tag;

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -7,15 +7,17 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                  | Type                                                                                                | Default     |
-| ------------ | ------------ | -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| `align`      | `align`      | Sets the text alignment.                     | `"center" \| "end" \| "justify" \| "start"`                                                         | `undefined` |
-| `color`      | `color`      | Sets the text color.                         | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
-| `decoration` | `decoration` | Sets the text decoration.                    | `"strikethrough" \| "underline-dotted"`                                                             | `undefined` |
-| `gutter`     | `gutter`     | Set the bottom margin for the text.          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `size`       | `size`       | Sets the font size.                          | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                            | `undefined` |
-| `tag`        | `tag`        | Determines what semantic text tag to render. | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`        | `"p"`       |
-| `weight`     | `weight`     | Sets the font weight.                        | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                         | `undefined` |
+| Property     | Attribute    | Description                                                                      | Type                                                                                                     | Default     |
+| ------------ | ------------ | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ----------- |
+| `align`      | `align`      | Sets the text alignment.                                                         | `"center" \| "end" \| "justify" \| "start"`                                                              | `undefined` |
+| `color`      | `color`      | Sets the text color.                                                             | `"accent" \| "danger" \| "info" \| "neutral" \| "primary" \| "secondary" \| "success" \| "warning"`      | `undefined` |
+| `decoration` | `decoration` | Sets the text decoration.                                                        | `"strikethrough" \| "underline-dotted"`                                                                  | `undefined` |
+| `gutter`     | `gutter`     | Set the bottom margin for the text.                                              | `"2xl" \| "2xs" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"`                                                 | `undefined` |
+| `italic`     | `italic`     | If set or `true`, the text will be italic.                                       | `boolean`                                                                                                | `undefined` |
+| `size`       | `size`       | Sets the font size.                                                              | `"2xl" \| "2xs" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "lg" \| "md" \| "sm" \| "xl" \| "xs"` | `undefined` |
+| `tag`        | `tag`        | Determines what semantic text tag to render.                                     | `"code" \| "em" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p" \| "pre" \| "strong"`             | `"p"`       |
+| `truncate`   | `truncate`   | If set or `true`, the text will be truncated. Must add a `width` to the element. | `boolean`                                                                                                | `undefined` |
+| `weight`     | `weight`     | Sets the font weight.                                                            | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                              | `undefined` |
 
 
 ----------------------------------------------


### PR DESCRIPTION
# Description

Adds heading level font sizes to Text component. Also adds truncate and italic props to props table.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
