### PR TITLE
style: readds responsive image styling

### DIFF
--- a/libs/core/src/components/pds-image/pds-image.scss
+++ b/libs/core/src/components/pds-image/pds-image.scss
@@ -9,4 +9,7 @@
 
 img {
   aspect-ratio: var(--dimension-aspect-ratio);
+  display: block;
+  height: auto;
+  max-width: 100%;
 }


### PR DESCRIPTION
# Description
Re-adds responsive image styling that was removed in a previous commit. Image should now scale down with the viewport instead of overflowing.

Fixes #(issue)

## Type of change
Before:
<img width="547" alt="Screenshot 2025-03-21 at 3 57 15 PM" src="https://github.com/user-attachments/assets/79a76482-49d9-499e-98f5-82ffe936faf9" />

After:
<img width="495" alt="Screenshot 2025-03-21 at 3 57 06 PM" src="https://github.com/user-attachments/assets/efcabcb9-7916-4990-87a9-74b5e544eff0" />


- [x] Style (adds, updates, or removes component styling)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
