### PR TITLE
fix: fixes copytext icon alignment

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -154,6 +154,7 @@
 }
 
 .pds-button__text {
+  align-items: center;
   display: inline-flex;
 }
 


### PR DESCRIPTION
# Description
Fixes icon alignment for Copytext 

## Type of change
Before:
<img width="321" alt="Screenshot 2025-03-21 at 4 23 43 PM" src="https://github.com/user-attachments/assets/f6d06e0c-1c7f-4918-a4c0-dc0f7a5f3e4f" />

After:
<img width="321" alt="Screenshot 2025-03-21 at 4 08 02 PM" src="https://github.com/user-attachments/assets/599c1835-0ced-4a8d-871f-f9cacba59756" />

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
