### PR TITLE
fix: copy text hover and truncate adjustments

### DIFF
--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -191,6 +191,56 @@ The button submits the form data to the server.
 
 The button resets all the controls to their initial values. [As noted on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type), this behavior tends to annoy users.
 
+
+## Styling with CSS Parts
+
+The `pds-button` component provides CSS parts that allow for targeted customization. These parts should be used sparingly and only when the built-in props do not provide the necessary styling flexibility.
+
+### Important Considerations
+- **Encapsulation:** CSS parts allow direct styling of specific elements within the `pds-button` component, but **do not affect their child elements**. This ensures internal styles remain consistent and prevents unintended overrides.
+- **Best Practices:** Whenever possible, use props to modify the button's appearance. CSS parts should only be leveraged for advanced styling needs.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <style>
+    .custom-button::part(button-text) {
+      color: yellow;
+    }
+    .custom-button::part(button) {
+      background-color: #628b83;
+      border-color: #628b83;
+    }
+    </style>
+
+    <PdsButton className="custom-button" variant="primary">Button</PdsButton>
+    `,
+    webComponent: `
+    <style>
+    .custom-button::part(button-text) {
+      color: yellow;
+    }
+    .custom-button::part(button) {
+      background-color: #628b83;
+      border-color: #628b83;
+    }
+    </style>
+
+    <pds-button class="custom-button" variant="primary">Button</pds-button>
+    `
+}}>
+  <style dangerouslySetInnerHTML={{__html: `
+    .custom-button::part(button-text) {
+      color: yellow;
+    }
+    .custom-button::part(button) {
+      background-color: #628b83;
+      border-color: #628b83;
+    }
+  `}} />
+  <pds-button class="custom-button" variant="primary">Button</pds-button>
+</DocCanvas>
+
 ## Additional Resources
 
 [CSS Tricks: Buttons vs. Links](https://css-tricks.com/buttons-vs-links/)

--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -191,56 +191,6 @@ The button submits the form data to the server.
 
 The button resets all the controls to their initial values. [As noted on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type), this behavior tends to annoy users.
 
-
-## Styling with CSS Parts
-
-The `pds-button` component provides CSS parts that allow for targeted customization. These parts should be used sparingly and only when the built-in props do not provide the necessary styling flexibility.
-
-### Important Considerations
-- **Encapsulation:** CSS parts allow direct styling of specific elements within the `pds-button` component, but **do not affect their child elements**. This ensures internal styles remain consistent and prevents unintended overrides.
-- **Best Practices:** Whenever possible, use props to modify the button's appearance. CSS parts should only be leveraged for advanced styling needs.
-
-<DocCanvas client:only
-  mdxSource={{
-    react: `
-    <style>
-    .custom-button::part(button-text) {
-      color: yellow;
-    }
-    .custom-button::part(button) {
-      background-color: #628b83;
-      border-color: #628b83;
-    }
-    </style>
-
-    <PdsButton className="custom-button" variant="primary">Button</PdsButton>
-    `,
-    webComponent: `
-    <style>
-    .custom-button::part(button-text) {
-      color: yellow;
-    }
-    .custom-button::part(button) {
-      background-color: #628b83;
-      border-color: #628b83;
-    }
-    </style>
-
-    <pds-button class="custom-button" variant="primary">Button</pds-button>
-    `
-}}>
-  <style dangerouslySetInnerHTML={{__html: `
-    .custom-button::part(button-text) {
-      color: yellow;
-    }
-    .custom-button::part(button) {
-      background-color: #628b83;
-      border-color: #628b83;
-    }
-  `}} />
-  <pds-button class="custom-button" variant="primary">Button</pds-button>
-</DocCanvas>
-
 ## Additional Resources
 
 [CSS Tricks: Buttons vs. Links](https://css-tricks.com/buttons-vs-links/)

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -151,6 +151,7 @@
   align-items: center;
   display: inline-flex;
   position: relative;
+  width: 100%;
 }
 
 .pds-button__text {

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -5,6 +5,8 @@ import { caretDown } from '@pine-ds/icons/icons';
 
 /**
  * @part button - Exposes the button element for styling.
+ * @part button-content - Exposes the button content for styling.
+ * @part button-text - Exposes the button text for styling.
  * @part caret - Exposes the caret icon component for styling. Appears only on the disclosure variant.
  * @part icon - Exposes the icon component for styling.
 */
@@ -129,7 +131,7 @@ export class PdsButton {
           type={this.type}
           value={this.value}
         >
-          <div class="pds-button__content">
+          <div class="pds-button__content" part="button-content">
             {this.icon && this.variant !== 'disclosure' &&
               <pds-icon
                 class={this.loading ? 'pds-button__icon--hidden' : ''}
@@ -138,7 +140,7 @@ export class PdsButton {
               ></pds-icon>
             }
 
-            <span class={`pds-button__text ${this.loading ? 'pds-button__text--hidden' : ''}`}>
+            <span class={`pds-button__text ${this.loading ? 'pds-button__text--hidden' : ''}`} part="button-text">
               <slot />
             </span>
 

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -29,11 +29,13 @@
 
 ## Shadow Parts
 
-| Part       | Description                                                                           |
-| ---------- | ------------------------------------------------------------------------------------- |
-| `"button"` | Exposes the button element for styling.                                               |
-| `"caret"`  | Exposes the caret icon component for styling. Appears only on the disclosure variant. |
-| `"icon"`   | Exposes the icon component for styling.                                               |
+| Part               | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `"button"`         | Exposes the button element for styling.                                               |
+| `"button-content"` | Exposes the button content for styling.                                               |
+| `"button-text"`    | Exposes the button text for styling.                                                  |
+| `"caret"`          | Exposes the caret icon component for styling. Appears only on the disclosure variant. |
+| `"icon"`           | Exposes the icon component for styling.                                               |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -11,8 +11,8 @@ describe('pds-button', () => {
       <pds-button variant="primary">
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>
@@ -31,8 +31,8 @@ describe('pds-button', () => {
       <pds-button variant="accent">
         <mock:shadow-root>
           <button class="pds-button pds-button--accent" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>
@@ -51,8 +51,8 @@ describe('pds-button', () => {
       <pds-button variant="unstyled">
         <mock:shadow-root>
           <button class="pds-button pds-button--unstyled" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>
@@ -71,8 +71,8 @@ describe('pds-button', () => {
       <pds-button disabled="true" aria-disabled="true" variant="primary">
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button" disabled>
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>
@@ -92,8 +92,8 @@ describe('pds-button', () => {
       <pds-button component-id="test" id="test" variant="primary">
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>
@@ -122,8 +122,8 @@ describe('pds-button', () => {
       <pds-button loading="true" variant="primary">
         <mock:shadow-root>
           <button aria-busy="true" aria-live="polite" class="pds-button pds-button--primary pds-button--loading" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text pds-button__text--hidden">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
               <span class="pds-button__loader">
@@ -174,8 +174,8 @@ describe('pds-button', () => {
       <pds-button full-width="true" variant="primary">
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
-            <div class="pds-button__content">
-              <span class="pds-button__text">
+            <div class="pds-button__content" part="button-content">
+              <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
             </div>

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -51,9 +51,10 @@
     pds-button {
       padding: var(--pine-dimension-none);
 
-      &:hover {
-        background: none;
-      }
+    }
+
+    &::part(button):hover {
+      background-color: transparent;
     }
 
     span {
@@ -93,8 +94,15 @@
 
   &:host(.pds-copytext--truncated) {
     pds-button {
-      display: flex;
+      display: inline-flex;
+      min-width: auto;
       width: 100%;
+
+      &::part(button-content),
+      &::part(button-text) {
+        flex-shrink: 1;
+        width: 100%;
+      }
 
       span {
         overflow: hidden;


### PR DESCRIPTION
# Description

Updates copy text and button component to address hover and truncate issues with copy text. These issues came from recent markup structure changes to the button.

- Adds parts to the button
- Corrects copytext styling

> [!NOTE]  
> This PR does not include centering updates in #405 

Fixes https://kajabi.atlassian.net/browse/DSS-1335

### Screenshots
||  Before   |  After  |
|--------|--------|--------|
|Hover |![Screenshot 2025-03-24 at 11 40 43 AM](https://github.com/user-attachments/assets/960c08ee-304e-446c-9f70-0f5d3464b612)|![Screenshot 2025-03-24 at 11 38 56 AM](https://github.com/user-attachments/assets/f78f7962-7197-40fb-b470-e5c526d6bb3d)|
|Truncate |![Screenshot 2025-03-24 at 11 39 16 AM](https://github.com/user-attachments/assets/1e0c391c-6f96-4349-baee-0c5f1890db8f)|![Screenshot 2025-03-24 at 11 39 43 AM](https://github.com/user-attachments/assets/bc170a80-b738-451e-87ca-5da2008a5957)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. Navigate to copy text
2. Verify hover states now display properly
3. Verify that the truncation variant is working as expected

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
