### PR TITLE
fix(checkbox):  label-hidden prop is not hiding label text

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -131,7 +131,9 @@ export class PdsCheckbox {
             onChange={this.handleCheckboxChange}
             onInput={this.handleInput}
           />
-          {this.label}
+          <span class={this.labelHidden ? 'visually-hidden' : ''}>
+            {this.label}
+          </span>
         </label>
         {this.helperMessage &&
           <div

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -14,6 +14,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label>
             <input type="checkbox">
+            <span></span>
           </label>
         </mock:shadow-root>
       </pds-checkbox>
@@ -31,7 +32,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input type="checkbox" id="default">
-            Label text
+            <span>Label text</span>
           </label>
         </mock:shadow-root>
       </pds-checkbox>
@@ -69,7 +70,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input aria-invalid="true" type="checkbox" id="default">
-            Label text
+            <span>Label text</span>
           </label>
         </mock:shadow-root>
       </pds-checkbox>
@@ -87,7 +88,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input indeterminate="" type="checkbox" id="default">
-            Label text
+            <span>Label text</span>
           </label>
         </mock:shadow-root>
       </pds-checkbox>
@@ -105,7 +106,25 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input type="checkbox" id="default">
-            This is label text
+            <span>This is label text</span>
+          </label>
+        </mock:shadow-root>
+      </pds-checkbox>
+    `);
+  });
+
+  it('renders hidden label text when label-hidden prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsCheckbox],
+      html: `<pds-checkbox component-id="default" label="This is label text" label-hidden />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <pds-checkbox component-id="default" label="This is label text" label-hidden>
+        <mock:shadow-root>
+          <label htmlfor="default">
+            <input type="checkbox" id="default">
+            <span class="visually-hidden">This is label text</span>
           </label>
         </mock:shadow-root>
       </pds-checkbox>
@@ -123,7 +142,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input aria-describedby="default__helper-message" type="checkbox" id="default">
-            Label text
+            <span>Label text</span>
           </label>
           <div class="pds-checkbox__message" id="default__helper-message">This is short message text.</div>
         </mock:shadow-root>
@@ -142,7 +161,7 @@ describe('pds-checkbox', () => {
         <mock:shadow-root>
           <label htmlfor="default">
             <input aria-invalid="true" id="default" type="checkbox">
-            Label text
+            <span>Label text</span>
           </label>
           <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">
             <pds-icon icon="${danger}" size="small"></pds-icon>


### PR DESCRIPTION
# Description

he label is still displayed when setting label-hidden on a `pds-checkbox` (e.g., in a table).

Fixes https://kajabi.atlassian.net/browse/DSS-1336

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2025-03-24 at 1 11 57 PM](https://github.com/user-attachments/assets/e1a41d4b-63ed-457f-a361-84d632f8cfe5)|![Screenshot 2025-03-24 at 1 27 46 PM](https://github.com/user-attachments/assets/2dd95a96-49af-4a97-8b41-b1c50f2d43e7)|


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Navigate to checkbox
Verify toggling label-hidden shows/hides the label

Naviate to table
Verify checkboxes in head and rows no longer show label

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
