### PR TITLE
style: updates Table styling to match Figma design

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
@@ -1,14 +1,12 @@
 :host {
   --box-shadow-fixed: 3px 3px 6px -2px rgba(0, 0, 0, 0.2);
 
-  color: var(--pine-color-text);
+  border-block-end: var(--pine-border);
+  color: var(--pine-color-text-readonly);
   display: table-cell;
-  font-family: var(--pine-font-family-body);
-  font-size: var(--pine-font-size);
-  font-weight: var(--pine-font-weight-regular);
+  font: var(--pine-typography-body);
   letter-spacing: var(--pine-letter-spacing);
-  line-height: var(--pine-line-height-body);
-  padding: 12px;
+  padding: var(--pine-dimension-xs) var(--pine-dimension-150);
   vertical-align: inherit;
 }
 
@@ -37,5 +35,5 @@
 
 :host(.has-checkbox) {
   vertical-align: middle;
-  width: 16px;
+  width: var(--pine-dimension-sm);
 }

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
@@ -1,16 +1,12 @@
 :host {
-  --border-head-cell-default: var(--pine-border-width-thin) solid var(--pine-color-grey-100);
-
   --box-shadow-default: 3px 3px 6px -2px rgba(0, 0, 0, 0.1);
 
-  border-block-end: var(--border-head-cell-default);
-  color: var(--pine-color-text);
+  border-block-end: var(--pine-border);
+  color: var(--pine-color-text-secondary);
   display: table-cell;
-  font-family: var(--pine-font-family-body);
-  font-size: var(--pine-font-size);
-  font-weight: var(--pine-font-weight-regular);
-  line-height: var(--pine-line-height-body);
-  padding: 12px;
+  font: var(--pine-typography-body-medium);
+  letter-spacing: var(--pine-letter-spacing-body);
+  padding: var(--pine-dimension-150);
   text-align: start;
   vertical-align: inherit;
 }

--- a/libs/core/src/components/pds-table/pds-table-head/pds-table-head.scss
+++ b/libs/core/src/components/pds-table/pds-table-head/pds-table-head.scss
@@ -1,7 +1,6 @@
 :host {
-  --border-head-default: var(--pine-border-width-thin) solid var(--pine-color-grey-100);
-
   border-color: inherit;
+  border-radius: var(--pine-dimension-125);
   box-sizing: border-box;
   display: table-header-group;
   vertical-align: middle;
@@ -10,6 +9,7 @@
   // because it is in the ShadowDom
   &::part(checkbox-cell) {
     background-color: var(--pine-color-background-container);
+    border-top-left-radius: var(--pine-dimension-125);
     left: 0;
     position: sticky;
     z-index: 1;
@@ -17,5 +17,5 @@
 }
 
 :host pds-table-checkbox-cell {
-  border-block-end: var(--border-head-default);
+  border-block-end: var(--pine-border);
 }

--- a/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
+++ b/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
@@ -1,6 +1,4 @@
 :host {
-  --color-background-interactive: var(--pine-color-grey-200);
-
   border-color: inherit;
   display: table-row;
   vertical-align: inherit;
@@ -15,11 +13,39 @@
   }
 }
 
+:host ::slotted(pds-table-cell:first-child) {
+  color: var(--pine-color-text);
+  font: var(--pine-typography-body-brand-label);
+}
+
+:host(:last-child) {
+  ::slotted(pds-table-cell) {
+    border-block-end: var(--pine-border-none);
+  }
+
+  ::slotted(pds-table-cell:first-child) {
+    border-bottom-left-radius: var(--pine-dimension-125);
+  }
+
+  ::slotted(pds-table-cell:last-child) {
+    border-bottom-right-radius: var(--pine-dimension-125);
+  }
+
+  .has-checkbox {
+    border-block-end: var(--pine-border-none);
+    border-bottom-left-radius: var(--pine-dimension-125);
+
+    + ::slotted(pds-table-cell) {
+      border-bottom-left-radius: var(--pine-dimension-none);
+    }
+  }
+}
+
 :host(:hover),
 :host(:hover)::part(checkbox-cell),
 :host(:hover) ::slotted(pds-table-cell),
 :host(.is-selected),
 :host(.is-selected)::part(checkbox-cell),
 :host(.is-selected) ::slotted(pds-table-cell) {
-  background: var(--color-background-interactive);
+  background: var(--pine-color-background-container-hover);
 }

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -1,8 +1,9 @@
 :host {
-  --color-background-default: var(--pine-color-white);
-
-  background: var(--color-background-default);
+  background: var(--pine-color-background-container);
+  border: var(--pine-border);
   border-collapse: separate;
+  border-radius: var(--pine-dimension-125);
+  box-shadow: var(--pine-box-shadow);
   box-sizing: border-box;
   display: table;
   width: 100%;
@@ -17,8 +18,8 @@
 
 :host(.is-responsive) {
   background-attachment: local, local, scroll, scroll;
-  background-image: linear-gradient(to right, var(--color-background-default), var(--color-background-default)),
-                    linear-gradient(to right, var(--color-background-default), var(--color-background-default)),
+  background-image: linear-gradient(to right, var(--pine-color-background-container), var(--pine-color-background-container)),
+                    linear-gradient(to right, var(--pine-color-background-container), var(--pine-color-background-container)),
                     linear-gradient(to right, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0)),
                     linear-gradient(to left, rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0));
   background-position: left center, right center, left center, right center;


### PR DESCRIPTION
# Description
Updates Pine Table styles to match [Figma](https://www.figma.com/design/CC1YmaGKHnsvB28yLY9mEH/%E2%9D%96-Mercury-components?m=auto&node-id=2738-23243&t=fsnsGDagHflliGhg-1) component.

[DSS-1341](https://kajabi.atlassian.net/browse/DSS-1341)

## Type of change

- [x] Styles (adds, updates, or removes, component styles)

Before:
<img width="1054" alt="Screenshot 2025-03-26 at 11 33 02 AM" src="https://github.com/user-attachments/assets/8b767625-2698-4f13-8648-f330128ffbc5" />

After:
<img width="1065" alt="Screenshot 2025-03-26 at 11 32 45 AM" src="https://github.com/user-attachments/assets/8fb333c6-7d26-4f99-b21c-cc095daa9f05" />


# How Has This Been Tested?


- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1341]: https://kajabi.atlassian.net/browse/DSS-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ