### PR TITLE
fix(copytext): correct full-width styling and update docs

### DIFF
--- a/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
+++ b/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
@@ -52,7 +52,9 @@ When `full-width` is set to `true`, the component will occupy the full width of 
     react: '<PdsCopytext value="Copy all of this text" fullWidth></PdsCopytext>',
     webComponent: '<pds-copytext value="Copy all of this text" full-width></pds-copytext>'
 }}>
-  <pds-copytext value="Copy all of this text" full-width></pds-copytext>
+  <div style={{ width: '100%' }}>
+    <pds-copytext value="Copy all of this text" full-width></pds-copytext>
+  </div>
 </DocCanvas>
 
 ### Truncate

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -72,26 +72,8 @@
     }
   }
 
-  // full width
-
-  &:host(.pds-copytext--full-width) {
-    display: flex;
-    width: 100%;
-
-    pds-button {
-      display: flex;
-      justify-content: space-between;
-      width: 100%;
-
-      span {
-        text-align: left;
-        width: 100%;
-      }
-    }
-  }
-
-  // truncated
-
+  // full width and truncated
+  &:host(.pds-copytext--full-width),
   &:host(.pds-copytext--truncated) {
     pds-button {
       display: inline-flex;
@@ -105,11 +87,24 @@
       }
 
       span {
-        overflow: hidden;
         text-align: left;
-        text-overflow: ellipsis;
         width: 100%;
       }
+    }
+  }
+
+  // full width
+  &:host(.pds-copytext--full-width) {
+    pds-button {
+      justify-content: space-between;
+    }
+  }
+
+  // truncated
+  &:host(.pds-copytext--truncated) {
+    pds-button span {
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }


### PR DESCRIPTION
# Description

When setting the copy-text full-width prop to true, the component does not expand. This is due to the recent button markup refactor. 

Somehow, I missed this while fixing the truncation issue. 😭 

Fixes https://kajabi.atlassian.net/browse/DSS-1342

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2025-03-26 at 1 26 52 PM](https://github.com/user-attachments/assets/383bd061-7341-4f8f-8c70-624c29b2d418)|![Screenshot 2025-03-26 at 1 27 09 PM](https://github.com/user-attachments/assets/36b4b200-150a-4fab-bc84-909b349963c7)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. Navigate to [Copy Text](http://localhost:6006/?path=/docs/components-copy-text--docs)
2. Verify full-width prop works as expected
3. Verify full-width documentation section displays properly

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
