### PR TITLE
fix(button): add disabled styles to host

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -30,6 +30,10 @@
   pointer-events: none;
 }
 
+:host([disabled="true"]) {
+  pointer-events: none;
+}
+
 .pds-button {
   --pds-loader-color: var(--color-text-default);
   align-items: center;


### PR DESCRIPTION
# Description

Although `pds-button`s disabled styles are being applied to the native button in the shadow, but the host is able to receive clicks. Adding the styling to the host as well

Fixes [DSS-1340](https://kajabi.atlassian.net/browse/DSS-1340)

![Screenshot 2025-03-27 at 1 23 50 PM](https://github.com/user-attachments/assets/7f374024-379b-46d1-9eab-14027fc5d617)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Visit the `pds-button` view
- Scroll to the playground and add the `disabled` property
- Verify that `pointer-events: none` exists on the host

No tests: style only change

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1340]: https://kajabi.atlassian.net/browse/DSS-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ