### PR TITLE
style: updates component focus rings

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -3,12 +3,7 @@
 }
 
 details {
-
-  // TODO: Needs discussion
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --color-text-hover: var(--pine-color-text-secondary);
   --number-animation-transform-timing: 200ms;
-
 
   border-radius: var(--pine-dimension-xs);
 
@@ -61,9 +56,7 @@ summary {
   }
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
     position: relative;
   }
 

--- a/libs/core/src/components/pds-accordion/pds-accordion.scss
+++ b/libs/core/src/components/pds-accordion/pds-accordion.scss
@@ -56,7 +56,7 @@ summary {
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     position: relative;
   }
 

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -31,8 +31,6 @@ div {
 }
 
 .pds-avatar__button {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
-
   align-items: center;
   appearance: none;
   background: transparent;
@@ -43,9 +41,7 @@ div {
   padding: var(--pine-dimension-none);
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   }
 }
 

--- a/libs/core/src/components/pds-avatar/pds-avatar.scss
+++ b/libs/core/src/components/pds-avatar/pds-avatar.scss
@@ -41,7 +41,7 @@ div {
   padding: var(--pine-dimension-none);
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
   }
 }
 

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -59,11 +59,9 @@
   }
 
   &:focus-visible {
-    --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
     border-color: var(--color-border-focus);
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   &:disabled {
@@ -110,9 +108,7 @@
   --button-loader-color: var(--pine-color-text-primary);
 
   &:focus-visible {
-    --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-danger);
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline-color: var(--pine-color-focus-ring-danger);
   }
 }
 

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -60,7 +60,7 @@
 
   &:focus-visible {
     border-color: var(--color-border-focus);
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -120,7 +120,7 @@ input {
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
   }
 }
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -1,7 +1,4 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-invalid: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
   align-items: center;
   display: flex;
   flex-flow: row wrap;
@@ -21,9 +18,7 @@
     }
 
     &:focus-visible {
-      // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-      box-shadow: var(--box-shadow-focus-invalid); // Remove when outline radius is supported in Safari
-      outline: none;
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 
@@ -125,9 +120,7 @@ input {
   }
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   }
 }
 

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -116,7 +116,7 @@ $pds-chip-sentiment-hover: (
   padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 
@@ -146,7 +146,7 @@ $pds-chip-sentiment-hover: (
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
   }
 }
 

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -1,6 +1,4 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
-
   --sizing-close: var(--pine-dimension-125);
 
   align-items: center;
@@ -86,6 +84,11 @@ $pds-chip-sentiment-hover: (
   width: var(--pine-dimension-2xs);
 }
 
+.pds-chip__label {
+  align-items: center;
+  display: flex;
+}
+
 .pds-chip__label, .pds-chip__button {
   font: var(--pine-typography-body-medium);
   letter-spacing: var(--pine-letter-spacing);
@@ -94,6 +97,8 @@ $pds-chip-sentiment-hover: (
 // dropdown
 
 :host(.pds-chip--dropdown) {
+  padding: var(--pine-dimension-none);
+
   .pds-chip__dot {
     margin-block-end: calc(var(--pine-dimension-025) / 4);
     margin-block-start: var(--pine-dimension-025);
@@ -106,12 +111,13 @@ $pds-chip-sentiment-hover: (
   background: transparent;
   border: var(--pine-dimension-none);
   border-radius: var(--pine-dimension-sm);
+  cursor: pointer;
   display: flex;
-  padding: var(--pine-dimension-none);
+  padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
 
   &:focus-visible {
-    box-shadow: var(--box-shadow-focus);
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   pds-icon {
@@ -140,8 +146,7 @@ $pds-chip-sentiment-hover: (
   }
 
   &:focus-visible {
-    box-shadow: var(--box-shadow-focus);
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   }
 }
 
@@ -155,4 +160,8 @@ $pds-chip-sentiment-hover: (
     font: var(--pine-typography-heading-6);
     letter-spacing: var(--pine-letter-spacing-heading-6);
   }
+}
+
+:host(.pds-chip--large):has(.pds-chip__button) {
+  padding: var(--pine-dimension-none);
 }

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -1,8 +1,4 @@
 :host(.pds-copytext) {
-
-
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-
   // Update custom prop usage in Button before changing
   --copytext-color-background-hover: var(--pine-color-grey-200);
 

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -103,14 +103,14 @@ A `helper-message` is used to provide additional information about how to comple
 
 ### Invalid
 
-When `error-message` is present, the input displays the error message and provides a visual treatment.
+When `invalid` is true, the input displays the error message and provides a visual treatment.
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<PdsInput componentId="pds-input-error-example" label="Email address" type="email" errorMessage="Please provide a valid email address" value="Frank Dux"></PdsInput>',
-    webComponent: '<pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>'
+    react: '<PdsInput componentId="pds-input-error-example" label="Email address" type="email" errorMessage="Please provide a valid email address" value="Frank Dux" invalid></PdsInput>',
+    webComponent: '<pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux" invalid></pds-input>'
 }}>
-  <pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux"></pds-input>
+  <pds-input component-id="pds-input-error-example" label="Email address" type="email" error-message="Please provide a valid email address" value="Frank Dux" invalid></pds-input>
 </DocCanvas>
 
 ## References

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -1,7 +1,4 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
   display: inline;
 }
 
@@ -65,8 +62,8 @@
 
   &:focus-visible {
     border-color: var(--pine-color-border-active);
-    box-shadow: var(--box-shadow-focus);
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   /* stylelint-disable */
@@ -92,7 +89,7 @@
     border-color: var(--pine-color-border-danger);
 
     &:focus-visible {
-      box-shadow: var(--box-shadow-focus-error);
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 }

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -62,7 +62,7 @@
 
   &:focus-visible {
     border-color: var(--pine-color-border-active);
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -14,7 +14,7 @@
 
   &:focus-visible {
     border-radius: var(--pine-dimension-2xs);
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width-thick);
     position: relative;
   }

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -1,7 +1,4 @@
 :host {
-
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-
   display: inline;
 
   pds-icon {
@@ -16,9 +13,9 @@
   font-weight: var(--pine-font-weight-medium);
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    border-radius: var(--pine-dimension-2xs);
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width-thick);
     position: relative;
   }
 }

--- a/libs/core/src/components/pds-popover/pds-popover.scss
+++ b/libs/core/src/components/pds-popover/pds-popover.scss
@@ -28,7 +28,7 @@
     padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
 
     &:focus-visible {
-      outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+      outline: var(--pine-outline-focus);
       outline-offset: var(--pine-border-width);
     }
 

--- a/libs/core/src/components/pds-popover/pds-popover.scss
+++ b/libs/core/src/components/pds-popover/pds-popover.scss
@@ -27,6 +27,11 @@
     min-height: 40px;
     padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
 
+    &:focus-visible {
+      outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+      outline-offset: var(--pine-border-width);
+    }
+
     &:hover {
       background-color: var(--pine-color-secondary-hover);
     }

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -1,7 +1,4 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
   --sizing-check-size: 6px;
   --sizing-input-size: var(--pine-dimension-sm);
   --sizing-margin-block-start: 6px;
@@ -25,8 +22,7 @@
     }
 
     &:focus-visible {
-      box-shadow: var(--box-shadow-focus-error);
-      outline: none;
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 
@@ -100,8 +96,7 @@ input {
   }
 
   &:focus-visible {
-    box-shadow: var(--box-shadow-focus);
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
   }
 
 }

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -96,7 +96,7 @@ input {
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
   }
 
 }

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -42,7 +42,7 @@ select {
 
   &:focus-visible {
     border-color: var(--pine-color-border-active);
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -1,7 +1,4 @@
 :host {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
   .hidden,
   :host([hidden]) {
     display: none;
@@ -45,8 +42,8 @@ select {
 
   &:focus-visible {
     border-color: var(--pine-color-border-active);
-    box-shadow: var(--box-shadow-focus);
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   &:disabled {
@@ -61,8 +58,7 @@ select {
     border-color: var(--pine-color-border-danger);
 
     &:focus-visible {
-      box-shadow: var(--box-shadow-focus-error);
-      outline: none;
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 }
@@ -73,8 +69,7 @@ select {
     border-color: var(--pine-color-border-danger);
 
     &:focus-visible {
-      box-shadow: var(--box-shadow-focus-error);
-      outline: none;
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 }

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
@@ -1,6 +1,4 @@
 :host(.pds-sortable-item) {
-  --box-shadow: var(--pine-box-shadow-400);
-
   align-items: center;
   display: flex;
   padding-block: var(--pine-dimension-xs);
@@ -61,7 +59,7 @@
 :host(.pds-sortable-item--drag) {
   background-color: var(--pine-color-background-container);
   border-radius: 0;
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--pine-box-shadow-400);
   opacity: 1;
 }
 

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -1,9 +1,5 @@
 :host {
-
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
-  // Need discussions
+// Need discussions
   --sizing-input-toggle-size: calc(var(--pine-dimension-250) - (var(--pine-dimension-025) * 2));
   --pine-dimension-025: 2px;
   --spacing-message-inline: calc(var(--pine-dimension-450) + var(--pine-dimension-150));
@@ -26,7 +22,7 @@
   }
 
   input:focus-visible:not(:disabled):not(:checked) {
-    box-shadow: var(--box-shadow-focus-error);
+    outline-color: var(--pine-color-focus-ring-danger);
   }
 
   label {
@@ -123,8 +119,8 @@ input:hover:not(:disabled) {
 
  // Focus state
 input:focus-visible:not(:disabled) {
-  box-shadow: var(--box-shadow-focus);
-  outline: none;
+  outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+  outline-offset: var(--pine-border-width);
 }
 
 // 'Checked' state

--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -119,7 +119,7 @@ input:hover:not(:disabled) {
 
  // Focus state
 input:focus-visible:not(:disabled) {
-  outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+  outline: var(--pine-outline-focus);
   outline-offset: var(--pine-border-width);
 }
 

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -9,7 +9,7 @@
 }
 
 :host(:focus-visible) {
-  outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+  outline: var(--pine-outline-focus);
 }
 
 :host(.is-responsive) {

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -9,10 +9,7 @@
 }
 
 :host(:focus-visible) {
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
-  // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-  box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-  outline: none;
+  outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
 }
 
 :host(.is-responsive) {

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -46,7 +46,7 @@ pds-tab {
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 
@@ -202,7 +202,7 @@ pds-tab {
 
       &:focus-visible {
         border-color: var(--color-border-focus);
-        outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+        outline: var(--pine-outline-focus);
         outline-offset: var(--pine-border-width);
       }
 

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -1,9 +1,4 @@
 pds-tab {
-
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-
-  --outline: 4px solid var(--pine-color-focus-ring);
-
   align-items: center;
   display: inline-flex;
   position: relative;
@@ -51,9 +46,8 @@ pds-tab {
   }
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   .pds-tab__content {
@@ -207,11 +201,9 @@ pds-tab {
       z-index: 1;
 
       &:focus-visible {
-        --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-purple-300);
         border-color: var(--color-border-focus);
-        // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-        box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-        outline: none;
+        outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+        outline-offset: var(--pine-border-width);
       }
 
       /* stylelint-disable max-nesting-depth */

--- a/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
@@ -8,7 +8,7 @@
   padding: var(--tabs-dimension-panel-padding);
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 

--- a/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
@@ -7,6 +7,11 @@
   margin-top: var(--tabs-dimension-panel-margin-top);
   padding: var(--tabs-dimension-panel-padding);
 
+  &:focus-visible {
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
+  }
+
   &.is-active {
     display: block;
   }

--- a/libs/core/src/components/pds-tabs/pds-tabs.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabs.scss
@@ -8,8 +8,6 @@
    */
   --tabs-dimension-panel-padding: 0;
 
-  --outline: 2px solid var(--pine-color-focus-ring);
-
   display: block;
 }
 

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -1,8 +1,4 @@
 :host {
-
-  --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
-  --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
-
   display: inline;
 }
 
@@ -42,9 +38,8 @@ label {
   }
 
   &:focus-visible {
-    // outline: var(--pine-border-focus); Border radius for outline does not work in Safari
-    box-shadow: var(--box-shadow-focus); // Remove when outline radius is supported in Safari
-    outline: none;
+    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline-offset: var(--pine-border-width);
   }
 
   &::placeholder {
@@ -56,7 +51,7 @@ label {
     border-color: var(--pine-color-border-danger);
 
     &:focus-visible {
-      box-shadow: var(--box-shadow-focus-error);
+      outline-color: var(--pine-color-focus-ring-danger);
     }
   }
 }

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -38,7 +38,7 @@ label {
   }
 
   &:focus-visible {
-    outline: var(--pine-border-width-thick) solid var(--pine-color-focus-ring);
+    outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
 

--- a/libs/core/src/global/styles/tokens/base/semantic.json
+++ b/libs/core/src/global/styles/tokens/base/semantic.json
@@ -786,5 +786,27 @@
       "value": "{font-family.inter}",
       "type": "fontFamilies"
     }
+  },
+  "outline": {
+    "focus": {
+      "@": {
+        "value": {
+          "width": "{border-width.thick}",
+          "style": "solid",
+          "color": "{color.focus-ring.@}"
+        },
+        "type": "border",
+        "description": "Default focus ring"
+      },
+      "danger": {
+        "value": {
+          "color": "{color.focus-ring.danger}",
+          "style": "solid",
+          "width": "{border-width.thick}"
+        },
+        "type": "border",
+        "description": "Focus ring for danger/invalid states"
+      }
+    }
   }
 }

--- a/libs/core/src/global/styles/tokens/brand/kajabi_products/styles/semantic.scss
+++ b/libs/core/src/global/styles/tokens/brand/kajabi_products/styles/semantic.scss
@@ -146,4 +146,6 @@
   --pine-typography-body-sm-bold: 700 12px/1.425 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-typography-body-sm-brand-label: 500 12px/1.425 'Greet Standard', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif; /* brand-label */
   --pine-typography-body-sm-brand-text: 500 12px/1.425 'FAIRE Sprig'; /* brand-text */
+  --pine-outline-focus: 2px solid #a4acfd; /* Default focus ring */
+  --pine-outline-focus-danger: 2px solid #fca5a5; /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/stories/tokens/semantic/border.docs.mdx
+++ b/libs/core/src/stories/tokens/semantic/border.docs.mdx
@@ -16,3 +16,7 @@ import {DocTokenTable} from '@pine-ds/doc-components';
 ## Radius
 
 <DocTokenTable category="border-radius" tier="semantic" />
+
+## Outline
+
+<DocTokenTable category="outline" tier="semantic" />

--- a/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
+++ b/libs/doc-components/src/components/docTokenTable/docTokenTable.tsx
@@ -55,6 +55,7 @@ const applyStyle = (category: string, value: string, use?: string): React.CSSPro
     'font-weight': (val) => style.fontWeight = transformVal(val),
     'letter-spacing': (val) => style.letterSpacing = transformVal(val),
     'line-height': (val) => style.lineHeight = transformVal(val),
+    'outline': (val) => style.outline = transformVal(val),
     'typography': (val) => style.font = transformVal(val),
   };
 
@@ -128,6 +129,11 @@ const DocTokenTable: React.FC<DocTokenTableProps> = ({ category, tier, use }) =>
 
       if (formattedCategoryName[token.type as keyof typeof formattedCategoryName]) {
         label = formattedCategoryName[token.type as keyof typeof formattedCategoryName];
+      }
+
+      // Rule for outline tokens since they are best handled as borders in Tokens Studio
+      if (category === 'outline') {
+        label = category;
       }
 
       const cssVariableName = `--pine-${camelToKebab(label as string)}-${tokenKeyName}`.replace(/-@/g, '');


### PR DESCRIPTION
# Description
Updates component focus rings to use `outline` over `box-shadow`. Previously, box shadows were used because of limitations with some browsers not allowing the outline to respect an element's border-radius. The border-radius bug for outlines was fixed in [Safari Tech Preview 157.](https://webkit.org/blog/13575/release-notes-for-safari-technology-preview-157/).

Additionally, box shadows **do not work** in Windows High Contrast mode, while outlines do, providing a slight improvement to accessibility.

Specific component callouts:

**Chip**
- Includes extra styling fixes here to better accommodate focus state for the Dropdown variant

**Input**
- Updates `invalid` docs verbiage to reflect style changes on error

This PR also adds semantic tokens for outlines:
- `--pine-outline-focus`
- `--pine-outline-focus-danger`

...and adds them to the tokens table under Borders. There is no outline category in Tokens Studio.


## Type of change
- [x] Style (adds, updates, or removes component styling)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS: Mac, Windows
- Browsers: Chrome 133 (MacOS), Chrome 134 (Windows 11, Browserstack) Firefox 136 (MacOS), Safari 17.6 (MacOS)
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
