### PR TITLE
fix(textarea): add hide label prop

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1002,6 +1002,10 @@ export namespace Components {
          */
         "helperMessage"?: string;
         /**
+          * Visually hides the label text for instances where only the textarea should be displayed. Label remains accessible to assistive technology such as screen readers.
+         */
+        "hideLabel"?: boolean;
+        /**
           * Determines whether or not the textarea is invalid or throws an error.
           * @defaultValue false
          */
@@ -2606,6 +2610,10 @@ declare namespace LocalJSX {
           * Displays a message or hint below the textarea field.
          */
         "helperMessage"?: string;
+        /**
+          * Visually hides the label text for instances where only the textarea should be displayed. Label remains accessible to assistive technology such as screen readers.
+         */
+        "hideLabel"?: boolean;
         /**
           * Determines whether or not the textarea is invalid or throws an error.
           * @defaultValue false

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -61,6 +61,19 @@ label {
   }
 }
 
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: polygon(0 0, 0 0, 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .pds-textarea__error-message,
 .pds-textarea__helper-message {
   font: var(--pine-typography-body-sm-medium);

--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -88,6 +88,11 @@ export class PdsTextarea {
   @Prop() errorMessage?: string;
 
   /**
+   * Visually hides the label text for instances where only the textarea should be displayed. Label remains accessible to assistive technology such as screen readers.
+   */
+  @Prop() hideLabel?: boolean;
+
+  /**
    * Displays a message or hint below the textarea field.
    */
   @Prop() helperMessage?: string;
@@ -248,7 +253,11 @@ export class PdsTextarea {
       >
         <div class="pds-textarea">
           {this.label &&
-            <label htmlFor={this.componentId}>{this.label}</label>
+            <label htmlFor={this.componentId}>
+              <span class={this.hideLabel ? 'visually-hidden' : ''}>
+                {this.label}
+              </span>
+            </label>
           }
           <textarea
             ref={(el) => this.nativeTextarea = el }

--- a/libs/core/src/components/pds-textarea/readme.md
+++ b/libs/core/src/components/pds-textarea/readme.md
@@ -7,22 +7,23 @@
 
 ## Properties
 
-| Property                   | Attribute        | Description                                                                                          | Type      | Default            |
-| -------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------- | --------- | ------------------ |
-| `autocomplete`             | `autocomplete`   | Specifies if and how the browser provides `autocomplete` assistance for the field.                   | `string`  | `undefined`        |
-| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                                | `string`  | `undefined`        |
-| `debounce`                 | `debounce`       | The amount of time, in milliseconds, to wait to trigger the event after each keystroke.              | `number`  | `undefined`        |
-| `disabled`                 | `disabled`       | Determines whether or not the textarea is disabled.                                                  | `boolean` | `false`            |
-| `errorMessage`             | `error-message`  | Displays an error message below the textarea field.                                                  | `string`  | `undefined`        |
-| `helperMessage`            | `helper-message` | Displays a message or hint below the textarea field.                                                 | `string`  | `undefined`        |
-| `invalid`                  | `invalid`        | Determines whether or not the textarea is invalid or throws an error.                                | `boolean` | `false`            |
-| `label`                    | `label`          | Text to be displayed as the textarea label.                                                          | `string`  | `undefined`        |
-| `name`                     | `name`           | Specifies the name. Submitted with the form name/value pair. This value will mirror the componentId. | `string`  | `this.componentId` |
-| `placeholder`              | `placeholder`    | Specifies a short hint that describes the expected value of the textarea.                            | `string`  | `undefined`        |
-| `readonly`                 | `readonly`       | Determines whether or not the textarea is readonly.                                                  | `boolean` | `false`            |
-| `required`                 | `required`       | Determines whether or not the textarea is required.                                                  | `boolean` | `false`            |
-| `rows`                     | `rows`           | Sets number of rows of text visible without needing to scroll in the textarea.                       | `number`  | `undefined`        |
-| `value`                    | `value`          | The value of the textarea.                                                                           | `string`  | `''`               |
+| Property                   | Attribute        | Description                                                                                                                                                       | Type      | Default            |
+| -------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------ |
+| `autocomplete`             | `autocomplete`   | Specifies if and how the browser provides `autocomplete` assistance for the field.                                                                                | `string`  | `undefined`        |
+| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                                                                                             | `string`  | `undefined`        |
+| `debounce`                 | `debounce`       | The amount of time, in milliseconds, to wait to trigger the event after each keystroke.                                                                           | `number`  | `undefined`        |
+| `disabled`                 | `disabled`       | Determines whether or not the textarea is disabled.                                                                                                               | `boolean` | `false`            |
+| `errorMessage`             | `error-message`  | Displays an error message below the textarea field.                                                                                                               | `string`  | `undefined`        |
+| `helperMessage`            | `helper-message` | Displays a message or hint below the textarea field.                                                                                                              | `string`  | `undefined`        |
+| `hideLabel`                | `hide-label`     | Visually hides the label text for instances where only the textarea should be displayed. Label remains accessible to assistive technology such as screen readers. | `boolean` | `undefined`        |
+| `invalid`                  | `invalid`        | Determines whether or not the textarea is invalid or throws an error.                                                                                             | `boolean` | `false`            |
+| `label`                    | `label`          | Text to be displayed as the textarea label.                                                                                                                       | `string`  | `undefined`        |
+| `name`                     | `name`           | Specifies the name. Submitted with the form name/value pair. This value will mirror the componentId.                                                              | `string`  | `this.componentId` |
+| `placeholder`              | `placeholder`    | Specifies a short hint that describes the expected value of the textarea.                                                                                         | `string`  | `undefined`        |
+| `readonly`                 | `readonly`       | Determines whether or not the textarea is readonly.                                                                                                               | `boolean` | `false`            |
+| `required`                 | `required`       | Determines whether or not the textarea is required.                                                                                                               | `boolean` | `false`            |
+| `rows`                     | `rows`           | Sets number of rows of text visible without needing to scroll in the textarea.                                                                                    | `number`  | `undefined`        |
+| `value`                    | `value`          | The value of the textarea.                                                                                                                                        | `string`  | `''`               |
 
 
 ## Events

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
@@ -10,6 +10,7 @@ export default {
     debounce: null,
     disabled: false,
     errorMessage: null,
+    hideLabel: false,
     helperMessage: null,
     invalid: false,
     label: null,
@@ -41,6 +42,7 @@ const BaseTemplate = (args) => html`<pds-textarea
   component-id="${args.componentId}"
   disabled="${args.disabled}"
   error-message="${args.errorMessage}"
+  hide-label="${args.hideLabel}"
   helper-message="${args.helperMessage}"
   invalid="${args.invalid}"
   label="${args.label}"

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -103,7 +103,25 @@ describe('pds-textarea', () => {
       <pds-textarea label="label">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label>label</label>
+            <label><span>label</span></label>
+            <textarea class="pds-textarea__field"></textarea>
+          </div>
+        </mock:shadow-root>
+      </pds-textarea>
+    `);
+  });
+
+  it('renders hidden label text when hide-label prop is set', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsTextarea],
+      html: `<pds-textarea label="label" hide-label />`,
+    });
+
+    expect(root).toEqualHtml(`
+      <pds-textarea label="label" hide-label>
+        <mock:shadow-root>
+          <div class="pds-textarea">
+            <label><span class="visually-hidden">label</span></label>
             <textarea class="pds-textarea__field"></textarea>
           </div>
         </mock:shadow-root>
@@ -189,7 +207,7 @@ describe('pds-textarea', () => {
       <pds-textarea component-id="pds-textarea-id" label="label">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label htmlFor="pds-textarea-id">label</label>
+            <label htmlFor="pds-textarea-id"><span>label</span></label>
             <textarea class="pds-textarea__field" id="pds-textarea-id" name="pds-textarea-id"></textarea>
           </div>
         </mock:shadow-root>
@@ -249,7 +267,7 @@ describe('pds-textarea', () => {
       <pds-textarea component-id="textarea-with-description" label="Textarea with description" helper-message="This is a helper message" error-message="This is an error message" invalid="true">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label htmlFor="textarea-with-description">Textarea with description</label>
+            <label htmlFor="textarea-with-description"><span>Textarea with description</span></label>
             <textarea aria-describedby="textarea-with-description__error-message" aria-invalid="true"  class="is-invalid pds-textarea__field" id="textarea-with-description" name="textarea-with-description"></textarea>
             <p id="textarea-with-description__helper-message"  class="pds-textarea__helper-message">
               This is a helper message


### PR DESCRIPTION
# Description
This PR is create to bring form elements in alignment with the hideLabel prop

- [x] add `hideLabel` prop

Fixes N/A

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visit Textarea view
In the Playground, toggle the `hideLabel` prop and verify

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1338]: https://kajabi.atlassian.net/browse/DSS-1338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ