### PR TITLE
style(switch): resolve error message icon alignment and parent overflow

### DIFF
--- a/libs/core/src/components/pds-switch/pds-switch.scss
+++ b/libs/core/src/components/pds-switch/pds-switch.scss
@@ -93,10 +93,10 @@ label {
 // Help and error messages
 .pds-switch__message {
   color: var(--pine-color-text-message);
-  flex: 1 0 100%;
   font: var(--pine-typography-body-sm-medium);
   margin-block-start: var(--pine-dimension-xs);
   margin-inline-start: var(--spacing-message-inline);
+  width: 100%;
 
   + .pds-switch__message {
     margin-block-start: var(--spacing-message-inline);
@@ -104,10 +104,13 @@ label {
 }
 
 .pds-switch__message--error {
-  align-items: center;
   color: inherit;
   display: flex;
   gap: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-025);
+  }
 }
 
 // Disabled state


### PR DESCRIPTION
# Description

- [x] Resolve error message icon misalignment when text wraps
- [x] Resolve error message text breaking out of the parent box

|  Before  |  After  |
|--------|--------|
|<img width="361" alt="Screenshot 2025-04-02 at 10 24 49 AM" src="https://github.com/user-attachments/assets/e03d8727-59b3-44b7-8008-07cf32bd8fdb" />|<img width="360" alt="Screenshot 2025-04-02 at 11 04 38 AM" src="https://github.com/user-attachments/assets/4d2b0501-43d4-4263-a127-0af3866fbc1c" />|

Fixes [DSS-1347](https://kajabi.atlassian.net/browse/DSS-1347)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visit the Switch view
In the Error message variant, add enough text for the line to wrap
Verify icon alignment

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1347]: https://kajabi.atlassian.net/browse/DSS-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ