### PR TITLE
style(typography): adds Noto font family for language support

### DIFF
--- a/libs/core/src/global/styles/_fonts.scss
+++ b/libs/core/src/global/styles/_fonts.scss
@@ -25,6 +25,21 @@ $sage-sprig-font-path: "#{$sage-font-cdn-root}/sprig" !default; // pathname of f
 $sprig-file-name: "FAIRE-Sprig";
 $sprig-font-family-name: "FAIRE Sprig";
 
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-arabic-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-arabic-file-name: "Noto-Sans-Arabic";
+$noto-arabic-font-family-name: "Noto Sans Arabic";
+
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-hebrew-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-hebrew-file-name: "Noto-Sans-Hebrew";
+$noto-hebrew-font-family-name: "Noto Sans Hebrew";
+
+/* stylelint-disable-next-line annotation-no-unknown */
+$sage-noto-devanagari-font-path: "#{$sage-font-cdn-root}/noto" !default; // pathname of font directory
+$noto-devanagari-file-name: "Noto-Sans-Devanagari";
+$noto-devanagari-font-family-name: "Noto Sans Devanagari";
+
 // Light
 @font-face {
   font-display: swap;
@@ -591,4 +606,34 @@ $sprig-font-family-name: "FAIRE Sprig";
   font-weight: 900;
   src: local("#{$sprig-file-name}-SuperItalic"),
     url("#{$sage-sprig-font-path}/#{$sprig-file-name}-SuperItalic.woff2?v=#{$body-font-version}") format("woff2");
+}
+
+// Arabic font (Noto Sans Arabic)
+@font-face {
+  font-display: swap;
+  font-family: "#{$noto-arabic-font-family-name}";
+  font-style: normal;
+  font-weight: normal;
+  src: local("#{$noto-arabic-file-name}"),
+    url("#{$sage-noto-arabic-font-path}/#{$noto-arabic-file-name}.woff2?v=#{$body-font-version}") format("woff2");
+}
+
+// Hebrew font (Noto Sans Hebrew)
+@font-face {
+  font-display: swap;
+  font-family: "#{$noto-hebrew-font-family-name}";
+  font-style: normal;
+  font-weight: normal;
+  src: local("#{$noto-hebrew-file-name}"),
+    url("#{$sage-noto-hebrew-font-path}/#{$noto-hebrew-file-name}.woff2?v=#{$body-font-version}") format("woff2");
+}
+
+// Devanagari font (Noto Sans Devanagari)
+@font-face {
+  font-display: swap;
+  font-family: "#{$noto-devanagari-font-family-name}";
+  font-style: normal;
+  font-weight: normal;
+  src: local("#{$noto-devanagari-file-name}"),
+    url("#{$sage-noto-devanagari-font-path}/#{$noto-devanagari-file-name}.woff2?v=#{$body-font-version}") format("woff2");
 }

--- a/libs/core/src/global/styles/tokens/_output/base/_core.scss
+++ b/libs/core/src/global/styles/tokens/_output/base/_core.scss
@@ -187,6 +187,9 @@
   --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
+  --pine-font-family-noto-arabic: 'Noto Sans Arabic', Cairo, Amiri, tahoma, arial, system-ui, sans-serif;
+  --pine-font-family-noto-hebrew: 'Noto Sans Hebrew', 'Arial Hebrew', Rubik, 'Frank Ruehl', tahoma, system-ui, sans-serif;
+  --pine-font-family-noto-devanagari: 'Noto Sans Devanagari', Mangal, Kokila, 'Lohit Devanagari', Sahadeva, tahoma, system-ui, sans-serif;
   --pine-font-size-100: 14px;
   --pine-font-size-116: 16px;
   --pine-font-size-128: 18px;

--- a/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
+++ b/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
@@ -126,26 +126,26 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
-  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
+  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
+++ b/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
@@ -141,7 +141,7 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);

--- a/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
+++ b/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
@@ -147,6 +147,6 @@
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
+++ b/libs/core/src/global/styles/tokens/_output/base/_semantic.scss
@@ -80,6 +80,7 @@
   --pine-color-brand: var(--pine-color-black);
   --pine-font-family-heading: var(--pine-font-family-greet);
   --pine-font-family-body: var(--pine-font-family-inter);
+  --pine-font-family-brand-text: var(--pine-font-family-faire-sprig);
   --pine-font-size: var(--pine-font-size-100);
   --pine-font-size-body-2xs: var(--pine-font-size-057);
   --pine-font-size-body-xs: var(--pine-font-size-071);
@@ -126,7 +127,6 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
@@ -142,6 +142,7 @@
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;

--- a/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
+++ b/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
@@ -334,6 +334,7 @@
   --pine-color-brand: var(--pine-color-black);
   --pine-font-family-heading: var(--pine-font-family-greet);
   --pine-font-family-body: var(--pine-font-family-inter);
+  --pine-font-family-brand-text: var(--pine-font-family-faire-sprig);
   --pine-font-size: var(--pine-font-size-100);
   --pine-font-size-body-2xs: var(--pine-font-size-057);
   --pine-font-size-body-xs: var(--pine-font-size-071);
@@ -380,7 +381,6 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
@@ -396,6 +396,7 @@
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;

--- a/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
+++ b/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
@@ -401,6 +401,6 @@
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
+++ b/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
@@ -187,6 +187,9 @@
   --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
+  --pine-font-family-noto-arabic: 'Noto Sans Arabic', Cairo, Amiri, tahoma, arial, system-ui, sans-serif;
+  --pine-font-family-noto-hebrew: 'Noto Sans Hebrew', 'Arial Hebrew', Rubik, 'Frank Ruehl', tahoma, system-ui, sans-serif;
+  --pine-font-family-noto-devanagari: 'Noto Sans Devanagari', Mangal, Kokila, 'Lohit Devanagari', Sahadeva, tahoma, system-ui, sans-serif;
   --pine-font-size-100: 14px;
   --pine-font-size-116: 16px;
   --pine-font-size-128: 18px;
@@ -377,26 +380,26 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
-  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
+  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
+++ b/libs/core/src/global/styles/tokens/_output/default/styles/default.scss
@@ -395,7 +395,7 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);

--- a/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
+++ b/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
@@ -401,6 +401,6 @@
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
   --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
+++ b/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
@@ -187,6 +187,9 @@
   --pine-font-family-greet-condensed: 'Greet Condensed', 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-inter: 'Inter', system-ui, 'Segoe UI', 'Roboto', 'Ubuntu', sans-serif;
   --pine-font-family-faire-sprig: 'FAIRE Sprig';
+  --pine-font-family-noto-arabic: 'Noto Sans Arabic', Cairo, Amiri, tahoma, arial, system-ui, sans-serif;
+  --pine-font-family-noto-hebrew: 'Noto Sans Hebrew', 'Arial Hebrew', Rubik, 'Frank Ruehl', tahoma, system-ui, sans-serif;
+  --pine-font-family-noto-devanagari: 'Noto Sans Devanagari', Mangal, Kokila, 'Lohit Devanagari', Sahadeva, tahoma, system-ui, sans-serif;
   --pine-font-size-100: 14px;
   --pine-font-size-116: 16px;
   --pine-font-size-128: 18px;
@@ -377,26 +380,26 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-greet);
-  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
-  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
-  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-greet); /* brand-label */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
+  --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-2: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-2)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-3: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-3)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-4: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-4)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-5: var(--pine-font-weight-medium) var(--pine-font-size-heading-5)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-6: var(--pine-font-weight-medium) var(--pine-font-size-heading-6)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-heading-caption: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-caption)/var(--pine-line-height-heading) var(--pine-font-family-heading);
+  --pine-typography-body: var(--pine-font-weight-regular) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;
+  --pine-typography-body-sm-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
+  --pine-typography-body-sm-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
   --pine-outline-focus-danger: var(--pine-border-width-thick) solid var(--pine-color-focus-ring-danger); /* Focus ring for danger/invalid states */
 }

--- a/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
+++ b/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
@@ -395,7 +395,7 @@
   --pine-typography-body-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) monospace;
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
-  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-heading); /* brand-label */
   --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);

--- a/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
+++ b/libs/core/src/global/styles/tokens/_output/kajabi_products/styles/kajabi_products.scss
@@ -334,6 +334,7 @@
   --pine-color-brand: var(--pine-color-mercury-500);
   --pine-font-family-heading: var(--pine-font-family-greet);
   --pine-font-family-body: var(--pine-font-family-inter);
+  --pine-font-family-brand-text: var(--pine-font-family-faire-sprig);
   --pine-font-size: var(--pine-font-size-100);
   --pine-font-size-body-2xs: var(--pine-font-size-057);
   --pine-font-size-body-xs: var(--pine-font-size-071);
@@ -380,7 +381,6 @@
   --pine-border: var(--pine-border-width-thin) solid var(--pine-color-grey-300);
   --pine-border-hover: var(--pine-border-width-thin) solid var(--pine-color-grey-400);
   --pine-border-none: var(--pine-border-width-none) solid var(--pine-color-grey-300);
-  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-typography-body-sm-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-faire-sprig); /* brand-text */
   --pine-outline-focus: var(--pine-border-width-thick) solid var(--pine-color-focus-ring); /* Default focus ring */
   --pine-typography-heading-1: var(--pine-font-weight-semi-bold) var(--pine-font-size-heading-1)/var(--pine-line-height-heading) var(--pine-font-family-heading);
@@ -396,6 +396,7 @@
   --pine-typography-body-semi-bold: var(--pine-font-weight-semi-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-bold: var(--pine-font-weight-bold) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-brand-label: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-body); /* brand-label */
+  --pine-typography-body-brand-text: var(--pine-font-weight-medium) var(--pine-font-size-body-md)/var(--pine-line-height-body) var(--pine-font-family-brand-text); /* brand-text */
   --pine-typography-body-sm: var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-medium: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-body);
   --pine-typography-body-sm-mono: var(--pine-font-weight-medium) var(--pine-font-size-body-sm)/var(--pine-line-height-body) monospace;

--- a/libs/core/src/global/styles/tokens/base/core.json
+++ b/libs/core/src/global/styles/tokens/base/core.json
@@ -860,6 +860,18 @@
     "faire-sprig": {
       "value": "FAIRE Sprig",
       "type": "fontFamilies"
+    },
+    "noto-arabic": {
+      "value": "Noto Sans Arabic, Cairo, Amiri, tahoma, arial, system-ui, sans-serif",
+      "type": "fontFamilies"
+    },
+    "noto-hebrew": {
+      "value": "Noto Sans Hebrew, Arial Hebrew, Rubik, Frank Ruehl, tahoma, system-ui, sans-serif",
+      "type": "fontFamilies"
+    },
+    "noto-devanagari": {
+      "value": "Noto Sans Devanagari, Mangal, Kokila, Lohit Devanagari, Sahadeva, tahoma, system-ui, sans-serif",
+      "type": "fontFamilies"
     }
   },
   "font-size": {

--- a/libs/core/src/global/styles/tokens/base/semantic.json
+++ b/libs/core/src/global/styles/tokens/base/semantic.json
@@ -675,7 +675,7 @@
       },
       "brand-text": {
         "value": {
-          "fontFamily": "{font-family.faire-sprig}",
+          "fontFamily": "{font-family.brand-text}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%"
@@ -784,6 +784,10 @@
     },
     "body": {
       "value": "{font-family.inter}",
+      "type": "fontFamilies"
+    },
+    "brand-text": {
+      "value": "{font-family.faire-sprig}",
       "type": "fontFamilies"
     }
   },

--- a/libs/core/src/global/styles/tokens/base/semantic.json
+++ b/libs/core/src/global/styles/tokens/base/semantic.json
@@ -544,7 +544,7 @@
     "heading": {
       "1": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.semi-bold}",
           "fontSize": "{font-size.heading.1}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -554,7 +554,7 @@
       },
       "2": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.semi-bold}",
           "fontSize": "{font-size.heading.2}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -564,7 +564,7 @@
       },
       "3": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.semi-bold}",
           "lineHeight": "{line-height.heading} * 100%",
           "letterSpacing": "{letter-spacing.157}",
@@ -574,7 +574,7 @@
       },
       "4": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.semi-bold}",
           "fontSize": "{font-size.heading.4}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -584,7 +584,7 @@
       },
       "5": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.heading.5}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -594,7 +594,7 @@
       },
       "6": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.heading.6}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -604,7 +604,7 @@
       },
       "caption": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.semi-bold}",
           "fontSize": "{font-size.heading.caption}",
           "lineHeight": "{line-height.heading} * 100%",
@@ -616,7 +616,7 @@
     "body": {
       "@": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.regular}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%",
@@ -626,7 +626,7 @@
       },
       "medium": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%",
@@ -645,7 +645,7 @@
       },
       "semi-bold": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.semi-bold}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%",
@@ -655,7 +655,7 @@
       },
       "bold": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.bold}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%",
@@ -665,7 +665,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%"
@@ -687,7 +687,7 @@
     "body-sm": {
       "@": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.regular}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"
@@ -696,7 +696,7 @@
       },
       "medium": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"
@@ -714,7 +714,7 @@
       },
       "bold": {
         "value": {
-          "fontFamily": "{font-family.inter}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.bold}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"
@@ -723,7 +723,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.greet}",
+          "fontFamily": "{font-family.body}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"

--- a/libs/core/src/global/styles/tokens/base/semantic.json
+++ b/libs/core/src/global/styles/tokens/base/semantic.json
@@ -723,7 +723,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.body}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.sm}",
           "lineHeight": "{line-height.body} * 100%"

--- a/libs/core/src/global/styles/tokens/base/semantic.json
+++ b/libs/core/src/global/styles/tokens/base/semantic.json
@@ -665,7 +665,7 @@
       },
       "brand-label": {
         "value": {
-          "fontFamily": "{font-family.body}",
+          "fontFamily": "{font-family.heading}",
           "fontWeight": "{font-weight.medium}",
           "fontSize": "{font-size.body.md}",
           "lineHeight": "{line-height.body} * 100%"

--- a/libs/core/src/global/styles/tokens/index.scss
+++ b/libs/core/src/global/styles/tokens/index.scss
@@ -6,19 +6,19 @@
 :root[lang="he"], [lang="he"] {
   --pine-font-family-body: var(--pine-font-family-noto-hebrew);
   --pine-font-family-heading: var(--pine-font-family-noto-hebrew);
-  --pine-font-family-faire-sprig: var(--pine-font-family-noto-hebrew);
+  --pine-font-family-brand-text: var(--pine-font-family-noto-hebrew);
 }
 
 // Arabic
 :root[lang="ar"], [lang="ar"] {
   --pine-font-family-body: var(--pine-font-family-noto-arabic);
   --pine-font-family-heading: var(--pine-font-family-noto-arabic);
-  --pine-font-family-faire-sprig: var(--pine-font-family-noto-arabic);
+  --pine-font-family-brand-text: var(--pine-font-family-noto-arabic);
 }
 
 // Hindi
 :root[lang="hi"], [lang="hi"] {
   --pine-font-family-body: var(--pine-font-family-noto-devanagari);
   --pine-font-family-heading: var(--pine-font-family-noto-devanagari);
-  --pine-font-family-faire-sprig: var(--pine-font-family-noto-devanagari);
+  --pine-font-family-brand-text: var(--pine-font-family-noto-devanagari);
 }

--- a/libs/core/src/global/styles/tokens/index.scss
+++ b/libs/core/src/global/styles/tokens/index.scss
@@ -1,1 +1,24 @@
 @use '_output/default/styles/default.scss';
+
+// Language-specific font-family rules for internationalization
+
+// Hebrew
+:root[lang="he"], [lang="he"] {
+  --pine-font-family-body: var(--pine-font-family-noto-hebrew);
+  --pine-font-family-heading: var(--pine-font-family-noto-hebrew);
+  --pine-font-family-faire-sprig: var(--pine-font-family-noto-hebrew);
+}
+
+// Arabic
+:root[lang="ar"], [lang="ar"] {
+  --pine-font-family-body: var(--pine-font-family-noto-arabic);
+  --pine-font-family-heading: var(--pine-font-family-noto-arabic);
+  --pine-font-family-faire-sprig: var(--pine-font-family-noto-arabic);
+}
+
+// Hindi
+:root[lang="hi"], [lang="hi"] {
+  --pine-font-family-body: var(--pine-font-family-noto-devanagari);
+  --pine-font-family-heading: var(--pine-font-family-noto-devanagari);
+  --pine-font-family-faire-sprig: var(--pine-font-family-noto-devanagari);
+}


### PR DESCRIPTION
# Description

- Updates the body and heading fonts to use semantic tokens.
- Adds `brand-text` token.
- Adds Noto font families to support additional languages. 
  - Noto Sans Arabic
  - Noto Sans Hebrew
  - Noto Sans Devanagari (used for Hindi)

Fixes https://kajabi.atlassian.net/browse/DSS-1380

## Type of change

- [x] Typography
- [x] Token adjustments

# How Has This Been Tested?

Navigate to the docs site. Verify that when changing the lang attribute, the correct font-family is applied. (may have to change lang on iframe)

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
