### PR TITLE
docs(popover): using template literals needed to include unsafeHTML from lit

### DIFF
--- a/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
+++ b/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 import { withActions } from '@storybook/addon-actions/decorator';
 
@@ -20,7 +21,7 @@ export default {
 
 const BaseTemplate = (args) => html`
 <pds-popover component-id=${args.componentId}  popover-type=${args.popoverType} popover-target-action=${args.popoverTargetAction} text=${args.text} max-width=${args.maxWidth} placement=${args.placement}>
-	${args.slot}
+	${unsafeHTML(args.slot)}
 </pds-popover>
 `;
 
@@ -29,8 +30,7 @@ Default.args = {
 	componentId: 'popover-1',
   placement: "right",
   text: "Show popover",
-	slot: html`<p>Popover content</p>
-    <p>Popover content</p>`
+	slot: "<p>Popover content</p><p>Popover content</p>"
 };
 
 export const Toggle = BaseTemplate.bind({});
@@ -40,6 +40,5 @@ Toggle.args = {
 	popoverType: "manual",
 	popoverTargetAction: "toggle",
   text: "Toggle popover",
-	slot: html`<p>Popover content</p>
-    <p>Popover content</p>`
+	slot: "<p>Popover content</p><p>Popover content</p>"
 };


### PR DESCRIPTION
…

# Description
When viewing the documentation for Storybook, this error pops up
![image](https://github.com/user-attachments/assets/c26b024f-b3d4-446a-958f-24a73541781c)

Fixes #(issue)

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: Storybook

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
