### PR TITLE
fix(checkbox): fixes checkbox not using error message for aria-describedby attribute

### DIFF
--- a/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
+++ b/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
@@ -16,6 +16,7 @@ Checkboxes provide users with selectable options like toggling a single setting 
 
 ### Accessibility
 - Provide a clear, descriptive label for each checkbox to ensure that screen readers can identify the option effectively.
+- The `aria-describedby` attribute is used to associate the checkbox with an error message or helper message but may not be read out by all screen readers.
 
 ## Properties
 

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -1,7 +1,10 @@
-import { Component, h, Prop, Host, Event, EventEmitter, Watch } from '@stencil/core';
+import { Component, Element, h, Prop, Host, Event, EventEmitter, Watch } from '@stencil/core';
 import { assignDescription, messageId } from '../../utils/form';
 import { CheckboxChangeEventDetail } from './checkbox-interface';
 import { danger } from '@pine-ds/icons/icons';
+
+import { inheritAriaAttributes } from '@utils/attributes';
+import type { Attributes } from '@utils/attributes';
 
 @Component({
   tag: 'pds-checkbox',
@@ -9,6 +12,10 @@ import { danger } from '@pine-ds/icons/icons';
   shadow: true,
 })
 export class PdsCheckbox {
+  private inheritedAttributes: Attributes = {};
+
+  @Element() el: HTMLPdsCheckboxElement;
+
   /**
    * It determines whether or not the checkbox is checked.
    */
@@ -113,6 +120,12 @@ export class PdsCheckbox {
     return classNames.join('  ');
   }
 
+  componentWillLoad() {
+    this.inheritedAttributes = {
+      ...inheritAriaAttributes(this.el)
+    }
+  }
+
   render() {
     return (
       <Host class={this.classNames()}>
@@ -130,6 +143,7 @@ export class PdsCheckbox {
             disabled={this.disabled}
             onChange={this.handleCheckboxChange}
             onInput={this.handleInput}
+            {...this.inheritedAttributes}
           />
           <span class={this.hideLabel ? 'visually-hidden' : ''}>
             {this.label}

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -119,7 +119,7 @@ export class PdsCheckbox {
         <label htmlFor={this.componentId}>
           <input
             type="checkbox"
-            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.errorMessage || this.helperMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
             id={this.componentId}
             indeterminate={this.indeterminate}

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -160,7 +160,7 @@ describe('pds-checkbox', () => {
       <pds-checkbox class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
         <mock:shadow-root>
           <label htmlfor="default">
-            <input aria-invalid="true" id="default" type="checkbox">
+            <input aria-describedby="default__error-message" aria-invalid="true" id="default" type="checkbox">
             <span>Label text</span>
           </label>
           <div aria-live="assertive" class="pds-checkbox__message pds-checkbox__message--error" id="default__error-message">


### PR DESCRIPTION
# Description

Fixes issue with `aria-describedby` attribute not reading potential error messages. Also adds another bullet point for accessibility regarding that attribute.

[DSS-1383](https://kajabi.atlassian.net/browse/DSS-1383)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<img width="769" alt="Screenshot 2025-05-01 at 3 40 12 PM" src="https://github.com/user-attachments/assets/e7e0535d-2cc5-4ee8-9b2b-bc233c4f8799" />


# How Has This Been Tested?

Check that error message exists within the `aria-describedby` attribute in the dev tools. Enable VoiceOver and check that error message is read (may not work in all browsers, seems to work in Chrome and Safari)

- [ ] unit tests
- [ ] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers: Safari, FF, Chrome
- Screen readers: VoiceOver
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1383]: https://kajabi.atlassian.net/browse/DSS-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ