### PR TITLE
fix(switch): fixes component not using error message for aria-describedby attribute

### DIFF
--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -16,7 +16,7 @@ A styled checkbox component that functions as a toggle.
 - Do not use for situations where the user's choice needs to be explicitly confirmed.
 
 ### Accessibility
-- The component includes `aria-describedby` when an error message is present, ensuring that screen readers announce the error after the label.
+- The `aria-describedby` attribute is used to associate the switch with an error message or helper message but may not be read out by all screen readers.
 
 ## Properties
 

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -95,7 +95,7 @@ export class PdsSwitch {
       <Host class={this.switchClassNames()} aria-disabled={this.disabled ? 'true' : null}>
         <label htmlFor={this.componentId}>
           <input
-            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.errorMessage || this.helperMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
             checked={this.checked}
             class="pds-switch__input"

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -2,12 +2,17 @@ import { Component, Element, Event, EventEmitter, Host, h, Prop } from '@stencil
 import { assignDescription, messageId } from '../../utils/form';
 import { danger } from '@pine-ds/icons/icons';
 
+import { inheritAriaAttributes } from '@utils/attributes';
+import type { Attributes } from '@utils/attributes';
+
 @Component({
   tag: 'pds-switch',
   styleUrls: ['../../global/styles/utils/label.scss', 'pds-switch.scss'],
   shadow: true,
 })
 export class PdsSwitch {
+  private inheritedAttributes: Attributes = {};
+
   @Element() el: HTMLPdsSwitchElement;
 
   /**
@@ -90,6 +95,12 @@ export class PdsSwitch {
     return switchClasses;
   };
 
+  componentWillLoad() {
+    this.inheritedAttributes = {
+      ...inheritAriaAttributes(this.el)
+    }
+  }
+
   render() {
     return (
       <Host class={this.switchClassNames()} aria-disabled={this.disabled ? 'true' : null}>
@@ -106,6 +117,7 @@ export class PdsSwitch {
             required={this.required}
             type="checkbox"
             value={this.value}
+            {...this.inheritedAttributes}
           />
           <span class={this.hideLabel ? 'visually-hidden' : ''}>
             {this.label}

--- a/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
+++ b/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
@@ -68,7 +68,7 @@ describe('pds-switch', () => {
     const ariaInvalid = el.getAttribute('aria-invalid');
 
     expect(ariaInvalid).toBe("true");
-    expect(ariaDesc).toBe("pds-switch-err__error-message");
+    expect(ariaDesc).toBe("switch-with-error__error-message");
     expect(errText.textContent).toEqual(`Please correct this item`);
   });
 

--- a/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
+++ b/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
@@ -57,7 +57,7 @@ describe('pds-switch', () => {
 
   it('renders an invalid input with error message when toggled', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-switch invalid="true" error-message="Please correct this item"></pds-switch>');
+    await page.setContent('<pds-switch component-id="switch-with-error" invalid="true" error-message="Please correct this item"></pds-switch>');
 
     const component = await page.find('pds-switch');
     expect(component).toHaveClass('hydrated');
@@ -68,7 +68,7 @@ describe('pds-switch', () => {
     const ariaInvalid = el.getAttribute('aria-invalid');
 
     expect(ariaInvalid).toBe("true");
-    expect(ariaDesc).toBeNull();
+    expect(ariaDesc).toBe("pds-switch-err__error-message");
     expect(errText.textContent).toEqual(`Please correct this item`);
   });
 

--- a/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
+++ b/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
@@ -137,7 +137,7 @@ describe('pds-switch', () => {
       <pds-switch component-id="pds-switch-err" class="pds-switch pds-switch--error" label="Switch error message" error-message="La croix blue bottle narwhal fam" invalid="true">
         <mock:shadow-root>
           <label htmlFor="pds-switch-err">
-            <input aria-invalid="true" id="pds-switch-err" name="pds-switch-err" class="pds-switch__input" type="checkbox">
+            <input aria-describedby="pds-switch-err__error-message" aria-invalid="true" id="pds-switch-err" name="pds-switch-err" class="pds-switch__input" type="checkbox">
             <span>Switch error message</span>
           </label>
           <div aria-live="assertive" id="pds-switch-err__error-message" class="pds-switch__message pds-switch__message--error">


### PR DESCRIPTION
# Description

Fixes issue with `aria-describedby` attribute not reading potential error messages. Also rewords bullet point for accessibility regarding that attribute.

[DSS-1395](https://kajabi.atlassian.net/browse/DSS-1395)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<img width="742" alt="Screenshot 2025-05-01 at 4 08 51 PM" src="https://github.com/user-attachments/assets/518e6ed3-07eb-492e-8d96-2a03d847897c" />


# How Has This Been Tested?

Check that error message exists within the `aria-describedby` attribute in the dev tools. Enable VoiceOver and check that error message is read (may not work in all browsers, seems to work in Chrome and Safari)

- [ ] unit tests
- [ ] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers: Safari, FF, Chrome
- Screen readers: VoiceOver
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1395]: https://kajabi.atlassian.net/browse/DSS-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ