### PR TITLE
feat(pds-icon): add additional props for react pds icon

### DIFF
--- a/libs/core/src/components/pds-icon/stories/IconCopyComponent.jsx
+++ b/libs/core/src/components/pds-icon/stories/IconCopyComponent.jsx
@@ -33,13 +33,15 @@ export const CopyIcon = ({ name }) => {
       {showToast && (
         <div style={{
           position: 'fixed',
-          bottom: '20px',
-          right: '20px',
-          background: '#333',
-          color: 'white',
-          padding: '10px',
-          borderRadius: '4px',
-          zIndex: 9999
+          bottom: 'var(--pine-dimension-sm)',
+          right: 'var(--pine-dimension-sm)',
+          background: 'var(--pine-color-grey-950)',
+          color: 'var(--pine-color-text-primary)',
+          padding: 'var(--pine-dimension-sm)',
+          borderRadius: 'var(--pine-dimension-xs)',
+          zIndex: 9999,
+          boxShadow: 'var(--pine-box-shadow-100)',
+          border: '1px solid var(--pine-color-grey-200)',
         }}>
           {toastMessage}
         </div>

--- a/libs/core/src/components/pds-icon/stories/IconCopyComponent.jsx
+++ b/libs/core/src/components/pds-icon/stories/IconCopyComponent.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { IconItem } from '@storybook/blocks';
+
+export const CopyIcon = ({ name }) => {
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+
+  useEffect(() => {
+    let timer;
+    if (showToast) {
+      timer = setTimeout(() => setShowToast(false), 3000);
+    }
+    return () => clearTimeout(timer);
+  }, [showToast]);
+
+  const handleCopy = async () => {
+    const code = `<pds-icon name="${name}"></pds-icon>`;
+    try {
+      await navigator.clipboard.writeText(code);
+      setToastMessage(`${name} has been copied to clipboard`);
+      setShowToast(true);
+    } catch (err) {
+      setToastMessage('Failed to copy');
+      setShowToast(true);
+    }
+  };
+
+  return (
+    <IconItem name={name}>
+    <div onClick={handleCopy} style={{ cursor: 'pointer', position: 'relative' }}>
+        <pds-icon name={name}>{name}</pds-icon>
+    </div>
+      {showToast && (
+        <div style={{
+          position: 'fixed',
+          bottom: '20px',
+          right: '20px',
+          background: '#333',
+          color: 'white',
+          padding: '10px',
+          borderRadius: '4px',
+          zIndex: 9999
+        }}>
+          {toastMessage}
+        </div>
+      )}
+      </IconItem>
+  );
+};

--- a/libs/core/src/components/pds-icon/stories/pds-icon.docs.mdx
+++ b/libs/core/src/components/pds-icon/stories/pds-icon.docs.mdx
@@ -6,6 +6,8 @@ import pdsIconsJson from '@pine-ds/icons/dist/pds-icons.json';
 
 import * as stories from './pds-icon.stories.js';
 
+import {CopyIcon} from './IconCopyComponent';
+
 import Docs from '../docs/pds-icon.mdx'
 
 <Meta of={stories} />
@@ -13,15 +15,12 @@ import Docs from '../docs/pds-icon.mdx'
 <Docs />
 
 ## All Icons
+__Note: Click to copy the icon code to clipboard.__
 
 <DocCanvas client:only mdxSource={{}}>
   <IconGallery>
-    {
-      Object.values(pdsIconsJson["icons"]).map((icon, index) => (
-        <IconItem conItem key={`item-${index}`} name={icon.name}>
-          <pds-icon name={icon.name}>{icon.name}</pds-icon>
-        </IconItem>
-      ))
-    }
+    {Object.values(pdsIconsJson["icons"]).map((icon, index) => (
+      <CopyIcon key={`item-${index}`} name={icon.name} />
+    ))}
   </IconGallery>
 </DocCanvas>

--- a/libs/core/src/components/pds-icon/stories/pds-icon.stories.js
+++ b/libs/core/src/components/pds-icon/stories/pds-icon.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'components/Icon'
 }
 
-const BaseTemplate = (args) => html`<pds-icon color=${args.color} name=${args.name} size=${args.size}></pds-icon>`;
+const BaseTemplate = (args) => html`<pds-icon color=${args.color} name=${args.name} size=${args.size} flip-rtl=${args.flipRtl}></pds-icon>`;
 
 export const Default = BaseTemplate.bind();
 Default.args = {

--- a/libs/react/src/components/PdsIcon.tsx
+++ b/libs/react/src/components/PdsIcon.tsx
@@ -7,9 +7,11 @@ import { createForwardRef } from './react-component-lib/utils';
 
 interface PdsIconProps {
   color?: string;
+  flipRtl?: boolean;
   icon?: string;
   name?: string;
   size?: string;
+  src?: string;
 }
 
 type InternalProps = PropsWithChildren<


### PR DESCRIPTION
# Description

Update the React `pds-icon` to include the new prop that was added to the web component.

* Added one new feature to the Icon page. You can now click on an icon and it will copy the code snippet to your clipboard.

Fixes #(issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
