### PR TITLE
style(pds-link): add hover style to remove text decoration

### DIFF
--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -18,6 +18,10 @@
     outline-offset: var(--pine-border-width-thick);
     position: relative;
   }
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 // We have a small consensus stating that

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -62,13 +62,3 @@
     text-decoration: underline;
   }
 }
-
-// Default = inline link
-.pds-link--default {
-  text-decoration: underline;
-
-  &:hover {
-    color: var(--pine-color-text-hover);
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
# Description

Per the design spec, the inline link’s underline is removed on hover.

Fixes https://kajabi.atlassian.net/browse/DSS-1343

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Style only

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
