### PR TITLE
fix(pds-popover): adds missing -start and -end positioning

### DIFF
--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -89,18 +89,50 @@ export class PdsPopover {
     switch (this.placement) {
       case 'top':
         top = triggerRect.top - popoverRect.height - offset;
+        left = triggerRect.left + (triggerRect.width - popoverRect.width) / 2;
+        break;
+      case 'top-start':
+        top = triggerRect.top - popoverRect.height - offset;
         left = triggerRect.left;
         break;
+      case 'top-end':
+        top = triggerRect.top - popoverRect.height - offset;
+        left = triggerRect.right - popoverRect.width;
+        break;
       case 'right':
+        top = triggerRect.top + (triggerRect.height - popoverRect.height) / 2;
+        left = triggerRect.right + offset;
+        break;
+      case 'right-start':
         top = triggerRect.top;
+        left = triggerRect.right + offset;
+        break;
+      case 'right-end':
+        top = triggerRect.bottom - popoverRect.height;
         left = triggerRect.right + offset;
         break;
       case 'bottom':
         top = triggerRect.bottom + offset;
+        left = triggerRect.left + (triggerRect.width - popoverRect.width) / 2;
+        break;
+      case 'bottom-start':
+        top = triggerRect.bottom + offset;
         left = triggerRect.left;
         break;
+      case 'bottom-end':
+        top = triggerRect.bottom + offset;
+        left = triggerRect.right - popoverRect.width;
+        break;
       case 'left':
+        top = triggerRect.top + (triggerRect.height - popoverRect.height) / 2;
+        left = triggerRect.left - popoverRect.width - offset;
+        break;
+      case 'left-start':
         top = triggerRect.top;
+        left = triggerRect.left - popoverRect.width - offset;
+        break;
+      case 'left-end':
+        top = triggerRect.bottom - popoverRect.height;
         left = triggerRect.left - popoverRect.width - offset;
         break;
     }

--- a/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
+++ b/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
@@ -77,18 +77,50 @@ describe('pds-popover', () => {
     const placements = {
       'top': {
         top: mockTriggerRect.top - mockPopoverRect.height - OFFSET,
+        left: mockTriggerRect.left + (mockTriggerRect.width - mockPopoverRect.width) / 2
+      },
+      'top-start': {
+        top: mockTriggerRect.top - mockPopoverRect.height - OFFSET,
         left: mockTriggerRect.left
       },
+      'top-end': {
+        top: mockTriggerRect.top - mockPopoverRect.height - OFFSET,
+        left: mockTriggerRect.right - mockPopoverRect.width
+      },
       'right': {
+        top: mockTriggerRect.top + (mockTriggerRect.height - mockPopoverRect.height) / 2,
+        left: mockTriggerRect.right + OFFSET
+      },
+      'right-start': {
         top: mockTriggerRect.top,
+        left: mockTriggerRect.right + OFFSET
+      },
+      'right-end': {
+        top: mockTriggerRect.bottom - mockPopoverRect.height,
         left: mockTriggerRect.right + OFFSET
       },
       'bottom': {
         top: mockTriggerRect.bottom + OFFSET,
+        left: mockTriggerRect.left + (mockTriggerRect.width - mockPopoverRect.width) / 2
+      },
+      'bottom-start': {
+        top: mockTriggerRect.bottom + OFFSET,
         left: mockTriggerRect.left
       },
+      'bottom-end': {
+        top: mockTriggerRect.bottom + OFFSET,
+        left: mockTriggerRect.right - mockPopoverRect.width
+      },
       'left': {
+        top: mockTriggerRect.top + (mockTriggerRect.height - mockPopoverRect.height) / 2,
+        left: mockTriggerRect.left - mockPopoverRect.width - OFFSET
+      },
+      'left-start': {
         top: mockTriggerRect.top,
+        left: mockTriggerRect.left - mockPopoverRect.width - OFFSET
+      },
+      'left-end': {
+        top: mockTriggerRect.bottom - mockPopoverRect.height,
         left: mockTriggerRect.left - mockPopoverRect.width - OFFSET
       }
     };


### PR DESCRIPTION
# Description

When setting the placement prop on the `pds-popover`, if a `—start` or `—end` placement is used, the popover panel does not appear relative to the trigger and is positioned incorrectly on the screen. The four general directions (top, right, bottom, left) seem fine.

It seems all of the `-start` and `-end` directions were missing from the positioning function altogether. The missing options were added.

Fixes https://kajabi.atlassian.net/browse/DSS-1428

### Screenshots
|  Before   |  After  |
|--------|--------|
|![Screenshot 2025-05-16 at 9 47 00 AM](https://github.com/user-attachments/assets/710cf40f-96da-48ac-a629-77418c6dfc7b)|![Screenshot 2025-05-16 at 10 12 33 AM](https://github.com/user-attachments/assets/eb46a8cd-4a6e-4a4d-b903-b1bf90a53c8e)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Navigate to [popover](http://localhost:6006/?path=/docs/components-popover--docs)
- Verify that all placements now display as expected.

Additional placement checks were also added to tests.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
