### PR TITLE
feat(link): adds color prop

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -569,6 +569,10 @@ export namespace Components {
     }
     interface PdsLink {
         /**
+          * Sets the link color.
+         */
+        "color"?: 'secondary' | 'accent' | 'danger';
+        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
@@ -2356,6 +2360,10 @@ declare namespace LocalJSX {
         "value"?: string | number | null;
     }
     interface PdsLink {
+        /**
+          * Sets the link color.
+         */
+        "color"?: 'secondary' | 'accent' | 'danger';
         /**
           * A unique identifier used for the underlying component `id` attribute.
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -571,7 +571,7 @@ export namespace Components {
         /**
           * Sets the link color.
          */
-        "color"?: 'secondary' | 'accent' | 'danger';
+        "color"?: string;
         /**
           * A unique identifier used for the underlying component `id` attribute.
          */
@@ -2363,7 +2363,7 @@ declare namespace LocalJSX {
         /**
           * Sets the link color.
          */
-        "color"?: 'secondary' | 'accent' | 'danger';
+        "color"?: string;
         /**
           * A unique identifier used for the underlying component `id` attribute.
          */

--- a/libs/core/src/components/pds-link/docs/pds-link.mdx
+++ b/libs/core/src/components/pds-link/docs/pds-link.mdx
@@ -29,21 +29,29 @@ The default `inline` link. Visually, it maintains the underlined appearance of a
 
 ### Colors
 
-The `color` prop can be used to change the color of the link. Available colors are `secondary`, `accent`, and `danger`.
+The `color` prop can be used to change the color of the link to any available preset or, Pine token, or custom color. The available preset colors are `secondary`, `accent`, and `danger`.
+
+>Note: Only presets have hover state colors.
 
 <DocCanvas client:only
   mdxSource={{
-    react: `<PdsLink href="https://www.google.com" color="secondary"></PdsLink>
-    <PdsLink href="https://www.google.com" color="danger"></PdsLink>
-    <PdsLink href="https://www.google.com" color="accent"></PdsLink>
+    react: `<PdsLink href="https://www.google.com" color="secondary">Link</PdsLink>
+    <PdsLink href="https://www.google.com" color="accent">Link</PdsLink>
+    <PdsLink href="https://www.google.com" color="danger">Link</PdsLink>
+    <PdsLink href="https://www.google.com" color="var(--pine-color-green-600)">Link</PdsLink>
+    <PdsLink href="https://www.google.com" color="#daa520">Link</PdsLink>
     `,
-    webComponent: `<pds-link href="https://www.google.com" color="secondary"></pds-link>
-    <pds-link href="https://www.google.com" color="danger"></pds-link>
-    <pds-link href="https://www.google.com" color="accent"></pds-link>`
+    webComponent: `<pds-link href="https://www.google.com" color="secondary">Link</pds-link>
+    <pds-link href="https://www.google.com" color="accent">Link</pds-link>
+    <pds-link href="https://www.google.com" color="danger">Link</pds-link>
+    <pds-link href="https://www.google.com" color="var(--pine-color-green-600)">Link</pds-link>
+    <pds-link href="https://www.google.com" color="#daa520">Link</pds-link>`
 }}>
-  <div style={{ backgroundColor: '#333', padding: '4px' }}><pds-link href="https://www.google.com" color="secondary"></pds-link></div>
-  <pds-link href="https://www.google.com" color="danger"></pds-link>
-  <pds-link href="https://www.google.com" color="accent"></pds-link>
+  <div style={{ backgroundColor: '#333', padding: '4px' }}><pds-link href="https://www.google.com" color="secondary">Link</pds-link></div>
+  <pds-link href="https://www.google.com" color="accent">Link</pds-link>
+  <pds-link href="https://www.google.com" color="danger">Link</pds-link>
+  <pds-link href="https://www.google.com" color="var(--pine-color-green-600)">Link</pds-link>
+  <pds-link href="https://www.google.com" color="#daa520">Link</pds-link>
 </DocCanvas>
 
 ### Plain

--- a/libs/core/src/components/pds-link/docs/pds-link.mdx
+++ b/libs/core/src/components/pds-link/docs/pds-link.mdx
@@ -27,6 +27,25 @@ The default `inline` link. Visually, it maintains the underlined appearance of a
   <pds-link href="https://www.google.com"></pds-link>
 </DocCanvas>
 
+### Colors
+
+The `color` prop can be used to change the color of the link. Available colors are `secondary`, `accent`, and `danger`.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsLink href="https://www.google.com" color="secondary"></PdsLink>
+    <PdsLink href="https://www.google.com" color="danger"></PdsLink>
+    <PdsLink href="https://www.google.com" color="accent"></PdsLink>
+    `,
+    webComponent: `<pds-link href="https://www.google.com" color="secondary"></pds-link>
+    <pds-link href="https://www.google.com" color="danger"></pds-link>
+    <pds-link href="https://www.google.com" color="accent"></pds-link>`
+}}>
+  <div style={{ backgroundColor: '#333', padding: '4px' }}><pds-link href="https://www.google.com" color="secondary"></pds-link></div>
+  <pds-link href="https://www.google.com" color="danger"></pds-link>
+  <pds-link href="https://www.google.com" color="accent"></pds-link>
+</DocCanvas>
+
 ### Plain
 
 The `plain` variant displays a standard plain hyperlink without an underline.

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -8,7 +8,7 @@
 
 .pds-link {
   align-items: center;
-  color: var(--pine-color-text);
+  color: var(--color, var(--pine-color-text));
   display: inline-flex;
   font-weight: var(--pine-font-weight-medium);
 
@@ -20,7 +20,7 @@
   }
 
   &:hover {
-    color: var(--pine-color-text-hover);
+    color: var(--color, var(--pine-color-text-hover));
     text-decoration: none;
   }
 

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -20,7 +20,32 @@
   }
 
   &:hover {
+    color: var(--pine-color-text-hover);
     text-decoration: none;
+  }
+
+  :host([color="secondary"]) & {
+    color: var(--pine-color-text-primary);
+
+    &:hover {
+      color: var(--pine-color-grey-150);
+    }
+  }
+
+  :host([color="accent"]) & {
+    color: var(--pine-color-accent);
+
+    &:hover {
+      color: var(--pine-color-accent-hover);
+    }
+  }
+
+  :host([color="danger"]) & {
+    color: var(--pine-color-danger);
+
+    &:hover {
+      color: var(--pine-color-danger-hover);
+    }
   }
 }
 

--- a/libs/core/src/components/pds-link/pds-link.tsx
+++ b/libs/core/src/components/pds-link/pds-link.tsx
@@ -13,6 +13,11 @@ import { launch } from '@pine-ds/icons/icons';
 })
 export class PdsLink {
   /**
+   * Sets the link color.
+   */
+  @Prop() color?: 'secondary' | 'accent' | 'danger';
+
+  /**
    * A unique identifier used for the underlying component `id` attribute.
    */
   @Prop() componentId: string;

--- a/libs/core/src/components/pds-link/pds-link.tsx
+++ b/libs/core/src/components/pds-link/pds-link.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
+import { setColor } from '../../utils/utils';
 
 import { launch } from '@pine-ds/icons/icons';
 
@@ -15,7 +16,7 @@ export class PdsLink {
   /**
    * Sets the link color.
    */
-  @Prop() color?: 'secondary' | 'accent' | 'danger';
+  @Prop() color?: string;
 
   /**
    * A unique identifier used for the underlying component `id` attribute.
@@ -59,6 +60,20 @@ export class PdsLink {
     return classNames.join(' ');
   }
 
+  private setLinkStyles() {
+    if (!this.color) return;
+
+    const linkColors = {
+      secondary: 'var(--pine-color-text-primary)',
+      accent: 'var(--pine-color-accent)',
+      danger: 'var(--pine-color-danger)',
+    }
+
+    const linkStyles = setColor(this.color, linkColors);
+
+    return linkStyles;
+  }
+
   render() {
 
     return (
@@ -66,8 +81,9 @@ export class PdsLink {
         class={this.classNames()}
         href={this.href}
         id={this.componentId}
-        target={this.external ? '_blank' : undefined}
         part="link"
+        target={this.external ? '_blank' : undefined}
+        style={this.setLinkStyles()}
       >
         <slot>{this.href}</slot>
         {this.external &&

--- a/libs/core/src/components/pds-link/readme.md
+++ b/libs/core/src/components/pds-link/readme.md
@@ -7,13 +7,14 @@ Link is mainly used as navigational element and usually appear within or directl
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                        | Type                   | Default     |
-| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- | ---------------------- | ----------- |
-| `componentId`       | `component-id` | A unique identifier used for the underlying component `id` attribute.                              | `string`               | `undefined` |
-| `external`          | `external`     | Determines whether the link should open in a new tab.                                              | `boolean`              | `false`     |
-| `fontSize`          | `font-size`    | The font size of the link's text.                                                                  | `"lg" \| "md" \| "sm"` | `'lg'`      |
-| `href` _(required)_ | `href`         | The hyperlink's destination URL. If no text is provided in the custom slot, the href will be used. | `string`               | `undefined` |
-| `variant`           | `variant`      | Sets the link variant styles.                                                                      | `"inline" \| "plain"`  | `'inline'`  |
+| Property            | Attribute      | Description                                                                                        | Type                                  | Default     |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
+| `color`             | `color`        | Sets the link color.                                                                               | `"accent" \| "danger" \| "secondary"` | `undefined` |
+| `componentId`       | `component-id` | A unique identifier used for the underlying component `id` attribute.                              | `string`                              | `undefined` |
+| `external`          | `external`     | Determines whether the link should open in a new tab.                                              | `boolean`                             | `false`     |
+| `fontSize`          | `font-size`    | The font size of the link's text.                                                                  | `"lg" \| "md" \| "sm"`                | `'lg'`      |
+| `href` _(required)_ | `href`         | The hyperlink's destination URL. If no text is provided in the custom slot, the href will be used. | `string`                              | `undefined` |
+| `variant`           | `variant`      | Sets the link variant styles.                                                                      | `"inline" \| "plain"`                 | `'inline'`  |
 
 
 ## Slots

--- a/libs/core/src/components/pds-link/readme.md
+++ b/libs/core/src/components/pds-link/readme.md
@@ -7,14 +7,14 @@ Link is mainly used as navigational element and usually appear within or directl
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                        | Type                                  | Default     |
-| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- |
-| `color`             | `color`        | Sets the link color.                                                                               | `"accent" \| "danger" \| "secondary"` | `undefined` |
-| `componentId`       | `component-id` | A unique identifier used for the underlying component `id` attribute.                              | `string`                              | `undefined` |
-| `external`          | `external`     | Determines whether the link should open in a new tab.                                              | `boolean`                             | `false`     |
-| `fontSize`          | `font-size`    | The font size of the link's text.                                                                  | `"lg" \| "md" \| "sm"`                | `'lg'`      |
-| `href` _(required)_ | `href`         | The hyperlink's destination URL. If no text is provided in the custom slot, the href will be used. | `string`                              | `undefined` |
-| `variant`           | `variant`      | Sets the link variant styles.                                                                      | `"inline" \| "plain"`                 | `'inline'`  |
+| Property            | Attribute      | Description                                                                                        | Type                   | Default     |
+| ------------------- | -------------- | -------------------------------------------------------------------------------------------------- | ---------------------- | ----------- |
+| `color`             | `color`        | Sets the link color.                                                                               | `string`               | `undefined` |
+| `componentId`       | `component-id` | A unique identifier used for the underlying component `id` attribute.                              | `string`               | `undefined` |
+| `external`          | `external`     | Determines whether the link should open in a new tab.                                              | `boolean`              | `false`     |
+| `fontSize`          | `font-size`    | The font size of the link's text.                                                                  | `"lg" \| "md" \| "sm"` | `'lg'`      |
+| `href` _(required)_ | `href`         | The hyperlink's destination URL. If no text is provided in the custom slot, the href will be used. | `string`               | `undefined` |
+| `variant`           | `variant`      | Sets the link variant styles.                                                                      | `"inline" \| "plain"`  | `'inline'`  |
 
 
 ## Slots

--- a/libs/core/src/components/pds-link/stories/pds-link.stories.js
+++ b/libs/core/src/components/pds-link/stories/pds-link.stories.js
@@ -5,10 +5,6 @@ export default {
   argTypes: extractArgTypes('pds-link'),
   args: { href: '#some-anchor' },
   argTypes: {
-    color: {
-      control: 'radio',
-      options: ['secondary', 'accent', 'danger'],
-    },
     variant: {
       control: 'radio',
       options: ['inline', 'plain'],

--- a/libs/core/src/components/pds-link/stories/pds-link.stories.js
+++ b/libs/core/src/components/pds-link/stories/pds-link.stories.js
@@ -4,12 +4,29 @@ import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 export default {
   argTypes: extractArgTypes('pds-link'),
   args: { href: '#some-anchor' },
+  argTypes: {
+    color: {
+      control: 'radio',
+      options: ['secondary', 'accent', 'danger'],
+    },
+    variant: {
+      control: 'radio',
+      options: ['inline', 'plain'],
+    },
+  },
   component: 'pds-link',
   title: 'components/Link'
 }
 
-const BaseTemplate = (args) => html`<pds-link external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}></pds-link>`;
-const BaseTemplateWithSlot = (args) => html` <pds-link external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}>${args.slot}</pds-link>`;
+const BaseTemplate = (args) => html`<pds-link color=${args.color} external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}></pds-link>`;
+const BaseTemplateWithSlot = (args) => html` <pds-link color=${args.color} external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}>${args.slot}</pds-link>`;
+
+export const Colors = BaseTemplate.bind();
+Colors.args = {
+  color: 'danger',
+  external: false,
+  fontSize: 'lg',
+};
 
 export const External = BaseTemplate.bind();
 External.args = {

--- a/libs/core/src/components/pds-link/test/pds-link.spec.tsx
+++ b/libs/core/src/components/pds-link/test/pds-link.spec.tsx
@@ -43,7 +43,7 @@ describe('pds-link', () => {
     expect(root).toEqualHtml(`
       <pds-link color="accent">
         <mock:shadow-root>
-          <a class="pds-link pds-link--inline pds-link--lg" part="link">
+          <a class="pds-link pds-link--inline pds-link--lg" part="link" style="--color: var(--pine-color-accent);">
             <slot></slot>
           </a>
         </mock:shadow-root>

--- a/libs/core/src/components/pds-link/test/pds-link.spec.tsx
+++ b/libs/core/src/components/pds-link/test/pds-link.spec.tsx
@@ -35,6 +35,22 @@ describe('pds-link', () => {
     `);
   });
 
+  it('renders with color', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsLink],
+      html: `<pds-link color="accent"></pds-link>`,
+    });
+    expect(root).toEqualHtml(`
+      <pds-link color="accent">
+        <mock:shadow-root>
+          <a class="pds-link pds-link--inline pds-link--lg" part="link">
+            <slot></slot>
+          </a>
+        </mock:shadow-root>
+      </pds-link>
+    `);
+  });
+
   it('renders with values', async () => {
     const { root } = await newSpecPage({
       components: [PdsLink],

--- a/libs/core/src/utils/utils.ts
+++ b/libs/core/src/utils/utils.ts
@@ -20,10 +20,10 @@ export const debounce = (func: (...args: any[]) => void, wait = 0) => {
   };
 };
 
-export const setColor = (color: string) => {
+export const setColor = (color: string, customColors?: Record<string, string>) => {
   if (!color) return;
 
-  const colors: Record<string, string> = {
+  const defaultColors: Record<string, string> = {
     primary: 'var(--pine-color-text-primary)',
     secondary: 'var(--pine-color-text-secondary)',
     neutral: 'var(--pine-color-text-neutral)',
@@ -33,6 +33,8 @@ export const setColor = (color: string) => {
     success: 'var(--pine-color-text-success)',
     warning: 'var(--pine-color-text-warning)',
   };
+
+  const colors = customColors || defaultColors;
 
   return {
     '--color': colors[color] ?? (color.startsWith('--') ? `var(${color})` : color)


### PR DESCRIPTION
# Description
Adds `color` prop for the Link

[DSS-1434](https://kajabi.atlassian.net/browse/DSS-1434)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<img width="1046" alt="Screenshot 2025-05-22 at 4 21 47 PM" src="https://github.com/user-attachments/assets/80cbb201-b7e1-420f-8857-a99f61afd85c" />


# How Has This Been Tested?


- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1434]: https://kajabi.atlassian.net/browse/DSS-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ