### PR TITLE
fix(pds-modal): update closeonbackdropclick prop and auto generated file

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -22,13 +22,13 @@ export namespace Components {
      */
     interface MockPdsModal {
         /**
-          * Whether the modal should close when clicking on the backdrop
-         */
-        "closeOnBackdropClick": boolean;
-        /**
           * The ID of the modal component
          */
         "componentId"?: string;
+        /**
+          * Whether clicking the backdrop to close the modal is disabled
+         */
+        "disableBackdropClick": boolean;
         /**
           * Hides the modal
          */
@@ -617,14 +617,14 @@ export namespace Components {
     }
     interface PdsModal {
         /**
-          * Whether the modal can be closed by clicking the backdrop
-          * @default true
-         */
-        "closeOnBackdropClick": boolean;
-        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
+        /**
+          * Whether clicking the backdrop to close the modal is disabled
+          * @default false
+         */
+        "disableBackdropClick": boolean;
         /**
           * Closes the modal
          */
@@ -1214,6 +1214,10 @@ export namespace Components {
         "showTooltip": () => Promise<void>;
     }
 }
+export interface MockPdsModalCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMockPdsModalElement;
+}
 export interface PdsAlertCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsAlertElement;
@@ -1772,13 +1776,13 @@ declare namespace LocalJSX {
      */
     interface MockPdsModal {
         /**
-          * Whether the modal should close when clicking on the backdrop
-         */
-        "closeOnBackdropClick"?: boolean;
-        /**
           * The ID of the modal component
          */
         "componentId"?: string;
+        /**
+          * Whether clicking the backdrop to close the modal is disabled
+         */
+        "disableBackdropClick"?: boolean;
         /**
           * Event emitted when the backdrop is clicked
          */
@@ -2401,14 +2405,14 @@ declare namespace LocalJSX {
     }
     interface PdsModal {
         /**
-          * Whether the modal can be closed by clicking the backdrop
-          * @default true
-         */
-        "closeOnBackdropClick"?: boolean;
-        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId"?: string;
+        /**
+          * Whether clicking the backdrop to close the modal is disabled
+          * @default false
+         */
+        "disableBackdropClick"?: boolean;
         /**
           * Emitted when the modal is closed
          */

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -22,13 +22,13 @@ export namespace Components {
      */
     interface MockPdsModal {
         /**
+          * Whether the modal can be dismissed by clicking the backdrop
+         */
+        "backdropDismiss": boolean;
+        /**
           * The ID of the modal component
          */
         "componentId"?: string;
-        /**
-          * Whether clicking the backdrop to close the modal is disabled
-         */
-        "disableBackdropClick": boolean;
         /**
           * Hides the modal
          */
@@ -617,14 +617,14 @@ export namespace Components {
     }
     interface PdsModal {
         /**
+          * Whether the modal can be dismissed by clicking the backdrop
+          * @default true
+         */
+        "backdropDismiss": boolean;
+        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
-        /**
-          * Whether clicking the backdrop to close the modal is disabled
-          * @default false
-         */
-        "disableBackdropClick": boolean;
         /**
           * Closes the modal
          */
@@ -1776,13 +1776,13 @@ declare namespace LocalJSX {
      */
     interface MockPdsModal {
         /**
+          * Whether the modal can be dismissed by clicking the backdrop
+         */
+        "backdropDismiss"?: boolean;
+        /**
           * The ID of the modal component
          */
         "componentId"?: string;
-        /**
-          * Whether clicking the backdrop to close the modal is disabled
-         */
-        "disableBackdropClick"?: boolean;
         /**
           * Event emitted when the backdrop is clicked
          */
@@ -2405,14 +2405,14 @@ declare namespace LocalJSX {
     }
     interface PdsModal {
         /**
+          * Whether the modal can be dismissed by clicking the backdrop
+          * @default true
+         */
+        "backdropDismiss"?: boolean;
+        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId"?: string;
-        /**
-          * Whether clicking the backdrop to close the modal is disabled
-          * @default false
-         */
-        "disableBackdropClick"?: boolean;
         /**
           * Emitted when the modal is closed
          */

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -202,10 +202,10 @@ modal.addEventListener('pds-modal-close', () => {
 Modals can be configured to close automatically in response to user actions:
 
 - Escape key - Always closes the modal (per accessibility guidelines)
-- `closeOnBackdropClick` (default: `true`) - Close when clicking outside the modal
+- `disableBackdropClick` (default: `false`) - Disable closing when clicking outside the modal
 
 ```html
-<pds-modal closeOnBackdropClick={false}>
+<pds-modal disableBackdropClick={true}>
   <!-- Modal content that can only be closed via explicit button clicks -->
 </pds-modal>
 ```

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -28,7 +28,7 @@ The Modal component is composed of several subcomponents that work together to c
 
 #### Modal Content
 
-The `pds-modal-content` component provides a scrollable container for the main content of the modal. This component is always scrollable by default and automatically handles border visibility based on scroll state. The content area's maximum height can be customized using the `--pds-modal-content-max-height` CSS variable.
+The `pds-modal-content` component provides a scrollable container for the main content of the modal. This component is always scrollable by default and automatically handles border visibility based on scroll state.
 
 <DocArgsTable componentName="pds-modal-content" docSource={components} />
 
@@ -202,10 +202,10 @@ modal.addEventListener('pds-modal-close', () => {
 Modals can be configured to close automatically in response to user actions:
 
 - Escape key - Always closes the modal (per accessibility guidelines)
-- `disableBackdropClick` (default: `false`) - Disable closing when clicking outside the modal
+- `backdropDismiss` (default: `true`) - Allow closing when clicking outside the modal
 
 ```html
-<pds-modal disableBackdropClick={true}>
+<pds-modal backdropDismiss={false}>
   <!-- Modal content that can only be closed via explicit button clicks -->
 </pds-modal>
 ```

--- a/libs/core/src/components/pds-modal/pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/pds-modal.tsx
@@ -13,12 +13,10 @@ export class PdsModal {
   @Element() el: HTMLPdsModalElement;
 
   /**
-   * Whether the modal can be closed by clicking the backdrop
-   * @default true
+   * Whether clicking the backdrop to close the modal is disabled
+   * @default false
    */
-  @Prop() closeOnBackdropClick = true;
-
-  // Escape key closing is always enabled for accessibility
+  @Prop() disableBackdropClick = false;
 
   /**
    * A unique identifier used for the underlying component `id` attribute.
@@ -201,7 +199,7 @@ export class PdsModal {
   }
 
   private handleBackdropClick = (e: MouseEvent) => {
-    if (!this.closeOnBackdropClick || !this.open) return;
+    if (this.disableBackdropClick || !this.open) return;
 
     if ((e.target as HTMLElement).classList.contains('pds-modal__backdrop')) {
       e.stopPropagation();

--- a/libs/core/src/components/pds-modal/pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/pds-modal.tsx
@@ -13,10 +13,10 @@ export class PdsModal {
   @Element() el: HTMLPdsModalElement;
 
   /**
-   * Whether clicking the backdrop to close the modal is disabled
-   * @default false
+   * Whether the modal can be dismissed by clicking the backdrop
+   * @default true
    */
-  @Prop() disableBackdropClick = false;
+  @Prop() backdropDismiss = true;
 
   /**
    * A unique identifier used for the underlying component `id` attribute.
@@ -199,7 +199,7 @@ export class PdsModal {
   }
 
   private handleBackdropClick = (e: MouseEvent) => {
-    if (this.disableBackdropClick || !this.open) return;
+    if (!this.backdropDismiss || !this.open) return;
 
     if ((e.target as HTMLElement).classList.contains('pds-modal__backdrop')) {
       e.stopPropagation();

--- a/libs/core/src/components/pds-modal/readme.md
+++ b/libs/core/src/components/pds-modal/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property               | Attribute                 | Description                                                           | Type                                   | Default     |
-| ---------------------- | ------------------------- | --------------------------------------------------------------------- | -------------------------------------- | ----------- |
-| `closeOnBackdropClick` | `close-on-backdrop-click` | Whether the modal can be closed by clicking the backdrop              | `boolean`                              | `true`      |
-| `componentId`          | `component-id`            | A unique identifier used for the underlying component `id` attribute. | `string`                               | `undefined` |
-| `open`                 | `open`                    | Whether the modal is open                                             | `boolean`                              | `false`     |
-| `size`                 | `size`                    | The size of the modal                                                 | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
+| Property               | Attribute                | Description                                                           | Type                                   | Default     |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------- | -------------------------------------- | ----------- |
+| `componentId`          | `component-id`           | A unique identifier used for the underlying component `id` attribute. | `string`                               | `undefined` |
+| `disableBackdropClick` | `disable-backdrop-click` | Whether clicking the backdrop to close the modal is disabled          | `boolean`                              | `false`     |
+| `open`                 | `open`                   | Whether the modal is open                                             | `boolean`                              | `false`     |
+| `size`                 | `size`                   | The size of the modal                                                 | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 
 ## Events

--- a/libs/core/src/components/pds-modal/readme.md
+++ b/libs/core/src/components/pds-modal/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property               | Attribute                | Description                                                           | Type                                   | Default     |
-| ---------------------- | ------------------------ | --------------------------------------------------------------------- | -------------------------------------- | ----------- |
-| `componentId`          | `component-id`           | A unique identifier used for the underlying component `id` attribute. | `string`                               | `undefined` |
-| `disableBackdropClick` | `disable-backdrop-click` | Whether clicking the backdrop to close the modal is disabled          | `boolean`                              | `false`     |
-| `open`                 | `open`                   | Whether the modal is open                                             | `boolean`                              | `false`     |
-| `size`                 | `size`                   | The size of the modal                                                 | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
+| Property          | Attribute          | Description                                                           | Type                                   | Default     |
+| ----------------- | ------------------ | --------------------------------------------------------------------- | -------------------------------------- | ----------- |
+| `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop           | `boolean`                              | `true`      |
+| `componentId`     | `component-id`     | A unique identifier used for the underlying component `id` attribute. | `string`                               | `undefined` |
+| `open`            | `open`             | Whether the modal is open                                             | `boolean`                              | `false`     |
+| `size`            | `size`             | The size of the modal                                                 | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 
 ## Events

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -8,7 +8,7 @@ export default {
   decorators: [withActions],
   title: 'components/Modal',
   args: {
-    disableBackdropClick: false,
+    backdropDismiss: true,
     componentId: 'modal-demo',
     open: false,
     size: 'md',
@@ -30,7 +30,7 @@ const BaseTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?disable-backdrop-click="${args.disableBackdropClick}"
+      ?backdrop-dismiss="${args.backdropDismiss}"
       ?open="${args.open}"
     >
       <pds-modal-header>
@@ -100,7 +100,7 @@ const DestructiveTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?disable-backdrop-click="${args.disableBackdropClick}"
+      ?backdrop-dismiss="${args.backdropDismiss}"
       ?open="${args.open}"
     >
       <pds-modal-header>
@@ -166,7 +166,7 @@ const CustomContentTemplate = (args) => html`
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?disable-backdrop-click="${args.disableBackdropClick}"
+        ?backdrop-dismiss="${args.backdropDismiss}"
         ?open="${args.open}"
       >
 
@@ -254,7 +254,7 @@ const ScrollableTemplate = (args) => {
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?disable-backdrop-click="${args.disableBackdropClick}"
+        ?backdrop-dismiss="${args.backdropDismiss}"
         ?open="${args.open}"
       >
         <pds-modal-header>
@@ -337,7 +337,7 @@ const FullscreenTemplate = (args) => html`
     <pds-modal
       id="${args.componentId}"
       size=${args.size}
-      ?disable-backdrop-click=${args.disableBackdropClick}
+      ?backdrop-dismiss=${args.backdropDismiss}
       ?open="${args.open}"
     >
       <pds-modal-header>

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -8,7 +8,7 @@ export default {
   decorators: [withActions],
   title: 'components/Modal',
   args: {
-    closeOnBackdropClick: true,
+    disableBackdropClick: false,
     componentId: 'modal-demo',
     open: false,
     size: 'md',
@@ -30,7 +30,7 @@ const BaseTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?close-on-backdrop-click="${args.closeOnBackdropClick}"
+      ?disable-backdrop-click="${args.disableBackdropClick}"
       ?open="${args.open}"
     >
       <pds-modal-header>
@@ -100,7 +100,7 @@ const DestructiveTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?close-on-backdrop-click="${args.closeOnBackdropClick}"
+      ?disable-backdrop-click="${args.disableBackdropClick}"
       ?open="${args.open}"
     >
       <pds-modal-header>
@@ -166,7 +166,7 @@ const CustomContentTemplate = (args) => html`
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?close-on-backdrop-click="${args.closeOnBackdropClick}"
+        ?disable-backdrop-click="${args.disableBackdropClick}"
         ?open="${args.open}"
       >
 
@@ -254,7 +254,7 @@ const ScrollableTemplate = (args) => {
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?close-on-backdrop-click="${args.closeOnBackdropClick}"
+        ?disable-backdrop-click="${args.disableBackdropClick}"
         ?open="${args.open}"
       >
         <pds-modal-header>
@@ -337,7 +337,7 @@ const FullscreenTemplate = (args) => html`
     <pds-modal
       id="${args.componentId}"
       size=${args.size}
-      ?close-on-backdrop-click=${args.closeOnBackdropClick}
+      ?disable-backdrop-click=${args.disableBackdropClick}
       ?open="${args.open}"
     >
       <pds-modal-header>

--- a/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
@@ -34,9 +34,9 @@ export class MockPdsModal {
   // Modal content is always scrollable by default
 
   /**
-   * Whether clicking the backdrop to close the modal is disabled
+   * Whether the modal can be dismissed by clicking the backdrop
    */
-  @Prop() disableBackdropClick = false;
+  @Prop() backdropDismiss = true;
 
   // Native dialog element always closes on Escape key press, so no closeOnEsc property is needed
 
@@ -87,7 +87,7 @@ export class MockPdsModal {
   handleBackdropClick(event: MouseEvent) {
     const backdrop = this.el.querySelector('.pds-modal__backdrop');
     // Check if the click was directly on the backdrop (not on a child element)
-    if (event.target === backdrop && this.disableBackdropClick === false) {
+    if (event.target === backdrop && this.backdropDismiss === true) {
       this.pdsModalBackdropClick.emit();
       this.hideModal();
     }

--- a/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
@@ -34,9 +34,9 @@ export class MockPdsModal {
   // Modal content is always scrollable by default
 
   /**
-   * Whether the modal should close when clicking on the backdrop
+   * Whether clicking the backdrop to close the modal is disabled
    */
-  @Prop() closeOnBackdropClick = true;
+  @Prop() disableBackdropClick = false;
 
   // Native dialog element always closes on Escape key press, so no closeOnEsc property is needed
 
@@ -87,7 +87,7 @@ export class MockPdsModal {
   handleBackdropClick(event: MouseEvent) {
     const backdrop = this.el.querySelector('.pds-modal__backdrop');
     // Check if the click was directly on the backdrop (not on a child element)
-    if (event.target === backdrop && this.closeOnBackdropClick === true) {
+    if (event.target === backdrop && this.disableBackdropClick === false) {
       this.pdsModalBackdropClick.emit();
       this.hideModal();
     }

--- a/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
+++ b/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
@@ -84,11 +84,11 @@ describe('pds-modal', () => {
 
   // Modal is always scrollable by default, no need to test scrollable property
 
-  it('should handle disableBackdropClick prop', async () => {
+  it('should handle backdropDismiss prop', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<pds-modal disable-backdrop-click="true"></pds-modal>`);
+    await page.setContent(`<pds-modal backdrop-dismiss="false"></pds-modal>`);
 
     const modal = await page.find('pds-modal');
-    expect(await modal.getProperty('disableBackdropClick')).toBe(true);
+    expect(await modal.getProperty('backdropDismiss')).toBe(false);
   });
 });

--- a/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
+++ b/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
@@ -84,11 +84,11 @@ describe('pds-modal', () => {
 
   // Modal is always scrollable by default, no need to test scrollable property
 
-  it('should handle closeOnBackdropClick prop', async () => {
+  it('should handle disableBackdropClick prop', async () => {
     const page = await newE2EPage();
-    await page.setContent(`<pds-modal close-on-backdrop-click="false"></pds-modal>`);
+    await page.setContent(`<pds-modal disable-backdrop-click="true"></pds-modal>`);
 
     const modal = await page.find('pds-modal');
-    expect(await modal.getProperty('closeOnBackdropClick')).toBe(false);
+    expect(await modal.getProperty('disableBackdropClick')).toBe(true);
   });
 });

--- a/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
+++ b/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
@@ -52,7 +52,7 @@ describe('pds-modal', () => {
 
   // Modal is always scrollable by default, no need to test scrollable attribute
 
-  it('should have the correct closeOnBackdropClick attribute', async () => {
+  it('should have the correct disableBackdropClick attribute', async () => {
     // Default value should be true
     const defaultPage = await newSpecPage({
       components: [MockPdsModal],
@@ -126,7 +126,7 @@ describe('pds-modal', () => {
     expect(page.rootInstance.open).toBe(false);
   });
   
-  it('should handle backdrop click when closeOnBackdropClick is true', async () => {
+  it('should handle backdrop click when disableBackdropClick is false', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
@@ -148,7 +148,7 @@ describe('pds-modal', () => {
     expect(page.rootInstance.open).toBe(false);
   });
   
-  it('should not close on backdrop click when closeOnBackdropClick is false', async () => {
+  it('should not close on backdrop click when disableBackdropClick is true', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal close-on-backdrop-click="false"></mock-pds-modal>`,

--- a/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
+++ b/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
@@ -9,7 +9,7 @@ describe('pds-modal', () => {
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
-    
+
     expect(page.root).not.toBeNull();
     expect(page.root?.tagName.toLowerCase()).toBe('mock-pds-modal');
   });
@@ -19,7 +19,7 @@ describe('pds-modal', () => {
       components: [MockPdsModal],
       html: `<mock-pds-modal component-id="test-modal" size="lg" scrollable="true"></mock-pds-modal>`,
     });
-    
+
     expect(page.root).not.toBeNull();
     expect(page.root?.getAttribute('component-id')).toBe('test-modal');
     expect(page.root?.getAttribute('size')).toBe('lg');
@@ -34,14 +34,14 @@ describe('pds-modal', () => {
       html: `<mock-pds-modal size="sm"></pds-modal>`,
     });
     expect(smallPage.root?.getAttribute('size')).toBe('sm');
-    
+
     // Test large size
     const largePage = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal size="lg"></pds-modal>`,
     });
     expect(largePage.root?.getAttribute('size')).toBe('lg');
-    
+
     // Test fullscreen size
     const fullscreenPage = await newSpecPage({
       components: [MockPdsModal],
@@ -52,21 +52,21 @@ describe('pds-modal', () => {
 
   // Modal is always scrollable by default, no need to test scrollable attribute
 
-  it('should have the correct disableBackdropClick attribute', async () => {
+  it('should have the correct backdropDismiss attribute', async () => {
     // Default value should be true
     const defaultPage = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
-    expect(defaultPage.root?.getAttribute('close-on-backdrop-click')).toBeNull(); // Default value is not set as attribute
-    
+    expect(defaultPage.root?.getAttribute('backdrop-dismiss')).toBeNull(); // Default value is not set as attribute
+
     // Explicit false value
     const page = await newSpecPage({
       components: [MockPdsModal],
-      html: `<mock-pds-modal close-on-backdrop-click="false"></pds-modal>`,
+      html: `<mock-pds-modal backdrop-dismiss="false"></pds-modal>`,
     });
-    
-    expect(page.root?.getAttribute('close-on-backdrop-click')).toBe('false');
+
+    expect(page.root?.getAttribute('backdrop-dismiss')).toBe('false');
   });
 
   it('should have the correct closeOnEsc attribute', async () => {
@@ -76,13 +76,13 @@ describe('pds-modal', () => {
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
     expect(defaultPage.root?.getAttribute('close-on-esc')).toBeNull(); // Default value is not set as attribute
-    
+
     // Explicit false value
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal close-on-esc="false"></pds-modal>`,
     });
-    
+
     expect(page.root?.getAttribute('close-on-esc')).toBe('false');
   });
 
@@ -93,13 +93,13 @@ describe('pds-modal', () => {
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
     expect(defaultPage.root?.getAttribute('open')).toBeNull(); // Default value is not set as attribute
-    
+
     // Explicit true value
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal open="true"></mock-pds-modal>`,
     });
-    
+
     expect(page.root?.getAttribute('open')).toBe('true');
   });
 
@@ -108,82 +108,82 @@ describe('pds-modal', () => {
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
-    
+
     // Set up event spies
     const openSpy = jest.fn();
     const closeSpy = jest.fn();
     page.root?.addEventListener('pdsModalOpen', openSpy);
     page.root?.addEventListener('pdsModalClose', closeSpy);
-    
+
     // Show the modal
     await page.rootInstance.showModal();
     expect(openSpy).toHaveBeenCalled();
     expect(page.rootInstance.open).toBe(true);
-    
+
     // Hide the modal
     await page.rootInstance.hideModal();
     expect(closeSpy).toHaveBeenCalled();
     expect(page.rootInstance.open).toBe(false);
   });
-  
-  it('should handle backdrop click when disableBackdropClick is false', async () => {
+
+  it('should handle backdrop click when backdropDismiss is true', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
-    
+
     // Open the modal
     page.rootInstance.open = true;
     await page.waitForChanges();
-    
+
     // Get the backdrop element
     const backdrop = page.root?.querySelector('.pds-modal__backdrop');
     expect(backdrop).not.toBeNull();
-    
+
     // Directly call the handler method with a mocked event
     const mockEvent = { target: backdrop } as MouseEvent;
     page.rootInstance.handleBackdropClick(mockEvent);
-    
+
     // Modal should be closed
     expect(page.rootInstance.open).toBe(false);
   });
-  
-  it('should not close on backdrop click when disableBackdropClick is true', async () => {
+
+  it('should not close on backdrop click when backdropDismiss is false', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
-      html: `<mock-pds-modal close-on-backdrop-click="false"></mock-pds-modal>`,
+      html: `<mock-pds-modal backdrop-dismiss="false"></mock-pds-modal>`,
     });
-    
+
     // Open the modal
     page.rootInstance.open = true;
     await page.waitForChanges();
-    
+
     // Get the backdrop element
     const backdrop = page.root?.querySelector('.pds-modal__backdrop');
     expect(backdrop).not.toBeNull();
-    
+
     // Directly call the handler method with a mocked event
     const mockEvent = { target: backdrop } as MouseEvent;
     page.rootInstance.handleBackdropClick(mockEvent);
-    
+
     // Modal should still be open
     expect(page.rootInstance.open).toBe(true);
   });
-  
+
   it('should close on Escape key press (native dialog behavior)', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
     });
-    
+
     // Open the modal
     page.rootInstance.open = true;
     await page.waitForChanges();
-    
+
     // Directly call the handler method with a mocked event
     const mockEvent = { key: 'Escape' } as KeyboardEvent;
     page.rootInstance.handleKeyDown(mockEvent);
-    
+
     // Modal should be closed
     expect(page.rootInstance.open).toBe(false);
   });

--- a/libs/core/src/components/pds-modal/test/readme.md
+++ b/libs/core/src/components/pds-modal/test/readme.md
@@ -12,12 +12,12 @@ This component mimics the real PdsModal but without using the Popover API
 
 ## Properties
 
-| Property               | Attribute                | Description                                                  | Type                                   | Default     |
-| ---------------------- | ------------------------ | ------------------------------------------------------------ | -------------------------------------- | ----------- |
-| `componentId`          | `component-id`           | The ID of the modal component                                | `string`                               | `undefined` |
-| `disableBackdropClick` | `disable-backdrop-click` | Whether clicking the backdrop to close the modal is disabled | `boolean`                              | `false`     |
-| `open`                 | `open`                   | Whether the modal is open                                    | `boolean`                              | `false`     |
-| `size`                 | `size`                   | The size of the modal                                        | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
+| Property          | Attribute          | Description                                                 | Type                                   | Default     |
+| ----------------- | ------------------ | ----------------------------------------------------------- | -------------------------------------- | ----------- |
+| `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop | `boolean`                              | `true`      |
+| `componentId`     | `component-id`     | The ID of the modal component                               | `string`                               | `undefined` |
+| `open`            | `open`             | Whether the modal is open                                   | `boolean`                              | `false`     |
+| `size`            | `size`             | The size of the modal                                       | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 
 ## Events

--- a/libs/core/src/components/pds-modal/test/readme.md
+++ b/libs/core/src/components/pds-modal/test/readme.md
@@ -12,12 +12,12 @@ This component mimics the real PdsModal but without using the Popover API
 
 ## Properties
 
-| Property               | Attribute                 | Description                                                  | Type                                   | Default     |
-| ---------------------- | ------------------------- | ------------------------------------------------------------ | -------------------------------------- | ----------- |
-| `closeOnBackdropClick` | `close-on-backdrop-click` | Whether the modal should close when clicking on the backdrop | `boolean`                              | `true`      |
-| `componentId`          | `component-id`            | The ID of the modal component                                | `string`                               | `undefined` |
-| `open`                 | `open`                    | Whether the modal is open                                    | `boolean`                              | `false`     |
-| `size`                 | `size`                    | The size of the modal                                        | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
+| Property               | Attribute                | Description                                                  | Type                                   | Default     |
+| ---------------------- | ------------------------ | ------------------------------------------------------------ | -------------------------------------- | ----------- |
+| `componentId`          | `component-id`           | The ID of the modal component                                | `string`                               | `undefined` |
+| `disableBackdropClick` | `disable-backdrop-click` | Whether clicking the backdrop to close the modal is disabled | `boolean`                              | `false`     |
+| `open`                 | `open`                   | Whether the modal is open                                    | `boolean`                              | `false`     |
+| `size`                 | `size`                   | The size of the modal                                        | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 
 ## Events


### PR DESCRIPTION
# Description

PR updates `closeOnBackdropClick` to `backdropDismiss`

- [x] address [PR feedback in comment](https://github.com/Kajabi/pine/pull/456#discussion_r2112740147)
- [x] resolve missing reference in auto-generated file


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
