### PR TITLE
feat(pds-toast): add pds-toast component

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1106,7 +1106,7 @@ export namespace Components {
          */
         "duration": number;
         /**
-          * The icon to display in the toast.
+          * The name of the icon to display in the toast.
          */
         "icon"?: string;
         /**
@@ -2844,7 +2844,7 @@ declare namespace LocalJSX {
          */
         "duration"?: number;
         /**
-          * The icon to display in the toast.
+          * The name of the icon to display in the toast.
          */
         "icon"?: string;
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1089,6 +1089,32 @@ export namespace Components {
          */
         "value"?: string | null;
     }
+    interface PdsToast {
+        /**
+          * A unique identifier used for the underlying component `id` attribute.
+         */
+        "componentId": string;
+        "dismiss": () => Promise<void>;
+        /**
+          * Whether the toast can be dismissed manually via the close button. Note: This only controls manual dismissal. Auto-dismissal via duration still applies.
+          * @default true
+         */
+        "dismissible": boolean;
+        /**
+          * The duration in milliseconds to show the toast before auto-dismissing. Set to 0 to disable auto-dismiss.
+          * @default 4500
+         */
+        "duration": number;
+        /**
+          * The icon to display in the toast.
+         */
+        "icon"?: string;
+        /**
+          * The type of toast to display. - default: Grey background (default) - danger: Red background - loading: With spinner animation
+          * @default 'default'
+         */
+        "type": 'default' | 'danger' | 'loading';
+    }
     interface PdsTooltip {
         /**
           * A unique identifier used for the underlying component `id` attribute.
@@ -1207,6 +1233,10 @@ export interface PdsTableRowCustomEvent<T> extends CustomEvent<T> {
 export interface PdsTextareaCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsTextareaElement;
+}
+export interface PdsToastCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPdsToastElement;
 }
 declare global {
     interface HTMLPdsAccordionElement extends Components.PdsAccordion, HTMLStencilElement {
@@ -1585,6 +1615,23 @@ declare global {
         prototype: HTMLPdsTextareaElement;
         new (): HTMLPdsTextareaElement;
     };
+    interface HTMLPdsToastElementEventMap {
+        "pdsToastDismissed": { componentId?: string };
+    }
+    interface HTMLPdsToastElement extends Components.PdsToast, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPdsToastElementEventMap>(type: K, listener: (this: HTMLPdsToastElement, ev: PdsToastCustomEvent<HTMLPdsToastElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPdsToastElementEventMap>(type: K, listener: (this: HTMLPdsToastElement, ev: PdsToastCustomEvent<HTMLPdsToastElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLPdsToastElement: {
+        prototype: HTMLPdsToastElement;
+        new (): HTMLPdsToastElement;
+    };
     interface HTMLPdsTooltipElement extends Components.PdsTooltip, HTMLStencilElement {
     }
     var HTMLPdsTooltipElement: {
@@ -1624,6 +1671,7 @@ declare global {
         "pds-tabs": HTMLPdsTabsElement;
         "pds-text": HTMLPdsTextElement;
         "pds-textarea": HTMLPdsTextareaElement;
+        "pds-toast": HTMLPdsToastElement;
         "pds-tooltip": HTMLPdsTooltipElement;
     }
 }
@@ -2780,6 +2828,35 @@ declare namespace LocalJSX {
          */
         "value"?: string | null;
     }
+    interface PdsToast {
+        /**
+          * A unique identifier used for the underlying component `id` attribute.
+         */
+        "componentId": string;
+        /**
+          * Whether the toast can be dismissed manually via the close button. Note: This only controls manual dismissal. Auto-dismissal via duration still applies.
+          * @default true
+         */
+        "dismissible"?: boolean;
+        /**
+          * The duration in milliseconds to show the toast before auto-dismissing. Set to 0 to disable auto-dismiss.
+          * @default 4500
+         */
+        "duration"?: number;
+        /**
+          * The icon to display in the toast.
+         */
+        "icon"?: string;
+        /**
+          * Event emitted when the toast is dismissed, either manually or automatically.
+         */
+        "onPdsToastDismissed"?: (event: PdsToastCustomEvent<{ componentId?: string }>) => void;
+        /**
+          * The type of toast to display. - default: Grey background (default) - danger: Red background - loading: With spinner animation
+          * @default 'default'
+         */
+        "type"?: 'default' | 'danger' | 'loading';
+    }
     interface PdsTooltip {
         /**
           * A unique identifier used for the underlying component `id` attribute.
@@ -2859,6 +2936,7 @@ declare namespace LocalJSX {
         "pds-tabs": PdsTabs;
         "pds-text": PdsText;
         "pds-textarea": PdsTextarea;
+        "pds-toast": PdsToast;
         "pds-tooltip": PdsTooltip;
     }
 }
@@ -2898,6 +2976,7 @@ declare module "@stencil/core" {
             "pds-tabs": LocalJSX.PdsTabs & JSXBase.HTMLAttributes<HTMLPdsTabsElement>;
             "pds-text": LocalJSX.PdsText & JSXBase.HTMLAttributes<HTMLPdsTextElement>;
             "pds-textarea": LocalJSX.PdsTextarea & JSXBase.HTMLAttributes<HTMLPdsTextareaElement>;
+            "pds-toast": LocalJSX.PdsToast & JSXBase.HTMLAttributes<HTMLPdsToastElement>;
             "pds-tooltip": LocalJSX.PdsTooltip & JSXBase.HTMLAttributes<HTMLPdsTooltipElement>;
         }
     }

--- a/libs/core/src/components/pds-toast/docs/pds-toast.mdx
+++ b/libs/core/src/components/pds-toast/docs/pds-toast.mdx
@@ -1,0 +1,121 @@
+import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
+import { components } from '../../../../dist/docs.json';
+
+# Toast
+
+A toast notification component that displays temporary messages to users.
+
+## Guidelines
+
+### When to use
+
+- To provide feedback about an action that has occurred.
+- To display temporary notifications that don't require user interaction.
+- To show system status updates or alerts.
+
+### When not to use
+
+- For critical information that requires user acknowledgment.
+- For complex messages that require user interaction.
+- As a replacement for form validation messages.
+
+### Accessibility
+
+For accessibility, it is strongly encouraged to follow these best practices:
+
+- Keep toast messages concise and clear.
+- Use appropriate toast types (default, danger, loading) to convey the message importance.
+
+## Properties
+
+<DocArgsTable componentName="pds-toast" docSource={components} />
+
+## Examples
+
+> **NOTE:** For demonstration purposes, all examples below have `duration="0"` set to prevent auto-dismissal. In production, toasts should typically use the default duration or a custom duration appropriate for your use case.
+
+### Default
+
+A basic toast notification with a message.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-default" duration={0}>This is a default toast</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-default" duration="0">This is a default toast</pds-toast>'
+}}>
+  <pds-toast component-id="toast-default" duration="0">This is a default toast</pds-toast>
+</DocCanvas>
+
+### Danger
+
+A toast notification indicating an error or critical message.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-danger" duration={0} type="danger">An error occurred</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-danger" duration="0" type="danger">An error occurred</pds-toast>'
+}}>
+  <pds-toast component-id="toast-danger" duration="0" type="danger">An error occurred</pds-toast>
+</DocCanvas>
+
+### Loading
+
+A toast notification indicating a loading or processing state.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-loading" duration={0} type="loading">Processing your request...</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-loading" duration="0" type="loading">Processing your request...</pds-toast>'
+}}>
+  <pds-toast component-id="toast-loading" duration="0" type="loading">Processing your request...</pds-toast>
+</DocCanvas>
+
+### With Icon
+
+A toast notification with a custom icon.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-icon" duration={0} icon="check-circle-filled">Successfully saved!</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-icon" duration="0" icon="check-circle-filled">Successfully saved!</pds-toast>'
+}}>
+  <pds-toast component-id="toast-icon" duration="0" icon="check-circle-filled">Successfully saved!</pds-toast>
+</DocCanvas>
+
+### With Link
+
+A toast notification that includes a clickable link. Links are automatically styled to match the toast design.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-link" duration={0}>New update available. <a href="#">Learn more</a></PdsToast>',
+    webComponent: '<pds-toast component-id="toast-link" duration="0">New update available. <a href="#">Learn more</a></pds-toast>'
+}}>
+  <div style={{ width: '100%', maxWidth: '300px' }}>
+  <pds-toast component-id="toast-link" duration="0">New update available. <a href="#">Learn more</a></pds-toast>
+  </div>
+</DocCanvas>
+
+### Complex Content
+
+A toast notification with rich content, demonstrating the flexibility of the default slot.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-complex" duration={0}><strong>Success!</strong> Your profile has been updated with new information.</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-complex" duration="0"><strong>Success!</strong> Your profile has been updated with new information.</pds-toast>'
+}}>
+  <pds-toast component-id="toast-complex" duration="0"><strong>Success!</strong> Your profile has been updated with new information.</pds-toast>
+</DocCanvas>
+
+### Non-dismissing Toast
+
+A toast notification that will remain visible until manually dismissed. This is achieved by setting the duration to 0.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsToast componentId="toast-persistent" duration={0}>This toast will stay until dismissed</PdsToast>',
+    webComponent: '<pds-toast component-id="toast-persistent" duration="0">This toast will stay until dismissed</pds-toast>'
+}}>
+  <pds-toast component-id="toast-persistent" duration="0">This toast will stay until dismissed</pds-toast>
+</DocCanvas>

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -171,6 +171,8 @@
 }
 
 // Animation for dismissing
-:host([hidden]) .pds-toast {
+:host([hidden]) .pds-toast,
+.pds-toast--animating-out {
   animation: pds-toast--animate-out var(--animation-duration) var(--animation-timing) forwards;
+  pointer-events: none; /* Prevent interaction during animation */
 }

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -1,7 +1,7 @@
 :host {
   --animation-duration: 0.3s;
   --animation-timing: cubic-bezier(0.4, 0, 0.2, 1);
-  --padding-inline: var(--pine-dimension-lg);
+  --padding-inline: var(--pine-dimension-md);
   --padding-inline-desktop: var(--pine-dimension-2xl);
   --sizing-height-default: 68px;
   --sizing-min-width: calc(var(--sizing-total-width) - (var(--padding-inline) * 2));

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -1,0 +1,176 @@
+:host {
+  --animation-duration: 0.3s;
+  --animation-timing: cubic-bezier(0.4, 0, 0.2, 1);
+  --padding-inline: var(--pine-dimension-lg);
+  --padding-inline-desktop: var(--pine-dimension-2xl);
+  --sizing-height-default: 68px;
+  --sizing-min-width: calc(var(--sizing-total-width) - (var(--padding-inline) * 2));
+  --sizing-min-width-desktop: calc(var(--sizing-total-width) - (var(--padding-inline-desktop) * 2));
+  --sizing-total-width: 350px;
+
+  box-sizing: border-box;
+  display: block;
+  font: var(--pine-typography-body-medium);
+}
+
+.pds-toast {
+  align-items: center;
+  animation: pds-toast--animate-in var(--animation-duration) var(--animation-timing);
+  background-color: var(--pine-color-primary);
+  border-radius: var(--pine-dimension-xs);
+  box-shadow: var(--pine-box-shadow);
+  color: var(--pine-color-text-primary);
+  display: flex;
+  height: var(--sizing-height-default);
+  justify-content: flex-start;
+  margin-block-end: var(--pine-dimension-2xs);
+  max-width: 90vw;
+  min-width: var(--sizing-min-width);
+  padding: 0 var(--padding-inline);
+  position: relative;
+  width: fit-content;
+
+  @media screen and (max-width: 767px) {
+    height: 36px;
+    max-width: calc(100vw - (var(--pine-dimension-2xs) * 2));
+    min-width: auto;
+    padding-inline: var(--pine-dimension-2xs);
+  }
+
+  &--danger {
+    background-color: var(--pine-color-danger);
+  }
+
+  &--loading {
+    .pds-toast__loader {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      margin-inline-end: var(--pine-dimension-sm);
+      position: relative;
+
+      &-spinner {
+        animation: pds-toast--rotate 2s linear infinite;
+        height: 20px;
+        width: 20px;
+      }
+
+      &-path {
+        animation: pds-toast--dash 1.5s ease-in-out infinite;
+        stroke-dasharray: 1, 200;
+        stroke-dashoffset: 0;
+        stroke-linecap: round;
+      }
+    }
+  }
+}
+
+.pds-toast__icon {
+  color: var(--pine-color-text-primary);
+  display: inline-flex;
+  margin-inline-end: var(--pine-dimension-sm);
+}
+
+.pds-toast__message {
+  font: var(--pine-typography-body-sm-medium);
+  margin-inline-end: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  // Style all slotted links
+  ::slotted(a) {
+    color: var(--pine-color-text-primary);
+    margin-inline-start: var(--pine-dimension-xs);
+    opacity: 0.7;
+    text-decoration: underline;
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--pine-color-text-primary);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.pds-toast__button {
+  align-items: center;
+  background: none;
+  border: 0;
+  border-radius: var(--pine-border-radius-full);
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  margin-inline-start: var(--pine-dimension-md);
+  opacity: 0.7;
+  padding: 0;
+  white-space: nowrap;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+
+  &:focus {
+    outline: var(--pine-outline-focus);
+    outline-offset: var(--pine-dimension-2xs);
+  }
+}
+
+// Animation keyframes
+@keyframes pds-toast--animate-in {
+  from {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pds-toast--animate-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(100%);
+  }
+}
+
+// Loading animation keyframes
+@keyframes pds-toast--rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pds-toast--dash {
+  0% {
+    stroke-dasharray: 1, 200;
+    stroke-dashoffset: 0;
+  }
+
+  50% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -35;
+  }
+
+  100% {
+    stroke-dasharray: 89, 200;
+    stroke-dashoffset: -124;
+  }
+}
+
+// Animation for dismissing
+:host([hidden]) .pds-toast {
+  animation: pds-toast--animate-out var(--animation-duration) var(--animation-timing) forwards;
+}

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -15,7 +15,7 @@
 
 .pds-toast {
   align-items: center;
-  animation: pds-toast--animate-in var(--animation-duration) var(--animation-timing);
+  animation: pds-toast-animate-in var(--animation-duration) var(--animation-timing);
   background-color: var(--pine-color-primary);
   border-radius: var(--pine-dimension-xs);
   box-shadow: var(--pine-box-shadow);
@@ -50,13 +50,13 @@
       position: relative;
 
       &-spinner {
-        animation: pds-toast--rotate 2s linear infinite;
+        animation: pds-toast-rotate 2s linear infinite;
         height: 20px;
         width: 20px;
       }
 
       &-path {
-        animation: pds-toast--dash 1.5s ease-in-out infinite;
+        animation: pds-toast-dash 1.5s ease-in-out infinite;
         stroke-dasharray: 1, 200;
         stroke-dashoffset: 0;
         stroke-linecap: round;
@@ -122,7 +122,7 @@
 }
 
 // Animation keyframes
-@keyframes pds-toast--animate-in {
+@keyframes pds-toast-animate-in {
   from {
     opacity: 0;
     transform: translateY(100%);
@@ -134,7 +134,7 @@
   }
 }
 
-@keyframes pds-toast--animate-out {
+@keyframes pds-toast-animate-out {
   from {
     opacity: 1;
     transform: translateY(0);
@@ -147,13 +147,13 @@
 }
 
 // Loading animation keyframes
-@keyframes pds-toast--rotate {
+@keyframes pds-toast-rotate {
   to {
     transform: rotate(360deg);
   }
 }
 
-@keyframes pds-toast--dash {
+@keyframes pds-toast-dash {
   0% {
     stroke-dasharray: 1, 200;
     stroke-dashoffset: 0;
@@ -173,6 +173,6 @@
 // Animation for dismissing
 :host([hidden]) .pds-toast,
 .pds-toast--animating-out {
-  animation: pds-toast--animate-out var(--animation-duration) var(--animation-timing) forwards;
+  animation: pds-toast-animate-out var(--animation-duration) var(--animation-timing) forwards;
   pointer-events: none; /* Prevent interaction during animation */
 }

--- a/libs/core/src/components/pds-toast/pds-toast.tsx
+++ b/libs/core/src/components/pds-toast/pds-toast.tsx
@@ -1,0 +1,156 @@
+import { Component, Event, EventEmitter, h, Host, Method, Prop, State, Watch } from '@stencil/core';
+
+@Component({
+  tag: 'pds-toast',
+  styleUrl: 'pds-toast.scss',
+  shadow: true,
+})
+export class PdsToast {
+  // Props
+  /**
+   * A unique identifier used for the underlying component `id` attribute.
+   */
+  @Prop() componentId!: string;
+
+  /**
+   * Whether the toast can be dismissed manually via the close button.
+   * Note: This only controls manual dismissal. Auto-dismissal via duration still applies.
+   * @default true
+   */
+  @Prop() dismissible: boolean = true;
+
+  /**
+   * The duration in milliseconds to show the toast before auto-dismissing.
+   * Set to 0 to disable auto-dismiss.
+   * @default 4500
+   */
+  @Prop() duration: number = 4500;
+
+  /**
+   * The icon to display in the toast.
+   */
+  @Prop() icon?: string;
+
+  /**
+   * The type of toast to display.
+   * - default: Grey background (default)
+   * - danger: Red background
+   * - loading: With spinner animation
+   * @default 'default'
+   */
+  @Prop() type: 'default' | 'danger' | 'loading' = 'default';
+
+  /**
+   * Whether the toast is currently visible.
+   */
+  @State() isVisible: boolean = true;
+
+  // Private properties
+  /**
+   * Timer for auto-dismissal
+   */
+  private dismissTimer?: number;
+
+  /**
+   * Event emitted when the toast is dismissed, either manually or automatically.
+   */
+  @Event() pdsToastDismissed: EventEmitter<{ componentId?: string }>;
+
+  componentDidLoad() {
+    if (this.duration > 0) {
+      this.startDismissTimer();
+    }
+  }
+
+  disconnectedCallback() {
+    this.cleanup();
+  }
+
+  @Watch('duration')
+  handleDurationChange(newDuration: number) {
+    if (this.dismissTimer) {
+      window.clearTimeout(this.dismissTimer);
+      this.dismissTimer = undefined;
+    }
+    if (newDuration > 0) {
+      this.startDismissTimer();
+    }
+  }
+
+  @Method()
+  async dismiss(): Promise<void> {
+    this.isVisible = false;
+
+    // Wait for animation to complete before cleanup
+    await new Promise((resolve) => setTimeout(resolve, 300)); // Match --pds-toast-animation-duration
+
+    this.cleanup();
+    this.pdsToastDismissed.emit({ componentId: this.componentId });
+  }
+
+  // Private methods
+  private cleanup(): void {
+    if (this.dismissTimer) {
+      window.clearTimeout(this.dismissTimer);
+      this.dismissTimer = undefined;
+    }
+  }
+
+  private startDismissTimer(): void {
+    this.dismissTimer = window.setTimeout(() => {
+      this.dismiss();
+    }, this.duration);
+  }
+
+  private renderIcon() {
+    if (this.type === 'loading') {
+      return (
+        <div class="pds-toast__loader">
+          <svg class="pds-toast__loader-spinner" viewBox="25 25 50 50" aria-hidden="true">
+            <circle class="pds-toast__loader-path" cx="50" cy="50" r="20" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" />
+          </svg>
+        </div>
+      );
+    }
+
+    if (this.icon) {
+      return <pds-icon name={this.icon} class="pds-toast__icon" />;
+    }
+
+    return null;
+  }
+
+  render() {
+    return (
+      <Host hidden={!this.isVisible}>
+        <div
+          class={{
+            'pds-toast': true,
+            [`pds-toast--${this.type}`]: this.type !== 'default',
+          }}
+          role="alert"
+          aria-live="polite"
+        >
+          {this.renderIcon()}
+
+          <span class="pds-toast__message">
+            <slot></slot>
+          </span>
+
+          {this.dismissible && (
+            <button
+              type="button"
+              class="pds-toast__button"
+              onClick={() => {
+                this.dismiss();
+              }}
+              aria-label="Dismiss message"
+            >
+              <pds-icon name="remove" />
+            </button>
+          )}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/libs/core/src/components/pds-toast/pds-toast.tsx
+++ b/libs/core/src/components/pds-toast/pds-toast.tsx
@@ -27,7 +27,7 @@ export class PdsToast {
   @Prop() duration: number = 4500;
 
   /**
-   * The icon to display in the toast.
+   * The name of the icon to display in the toast.
    */
   @Prop() icon?: string;
 
@@ -110,6 +110,7 @@ export class PdsToast {
   }
 
   private renderIcon() {
+    // Loading type takes priority
     if (this.type === 'loading') {
       return (
         <div class="pds-toast__loader">
@@ -120,11 +121,8 @@ export class PdsToast {
       );
     }
 
-    if (this.icon) {
-      return <pds-icon name={this.icon} class="pds-toast__icon" />;
-    }
-
-    return null;
+    // Return icon if provided, otherwise undefined (which renders as nothing)
+    return this.icon && <pds-icon name={this.icon} class="pds-toast__icon" />;
   }
 
   render() {

--- a/libs/core/src/components/pds-toast/pds-toast.tsx
+++ b/libs/core/src/components/pds-toast/pds-toast.tsx
@@ -27,7 +27,7 @@ export class PdsToast {
   @Prop() duration: number = 4500;
 
   /**
-   * The name of the icon to display in the toast.
+   * The icon to display in the toast.
    */
   @Prop() icon?: string;
 
@@ -44,6 +44,11 @@ export class PdsToast {
    * Whether the toast is currently visible.
    */
   @State() isVisible: boolean = true;
+
+  /**
+   * Whether the toast is animating out.
+   */
+  @State() isAnimatingOut: boolean = false;
 
   // Private properties
   /**
@@ -79,11 +84,13 @@ export class PdsToast {
 
   @Method()
   async dismiss(): Promise<void> {
+    // Start the animation out
+    this.isAnimatingOut = true;
+
+    // Wait for animation to complete before hiding and cleanup
+    await new Promise((resolve) => setTimeout(resolve, 300)); // Match --animation-duration
+
     this.isVisible = false;
-
-    // Wait for animation to complete before cleanup
-    await new Promise((resolve) => setTimeout(resolve, 300)); // Match --pds-toast-animation-duration
-
     this.cleanup();
     this.pdsToastDismissed.emit({ componentId: this.componentId });
   }
@@ -127,6 +134,7 @@ export class PdsToast {
           class={{
             'pds-toast': true,
             [`pds-toast--${this.type}`]: this.type !== 'default',
+            'pds-toast--animating-out': this.isAnimatingOut
           }}
           role="alert"
           aria-live="polite"

--- a/libs/core/src/components/pds-toast/pds-toast.tsx
+++ b/libs/core/src/components/pds-toast/pds-toast.tsx
@@ -27,7 +27,7 @@ export class PdsToast {
   @Prop() duration: number = 4500;
 
   /**
-   * The icon to display in the toast.
+   * The name of the icon to display in the toast.
    */
   @Prop() icon?: string;
 

--- a/libs/core/src/components/pds-toast/readme.md
+++ b/libs/core/src/components/pds-toast/readme.md
@@ -1,0 +1,54 @@
+# pds-toast
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property                   | Attribute      | Description                                                                                                                                             | Type                                 | Default     |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------- |
+| `componentId` _(required)_ | `component-id` | A unique identifier used for the underlying component `id` attribute.                                                                                   | `string`                             | `undefined` |
+| `dismissible`              | `dismissible`  | Whether the toast can be dismissed manually via the close button. Note: This only controls manual dismissal. Auto-dismissal via duration still applies. | `boolean`                            | `true`      |
+| `duration`                 | `duration`     | The duration in milliseconds to show the toast before auto-dismissing. Set to 0 to disable auto-dismiss.                                                | `number`                             | `4500`      |
+| `icon`                     | `icon`         | The icon to display in the toast.                                                                                                                       | `string`                             | `undefined` |
+| `type`                     | `type`         | The type of toast to display. - default: Grey background (default) - danger: Red background - loading: With spinner animation                           | `"danger" \| "default" \| "loading"` | `'default'` |
+
+
+## Events
+
+| Event               | Description                                                                  | Type                                     |
+| ------------------- | ---------------------------------------------------------------------------- | ---------------------------------------- |
+| `pdsToastDismissed` | Event emitted when the toast is dismissed, either manually or automatically. | `CustomEvent<{ componentId?: string; }>` |
+
+
+## Methods
+
+### `dismiss() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Depends on
+
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-toast --> pds-icon
+  style pds-toast fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/libs/core/src/components/pds-toast/readme.md
+++ b/libs/core/src/components/pds-toast/readme.md
@@ -12,7 +12,7 @@
 | `componentId` _(required)_ | `component-id` | A unique identifier used for the underlying component `id` attribute.                                                                                   | `string`                             | `undefined` |
 | `dismissible`              | `dismissible`  | Whether the toast can be dismissed manually via the close button. Note: This only controls manual dismissal. Auto-dismissal via duration still applies. | `boolean`                            | `true`      |
 | `duration`                 | `duration`     | The duration in milliseconds to show the toast before auto-dismissing. Set to 0 to disable auto-dismiss.                                                | `number`                             | `4500`      |
-| `icon`                     | `icon`         | The icon to display in the toast.                                                                                                                       | `string`                             | `undefined` |
+| `icon`                     | `icon`         | The name of the icon to display in the toast.                                                                                                           | `string`                             | `undefined` |
 | `type`                     | `type`         | The type of toast to display. - default: Grey background (default) - danger: Red background - loading: With spinner animation                           | `"danger" \| "default" \| "loading"` | `'default'` |
 
 

--- a/libs/core/src/components/pds-toast/stories/pds-toast.docs.mdx
+++ b/libs/core/src/components/pds-toast/stories/pds-toast.docs.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+
+import Docs from '../docs/pds-toast.mdx'
+
+import * as stories from './pds-toast.stories.js';
+
+<Meta of={stories} />
+
+<Docs />
+
+## Playground
+
+<Canvas of={stories.Default} />
+
+<Controls of={stories.Default} />

--- a/libs/core/src/components/pds-toast/stories/pds-toast.stories.js
+++ b/libs/core/src/components/pds-toast/stories/pds-toast.stories.js
@@ -1,0 +1,103 @@
+import { html } from 'lit';
+import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
+
+export default {
+  argTypes: extractArgTypes('pds-toast'),
+  component: 'pds-toast',
+  title: 'components/Toast',
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: [
+        'pdsToastDismissed'
+      ],
+    },
+  },
+}
+
+const BaseTemplate = (args) => html`
+<pds-toast
+  .dismissible="${args.dismissible}"
+  component-id="${args.componentId}"
+  duration="${args.duration}"
+  icon="${args.icon || ''}"
+  type="${args.type}"
+>
+  ${args.content || ''}
+</pds-toast>`;
+
+const WithLinkTemplate = (args) => html`
+<pds-toast
+  .dismissible="${args.dismissible}"
+  component-id="${args.componentId}"
+  duration="${args.duration}"
+  icon="${args.icon || ''}"
+  type="${args.type}"
+>
+  New update available. <a href="#">Learn more</a>
+</pds-toast>`;
+
+export const Default = BaseTemplate.bind();
+Default.args = {
+  componentId: 'toast-default',
+  content: 'This is a default toast message',
+  dismissible: true,
+  duration: 0, // Set to 0 for demo purposes
+  type: 'default',
+};
+
+export const Danger = BaseTemplate.bind();
+Danger.args = {
+  componentId: 'toast-danger',
+  content: 'An error occurred. Please try again.',
+  dismissible: true,
+  duration: 0,
+  type: 'danger',
+};
+
+export const Loading = BaseTemplate.bind();
+Loading.args = {
+  componentId: 'toast-loading',
+  content: 'Processing your request...',
+  dismissible: false,
+  duration: 0,
+  type: 'loading',
+};
+
+export const WithIcon = BaseTemplate.bind();
+WithIcon.args = {
+  componentId: 'toast-with-icon',
+  content: 'Successfully saved!',
+  dismissible: true,
+  duration: 0,
+  icon: 'check-circle-filled',
+  type: 'default',
+};
+
+export const WithLink = WithLinkTemplate.bind();
+WithLink.args = {
+  componentId: 'toast-with-link',
+  dismissible: true,
+  duration: 0,
+  type: 'default',
+};
+
+export const NonDismissible = BaseTemplate.bind();
+NonDismissible.args = {
+  componentId: 'toast-non-dismissible',
+  content: 'This toast cannot be manually dismissed and will auto-dismiss after 4.5 seconds',
+  dismissible: false,
+  duration: 4500,
+  type: 'default',
+};
+
+export const AutoDismiss = BaseTemplate.bind();
+AutoDismiss.args = {
+  componentId: 'toast-auto-dismiss',
+  type: 'default',
+  content: 'This toast will auto-dismiss after 2 seconds',
+  dismissible: true,
+  duration: 2000
+};
+

--- a/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
+++ b/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
@@ -8,4 +8,289 @@ describe('pds-toast', () => {
     const element = await page.find('pds-toast');
     expect(element).toHaveClass('hydrated');
   });
+
+  it('should render with message content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast">
+        <span>This is a test message</span>
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+    expect(element).toHaveClass('hydrated');
+
+    // Use page.evaluate to access shadow DOM directly
+    const hasMessageContent = await page.evaluate(() => {
+      const toast = document.querySelector('pds-toast');
+      const shadowRoot = toast?.shadowRoot;
+      const messageElement = shadowRoot?.querySelector('.pds-toast__message');
+      return !!messageElement;
+    });
+
+    expect(hasMessageContent).toBe(true);
+
+    const textContent = await page.evaluate(() => {
+      const toast = document.querySelector('pds-toast');
+      return toast?.textContent?.trim();
+    });
+    expect(textContent).toContain('This is a test message');
+  });
+
+  it('should render dismiss button by default', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast">
+        Test message
+      </pds-toast>
+    `);
+
+    const dismissButton = await page.find('pds-toast >>> .pds-toast__button');
+    expect(dismissButton).toBeTruthy();
+
+    const ariaLabel = await dismissButton.getAttribute('aria-label');
+    expect(ariaLabel).toBe('Dismiss message');
+  });
+
+  it('should not render dismiss button when dismissible is false', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" dismissible="false">
+        Test message
+      </pds-toast>
+    `);
+
+    const dismissButton = await page.find('pds-toast >>> .pds-toast__button');
+    expect(dismissButton).toBeNull();
+  });
+
+  it('should dismiss when dismiss button is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Test message
+      </pds-toast>
+    `);
+
+    // Wait for component to be ready
+    await page.waitForChanges();
+
+    const element = await page.find('pds-toast');
+    const dismissButton = await page.find('pds-toast >>> .pds-toast__button');
+
+    // Verify toast is initially visible
+    expect(await element.isVisible()).toBe(true);
+
+    // Click dismiss button
+    await dismissButton.click();
+    await page.waitForChanges();
+
+    // Wait for animation to complete
+    await new Promise(resolve => setTimeout(resolve, 400));
+
+    // Verify toast is hidden
+    const hiddenAttribute = await element.getAttribute('hidden');
+    expect(hiddenAttribute).not.toBeNull();
+  });
+
+  it('should emit dismiss event when dismissed', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Test message
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+    const dismissButton = await page.find('pds-toast >>> .pds-toast__button');
+
+    // Listen for the dismiss event
+    const dismissEvent = await element.spyOnEvent('pdsToastDismissed');
+
+    // Click dismiss button
+    await dismissButton.click();
+    await page.waitForChanges();
+
+    // Wait for dismiss to complete
+    await new Promise(resolve => setTimeout(resolve, 400));
+
+    // Verify event was emitted
+    expect(dismissEvent).toHaveReceivedEventTimes(1);
+    expect(dismissEvent).toHaveReceivedEventDetail({ componentId: 'test-toast' });
+  });
+
+  it('should auto-dismiss after specified duration', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="500">
+        Test message
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+
+    // Listen for the dismiss event
+    const dismissEvent = await element.spyOnEvent('pdsToastDismissed');
+
+    // Verify toast is initially visible
+    expect(await element.isVisible()).toBe(true);
+
+    // Wait for auto-dismiss (shorter duration for faster test)
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Verify toast was dismissed by checking the event first
+    expect(dismissEvent).toHaveReceivedEventTimes(1);
+  });
+
+  it('should not auto-dismiss when duration is 0', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Test message
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+
+    // Listen for the dismiss event
+    const dismissEvent = await element.spyOnEvent('pdsToastDismissed');
+
+    // Verify toast is initially visible
+    expect(await element.isVisible()).toBe(true);
+
+    // Wait longer than a typical auto-dismiss duration
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Verify toast was NOT auto-dismissed
+    expect(dismissEvent).toHaveReceivedEventTimes(0);
+    expect(await element.isVisible()).toBe(true);
+  });
+
+  it('should render with icon when provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" icon="info">
+        Test message with icon
+      </pds-toast>
+    `);
+
+    const iconElement = await page.find('pds-toast >>> .pds-toast__icon');
+    expect(iconElement).toBeTruthy();
+
+    const iconName = await iconElement.getAttribute('name');
+    expect(iconName).toBe('info');
+  });
+
+  it('should render loading type with spinner', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" type="loading">
+        Loading message
+      </pds-toast>
+    `);
+
+    const toastElement = await page.find('pds-toast >>> .pds-toast');
+    const loaderElement = await page.find('pds-toast >>> .pds-toast__loader');
+    const spinnerElement = await page.find('pds-toast >>> .pds-toast__loader-spinner');
+
+    expect(toastElement).toHaveClass('pds-toast--loading');
+    expect(loaderElement).toBeTruthy();
+    expect(spinnerElement).toBeTruthy();
+  });
+
+  it('should render danger type with correct styling', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" type="danger">
+        Error message
+      </pds-toast>
+    `);
+
+    const toastElement = await page.find('pds-toast >>> .pds-toast');
+    expect(toastElement).toHaveClass('pds-toast--danger');
+  });
+
+  it('should have proper ARIA attributes for accessibility', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast">
+        Accessible message
+      </pds-toast>
+    `);
+
+    const toastElement = await page.find('pds-toast >>> .pds-toast');
+
+    const role = await toastElement.getAttribute('role');
+    const ariaLive = await toastElement.getAttribute('aria-live');
+
+    expect(role).toBe('alert');
+    expect(ariaLive).toBe('polite');
+  });
+
+  it('should handle links within message content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Message with <a href="#test">link</a>
+      </pds-toast>
+    `);
+
+    const linkElement = await page.find('pds-toast a');
+    expect(linkElement).toBeTruthy();
+
+    const href = await linkElement.getAttribute('href');
+    expect(href).toBe('#test');
+
+    // Test that link is clickable
+    await linkElement.click();
+    // In a real scenario, you'd test navigation or event handling
+  });
+
+  it('should update when duration property changes', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Test message
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+
+    // Change duration property
+    element.setProperty('duration', 500);
+    await page.waitForChanges();
+
+    const duration = await element.getProperty('duration');
+    expect(duration).toBe(500);
+  });
+
+  it('should maintain visibility state correctly', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-toast component-id="test-toast" duration="0">
+        Test message
+      </pds-toast>
+    `);
+
+    const element = await page.find('pds-toast');
+
+    // Check initial visibility through DOM
+    expect(await element.isVisible()).toBe(true);
+
+    // Check that component has no hidden attribute initially
+    let hiddenAttribute = await element.getAttribute('hidden');
+    expect(hiddenAttribute).toBeNull();
+
+    // Trigger dismiss
+    const dismissButton = await page.find('pds-toast >>> .pds-toast__button');
+    await dismissButton.click();
+    await page.waitForChanges();
+
+    // Wait for animation
+    await new Promise(resolve => setTimeout(resolve, 400));
+
+    // Check final state through hidden attribute
+    hiddenAttribute = await element.getAttribute('hidden');
+    expect(hiddenAttribute).not.toBeNull();
+  });
 });

--- a/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
+++ b/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pds-toast', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-toast></pds-toast>');
+
+    const element = await page.find('pds-toast');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
+++ b/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
@@ -85,12 +85,11 @@ describe('pds-toast', () => {
     await dismissButton.click();
     await page.waitForChanges();
 
-    // Wait for animation to complete
-    await new Promise(resolve => setTimeout(resolve, 400));
+    // Wait for animation to complete (component uses 300ms + some processing time)
+    await new Promise(resolve => setTimeout(resolve, 500));
 
-    // Verify toast is hidden
-    const hiddenAttribute = await element.getAttribute('hidden');
-    expect(hiddenAttribute).not.toBeNull();
+    // Verify toast is hidden - check visibility
+    expect(await element.isVisible()).toBe(false);
   });
 
   it('should emit dismiss event when dismissed', async () => {
@@ -278,7 +277,7 @@ describe('pds-toast', () => {
     expect(await element.isVisible()).toBe(true);
 
     // Check that component has no hidden attribute initially
-    let hiddenAttribute = await element.getAttribute('hidden');
+    const hiddenAttribute = await element.getAttribute('hidden');
     expect(hiddenAttribute).toBeNull();
 
     // Trigger dismiss
@@ -286,11 +285,10 @@ describe('pds-toast', () => {
     await dismissButton.click();
     await page.waitForChanges();
 
-    // Wait for animation
-    await new Promise(resolve => setTimeout(resolve, 400));
+    // Wait for animation and state update (component uses 300ms + processing time)
+    await new Promise(resolve => setTimeout(resolve, 500));
 
-    // Check final state through hidden attribute
-    hiddenAttribute = await element.getAttribute('hidden');
-    expect(hiddenAttribute).not.toBeNull();
+    // Check final state - should not be visible
+    expect(await element.isVisible()).toBe(false);
   });
 });

--- a/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
+++ b/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
@@ -5,14 +5,270 @@ describe('pds-toast', () => {
   it('renders', async () => {
     const page = await newSpecPage({
       components: [PdsToast],
-      html: `<pds-toast></pds-toast>`,
+      html: `<pds-toast component-id="test-toast"></pds-toast>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-toast>
+      <pds-toast component-id="test-toast">
         <mock:shadow-root>
-          <slot></slot>
+          <div aria-live="polite" class="pds-toast" role="alert">
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+              <pds-icon name="remove"></pds-icon>
+            </button>
+          </div>
         </mock:shadow-root>
       </pds-toast>
     `);
+  });
+
+  it('renders with icon', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" icon="info"></pds-toast>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-toast component-id="test-toast" icon="info">
+        <mock:shadow-root>
+          <div aria-live="polite" class="pds-toast" role="alert">
+            <pds-icon class="pds-toast__icon" name="info"></pds-icon>
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+              <pds-icon name="remove"></pds-icon>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+
+  it('renders loading type with spinner', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" type="loading"></pds-toast>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-toast component-id="test-toast" type="loading">
+        <mock:shadow-root>
+          <div aria-live="polite" class="pds-toast pds-toast--loading" role="alert">
+            <div class="pds-toast__loader">
+              <svg aria-hidden="true" class="pds-toast__loader-spinner" viewBox="25 25 50 50">
+                <circle class="pds-toast__loader-path" cx="50" cy="50" fill="none" r="20" stroke="currentColor" stroke-linecap="round" stroke-width="4"></circle>
+              </svg>
+            </div>
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+              <pds-icon name="remove"></pds-icon>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+
+  it('renders danger type', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" type="danger"></pds-toast>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-toast component-id="test-toast" type="danger">
+        <mock:shadow-root>
+          <div aria-live="polite" class="pds-toast pds-toast--danger" role="alert">
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+              <pds-icon name="remove"></pds-icon>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+
+  it('renders without dismiss button when dismissible is false', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" dismissible="false"></pds-toast>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-toast component-id="test-toast" dismissible="false">
+        <mock:shadow-root>
+          <div aria-live="polite" class="pds-toast" role="alert">
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+          </div>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+
+  it('hides when isVisible is false', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+    component.isVisible = false;
+    await page.waitForChanges();
+
+    expect(page.root).toEqualHtml(`
+      <pds-toast component-id="test-toast" hidden="">
+        <mock:shadow-root>
+          <div aria-live="polite" class="pds-toast" role="alert">
+            <span class="pds-toast__message">
+              <slot></slot>
+            </span>
+            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+              <pds-icon name="remove"></pds-icon>
+            </button>
+          </div>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+
+  // Test for renderIcon() returning null (line 101)
+  it('renders without icon when no icon prop and type is default', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" type="default"></pds-toast>`,
+    });
+
+    expect(page.root).toBeDefined();
+    expect(page.root!.shadowRoot).toBeDefined();
+
+    const iconElement = page.root!.shadowRoot!.querySelector('.pds-toast__icon');
+    const loaderElement = page.root!.shadowRoot!.querySelector('.pds-toast__loader');
+
+    expect(iconElement).toBeNull();
+    expect(loaderElement).toBeNull();
+  });
+
+  // Test for dismiss() method (lines 71-88)
+  it('should call dismiss method and emit event', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+    const dismissSpy = jest.spyOn(component.pdsToastDismissed, 'emit');
+
+    await component.dismiss();
+
+    expect(component.isVisible).toBe(false);
+    expect(dismissSpy).toHaveBeenCalledWith({ componentId: 'test-toast' });
+  });
+
+  // Test for button onClick calling dismiss (line 145)
+  it('should dismiss when dismiss button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+    const dismissSpy = jest.spyOn(component, 'dismiss');
+
+    expect(page.root).toBeDefined();
+    expect(page.root!.shadowRoot).toBeDefined();
+
+    const dismissButton = page.root!.shadowRoot!.querySelector('.pds-toast__button') as HTMLButtonElement;
+    dismissButton.click();
+
+    expect(dismissSpy).toHaveBeenCalled();
+  });
+
+  // Test duration watcher behavior
+  it('should handle duration changes', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" duration="1000"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+
+    // Test that duration property can be changed
+    expect(component.duration).toBe(1000);
+
+    // Change duration
+    component.duration = 2000;
+    await page.waitForChanges();
+
+    // Verify the new duration is set
+    expect(component.duration).toBe(2000);
+  });
+
+  // Test duration watcher when setting to 0
+  it('should handle duration set to 0', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" duration="1000"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+
+    // Test initial duration
+    expect(component.duration).toBe(1000);
+
+    // Change duration to 0
+    component.duration = 0;
+    await page.waitForChanges();
+
+    // Verify duration is now 0
+    expect(component.duration).toBe(0);
+  });
+
+  // Test cleanup method exists and can be called
+  it('should have cleanup functionality', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" duration="1000"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+
+    // Test that disconnectedCallback can be called without errors
+    expect(() => component.disconnectedCallback()).not.toThrow();
+
+    // Component should still be functional after cleanup
+    expect(component.isVisible).toBe(true);
+  });
+
+  // Test auto-dismissal behavior without timer manipulation
+  it('should have auto-dismiss functionality when duration > 0', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" duration="1000"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+
+    // Verify that the component starts the dismiss timer on load
+    expect(component.duration).toBe(1000);
+    expect(component.isVisible).toBe(true);
+  });
+
+  // Test no auto-dismissal when duration is 0
+  it('should not auto-dismiss when duration is 0', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast component-id="test-toast" duration="0"></pds-toast>`,
+    });
+
+    const component = page.rootInstance as PdsToast;
+
+    // Component should be visible and no timer should be active
+    expect(component.duration).toBe(0);
+    expect(component.isVisible).toBe(true);
   });
 });

--- a/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
+++ b/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PdsToast } from '../pds-toast';
+
+describe('pds-toast', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [PdsToast],
+      html: `<pds-toast></pds-toast>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-toast>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </pds-toast>
+    `);
+  });
+});

--- a/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
+++ b/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
@@ -136,7 +136,7 @@ describe('pds-toast', () => {
     `);
   });
 
-  // Test for renderIcon() returning null (line 101)
+  // Test for renderIcon() returning null
   it('renders without icon when no icon prop and type is default', async () => {
     const page = await newSpecPage({
       components: [PdsToast],
@@ -153,7 +153,7 @@ describe('pds-toast', () => {
     expect(loaderElement).toBeNull();
   });
 
-  // Test for dismiss() method (lines 71-88)
+  // Test for dismiss() method
   it('should call dismiss method and emit event', async () => {
     const page = await newSpecPage({
       components: [PdsToast],
@@ -169,7 +169,7 @@ describe('pds-toast', () => {
     expect(dismissSpy).toHaveBeenCalledWith({ componentId: 'test-toast' });
   });
 
-  // Test for button onClick calling dismiss (line 145)
+  // Test for button onClick calling dismiss
   it('should dismiss when dismiss button is clicked', async () => {
     const page = await newSpecPage({
       components: [PdsToast],

--- a/libs/react/src/components/proxies.ts
+++ b/libs/react/src/components/proxies.ts
@@ -37,6 +37,7 @@ import { defineCustomElement as definePdsTabpanel } from '@pine-ds/core/componen
 import { defineCustomElement as definePdsTabs } from '@pine-ds/core/components/pds-tabs.js';
 import { defineCustomElement as definePdsText } from '@pine-ds/core/components/pds-text.js';
 import { defineCustomElement as definePdsTextarea } from '@pine-ds/core/components/pds-textarea.js';
+import { defineCustomElement as definePdsToast } from '@pine-ds/core/components/pds-toast.js';
 import { defineCustomElement as definePdsTooltip } from '@pine-ds/core/components/pds-tooltip.js';
 
 export const PdsAccordion = /*@__PURE__*/createReactComponent<JSX.PdsAccordion, HTMLPdsAccordionElement>('pds-accordion', undefined, undefined, definePdsAccordion);
@@ -71,4 +72,5 @@ export const PdsTabpanel = /*@__PURE__*/createReactComponent<JSX.PdsTabpanel, HT
 export const PdsTabs = /*@__PURE__*/createReactComponent<JSX.PdsTabs, HTMLPdsTabsElement>('pds-tabs', undefined, undefined, definePdsTabs);
 export const PdsText = /*@__PURE__*/createReactComponent<JSX.PdsText, HTMLPdsTextElement>('pds-text', undefined, undefined, definePdsText);
 export const PdsTextarea = /*@__PURE__*/createReactComponent<JSX.PdsTextarea, HTMLPdsTextareaElement>('pds-textarea', undefined, undefined, definePdsTextarea);
+export const PdsToast = /*@__PURE__*/createReactComponent<JSX.PdsToast, HTMLPdsToastElement>('pds-toast', undefined, undefined, definePdsToast);
 export const PdsTooltip = /*@__PURE__*/createReactComponent<JSX.PdsTooltip, HTMLPdsTooltipElement>('pds-tooltip', undefined, undefined, definePdsTooltip);


### PR DESCRIPTION
# Description
This PR introduces a new toast notification component (`pds-toast`) to the Pine design system. The component offers a flexible and accessible way to display temporary messages to users, featuring various styling options and customizable dismissal behaviors.


Fixes https://kajabi.atlassian.net/browse/DSS-1425

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
