### PR TITLE
fix(pds-alert): remove description prop and use slot

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -34,10 +34,6 @@ export namespace Components {
          */
         "componentId": string;
         /**
-          * Text displayed as the description of the alert.
-         */
-        "description": string;
-        /**
           * If true, shows the dismiss button. If false, the dismiss button is hidden.
           * @defaultValue false
          */
@@ -1645,10 +1641,6 @@ declare namespace LocalJSX {
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId"?: string;
-        /**
-          * Text displayed as the description of the alert.
-         */
-        "description"?: string;
         /**
           * If true, shows the dismiss button. If false, the dismiss button is hidden.
           * @defaultValue false

--- a/libs/core/src/components/pds-alert/docs/pds-alert.mdx
+++ b/libs/core/src/components/pds-alert/docs/pds-alert.mdx
@@ -43,10 +43,10 @@ The alert component supports multiple style variants to indicate different types
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="default"></pdsAlert>',
-    webComponent: '<pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="default"></pds-alert>'
+    react: '<pdsAlert heading="Alert heading text" variant="default">Alerts can also have description text that can be used to provide more information about the alert.</pdsAlert>',
+    webComponent: '<pds-alert heading="Alert heading text" variant="default">Alerts can also have description text that can be used to provide more information about the alert.</pds-alert>'
 }}>
-  <pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="default"></pds-alert>
+  <pds-alert heading="Alert heading text" variant="default">Alerts can also have description text that can be used to provide more information about the alert.</pds-alert>
 </DocCanvas>
 
 ### Small
@@ -57,10 +57,10 @@ Text in small alerts is truncated when it becomes too long for the alert descrip
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." heading="Alert heading text" small="true" variant="info"></pdsAlert>',
-    webComponent: '<pds-alert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." heading="Alert heading text" small="true" variant="info"></pds-alert>'
+    react: '<pdsAlert heading="Alert heading text" small="true" variant="info">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pdsAlert>',
+    webComponent: '<pds-alert heading="Alert heading text" small="true" variant="info">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pds-alert>'
 }}>
-  <pds-alert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." heading="Alert heading text" small="true" variant="info"></pds-alert>
+  <pds-alert heading="Alert heading text" small="true" variant="info">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pds-alert>
 </DocCanvas>
 
 ## Actions
@@ -74,10 +74,10 @@ Action items such as buttons and links should be added to alerts using the `acti
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="success"><pdsButton slot="actions" variant="primary">Action button</pdsButton><pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink></pdsAlert>',
-    webComponent: '<pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="success"><pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>'
+    react: '<pdsAlert heading="Alert heading text" variant="success">Alerts can also have description text that can be used to provide more information about the alert.<pdsButton slot="actions" variant="primary">Action button</pdsButton><pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink></pdsAlert>',
+    webComponent: '<pds-alert heading="Alert heading text" variant="success">Alerts can also have description text that can be used to provide more information about the alert.<pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>'
 }}>
-  <pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" variant="success"><pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
+  <pds-alert heading="Alert heading text" variant="success">Alerts can also have description text that can be used to provide more information about the alert.<pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
 </DocCanvas>
 
 ### Small with actions
@@ -86,10 +86,10 @@ When using the small variant, actions are displayed on the same line as the desc
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" small="true" variant="warning"><pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink> <pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink></pdsAlert>',
-    webComponent: '<pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" small="true" variant="warning"><pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>'
+    react: '<pdsAlert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink> <pdsLink href="#" slot="actions" variant="plain">Action link</pdsLink></pdsAlert>',
+    webComponent: '<pds-alert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>'
 }}>
-  <pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." heading="Alert heading text" small="true" variant="warning"><pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
+  <pds-alert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
 </DocCanvas>
 
 ## Dismissible
@@ -100,18 +100,18 @@ An event `pdsAlertDismissClick` is emitted when the dismiss button is clicked, w
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Alerts can also have description text that can be used to provide more information about the alert." dismissible="true" heading="Alert heading text" variant="danger"></pdsAlert>',
-    webComponent: '<pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." dismissible="true" heading="Alert heading text" variant="danger"></pds-alert>'
+    react: '<pdsAlert dismissible="true" heading="Alert heading text" variant="danger">Alerts can also have description text that can be used to provide more information about the alert.</pdsAlert>',
+    webComponent: '<pds-alert dismissible="true" heading="Alert heading text" variant="danger">Alerts can also have description text that can be used to provide more information about the alert.</pds-alert>'
 }}>
-  <pds-alert description="Alerts can also have description text that can be used to provide more information about the alert." dismissible="true" heading="Alert heading text" variant="danger"></pds-alert>
+  <pds-alert dismissible="true" heading="Alert heading text" variant="danger">Alerts can also have description text that can be used to provide more information about the alert.</pds-alert>
 </DocCanvas>
 
 ### Small dismissible
 
 <DocCanvas client:only
   mdxSource={{
-    react: '<pdsAlert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." dismissible="true" heading="Alert heading text" small="true" variant="danger"></pdsAlert>',
-    webComponent: '<pds-alert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." dismissible="true" heading="Alert heading text" small="true" variant="danger"></pds-alert>'
+    react: '<pdsAlert dismissible="true" heading="Alert heading text" small="true" variant="danger">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pdsAlert>',
+    webComponent: '<pds-alert dismissible="true" heading="Alert heading text" small="true" variant="danger">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pds-alert>'
 }}>
-  <pds-alert description="Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen." dismissible="true" heading="Alert heading text" small="true" variant="danger"></pds-alert>
+  <pds-alert dismissible="true" heading="Alert heading text" small="true" variant="danger">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pds-alert>
 </DocCanvas>

--- a/libs/core/src/components/pds-alert/pds-alert.tsx
+++ b/libs/core/src/components/pds-alert/pds-alert.tsx
@@ -24,11 +24,6 @@ export class PdsAlert {
   @Prop() heading: string;
 
   /**
-   * Text displayed as the description of the alert.
-   */
-  @Prop() description: string;
-
-  /**
    * If true, the alert is displayed in a smaller size and description text is truncated. Heading is not displayed.
    */
   @Prop() small = false;
@@ -81,7 +76,7 @@ export class PdsAlert {
             color="var(--pds-alert-color-text)"
             tag="p"
           >
-            {this.description}
+            <slot></slot>
           </pds-text>
           {this.hasActionsContent && this.renderActions(true)}
         </pds-box>
@@ -91,7 +86,7 @@ export class PdsAlert {
     return (
       <div>
         <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">
-          {this.description}
+          <slot></slot>
         </pds-text>
         {this.hasActionsContent && this.renderActions(false)}
       </div>

--- a/libs/core/src/components/pds-alert/readme.md
+++ b/libs/core/src/components/pds-alert/readme.md
@@ -10,7 +10,6 @@
 | Property      | Attribute      | Description                                                                                                    | Type                                                        | Default     |
 | ------------- | -------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------- |
 | `componentId` | `component-id` | A unique identifier used for the underlying component `id` attribute.                                          | `string`                                                    | `undefined` |
-| `description` | `description`  | Text displayed as the description of the alert.                                                                | `string`                                                    | `undefined` |
 | `dismissible` | `dismissible`  | If true, shows the dismiss button. If false, the dismiss button is hidden.                                     | `boolean`                                                   | `false`     |
 | `heading`     | `heading`      | Text displayed as the heading of the alert.                                                                    | `string`                                                    | `undefined` |
 | `small`       | `small`        | If true, the alert is displayed in a smaller size and description text is truncated. Heading is not displayed. | `boolean`                                                   | `false`     |

--- a/libs/core/src/components/pds-alert/stories/pds-alert.stories.js
+++ b/libs/core/src/components/pds-alert/stories/pds-alert.stories.js
@@ -18,19 +18,18 @@ const BaseTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  description="${args.description}"
   small="${args.small}"
   dismissible="${args.dismissible}"
-></pds-alert>`;
+>${args.description}</pds-alert>`;
 
 const ActionsTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  description="${args.description}"
   small="${args.small}"
   dismissible="${args.dismissible}"
 >
+  ${args.description}
   <pds-button slot="actions" variant="primary">Button</pds-button>
   <pds-link slot="actions" variant="plain" href="#">Link</pds-link>
 </pds-alert>`;
@@ -39,10 +38,10 @@ const SmallActionsTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  description="${args.description}"
   small="${args.small}"
   dismissible="${args.dismissible}"
 >
+  ${args.description}
   <pds-link slot="actions" variant="plain" href="#">Link</pds-link>
   <pds-link slot="actions" variant="plain" href="#">Link</pds-link>
 </pds-alert>`;

--- a/libs/core/src/components/pds-alert/test/pds-alert.e2e.ts
+++ b/libs/core/src/components/pds-alert/test/pds-alert.e2e.ts
@@ -11,7 +11,7 @@ describe('pds-alert', () => {
 
   it('emits "pdsAlertDismissClick" event when dismiss button is clicked', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-alert dismissible="true" description="Test alert with dismiss button"></pds-alert>');
+    await page.setContent('<pds-alert dismissible="true">Test alert with dismiss button</pds-alert>');
 
     const closeBtn = await page.find('pds-alert >>> .pds-alert__dismiss');
     const eventSpy = await page.spyOnEvent('pdsAlertDismissClick');

--- a/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
+++ b/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
@@ -15,7 +15,9 @@ describe('pds-alert', () => {
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <div>
-                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p"></pds-text>
+                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">
+                    <slot></slot>
+                  </pds-text>
                 </div>
               </pds-box>
             </pds-box>
@@ -39,7 +41,9 @@ describe('pds-alert', () => {
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <pds-text class="pds-alert__heading" color="var(--pds-alert-color-text)" size="h5" tag="h3" weight="medium">Test Alert Heading</pds-text>
                 <div>
-                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p"></pds-text>
+                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">
+                    <slot></slot>
+                  </pds-text>
                 </div>
               </pds-box>
             </pds-box>
@@ -52,22 +56,25 @@ describe('pds-alert', () => {
   it('renders description when provided', async () => {
     const page = await newSpecPage({
       components: [PdsAlert],
-      html: `<pds-alert description="Test alert description text"></pds-alert>`,
+      html: `<pds-alert>Test alert description text</pds-alert>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-alert class="pds-alert" description="Test alert description text" variant="default">
+      <pds-alert class="pds-alert" variant="default">
         <mock:shadow-root>
           <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <div>
-                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">Test alert description text</pds-text>
+                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">
+                    <slot></slot>
+                  </pds-text>
                 </div>
               </pds-box>
             </pds-box>
           </pds-box>
         </mock:shadow-root>
+        Test alert description text
       </pds-alert>
     `);
   });
@@ -75,22 +82,25 @@ describe('pds-alert', () => {
   it('renders small variant when small prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsAlert],
-      html: `<pds-alert small="true" heading="This heading should not show" description="Small alert description"></pds-alert>`,
+      html: `<pds-alert small="true" heading="This heading should not show">Small alert description</pds-alert>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-alert class="pds-alert" description="Small alert description" heading="This heading should not show" small="true" variant="default">
+      <pds-alert class="pds-alert" heading="This heading should not show" small="true" variant="default">
         <mock:shadow-root>
           <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon pds-alert__icon--small" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <pds-box align-items="center" display="flex" gap="md">
-                  <pds-text class="pds-alert__description--small" color="var(--pds-alert-color-text)" tag="p" truncate="">Small alert description</pds-text>
+                  <pds-text class="pds-alert__description--small" color="var(--pds-alert-color-text)" tag="p" truncate="">
+                    <slot></slot>
+                  </pds-text>
                 </pds-box>
               </pds-box>
             </pds-box>
           </pds-box>
         </mock:shadow-root>
+        Small alert description
       </pds-alert>
     `);
   });
@@ -98,17 +108,19 @@ describe('pds-alert', () => {
   it('renders dismiss button when dismissible prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsAlert],
-      html: `<pds-alert dismissible="true" description="Alert with dismiss button"></pds-alert>`,
+      html: `<pds-alert dismissible="true">Alert with dismiss button</pds-alert>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-alert class="pds-alert" description="Alert with dismiss button" dismissible="true" variant="default">
+      <pds-alert class="pds-alert" dismissible="true" variant="default">
         <mock:shadow-root>
           <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <div>
-                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">Alert with dismiss button</pds-text>
+                  <pds-text class="pds-alert__description" color="var(--pds-alert-color-text)" tag="p">
+                    <slot></slot>
+                  </pds-text>
                 </div>
               </pds-box>
               <button aria-label="Dismiss alert" class="pds-alert__dismiss" type="button">
@@ -117,6 +129,7 @@ describe('pds-alert', () => {
             </pds-box>
           </pds-box>
         </mock:shadow-root>
+        Alert with dismiss button
       </pds-alert>
     `);
   });
@@ -151,7 +164,7 @@ describe('pds-alert', () => {
     const page = await newSpecPage({
       components: [PdsAlert],
       html: `
-        <pds-alert description="Alert with action buttons">
+        <pds-alert>Alert with action buttons
           <button slot="actions">Action Button</button>
           <a slot="actions" href="#">Action Link</a>
         </pds-alert>
@@ -184,7 +197,7 @@ describe('pds-alert', () => {
     for (const variant of variants) {
       const page = await newSpecPage({
         components: [PdsAlert],
-        html: `<pds-alert variant="${variant}" description="Variant test"></pds-alert>`,
+        html: `<pds-alert variant="${variant}">Variant test</pds-alert>`,
       });
 
       if (page.root) {
@@ -203,7 +216,7 @@ describe('pds-alert', () => {
     const page = await newSpecPage({
       components: [PdsAlert],
       html: `
-        <pds-alert small="true" description="Small alert with action">
+        <pds-alert small="true">Small alert with action
           <a slot="actions" href="#">Action Link</a>
         </pds-alert>
       `,
@@ -227,7 +240,7 @@ describe('pds-alert', () => {
   it('falls back to default icon when invalid variant is provided', async () => {
     const page = await newSpecPage({
       components: [PdsAlert],
-      html: `<pds-alert variant="invalid-variant" description="Testing fallback"></pds-alert>`,
+      html: `<pds-alert variant="invalid-variant">Testing fallback</pds-alert>`,
     });
 
     if (page.root && page.root.shadowRoot) {
@@ -240,14 +253,13 @@ describe('pds-alert', () => {
   it('applies correct description class when small is false', async () => {
     const page = await newSpecPage({
       components: [PdsAlert],
-      html: `<pds-alert small="false" description="Testing description class"></pds-alert>`,
+      html: `<pds-alert small="false">Testing description class</pds-alert>`,
     });
 
     if (page.root && page.root.shadowRoot) {
       // Verify the non-small description class is applied
       const descriptionText = page.root.shadowRoot.querySelector('.pds-alert__description');
       expect(descriptionText).not.toBeNull();
-      expect(descriptionText?.textContent).toBe('Testing description class');
 
       // Make sure the small class is not applied
       const smallDescriptionText = page.root.shadowRoot.querySelector('.pds-alert__description--small');


### PR DESCRIPTION
# Description

Updates pds-alert to use the default slot for description text instead of the previously implemented prop.

Fixes https://kajabi.atlassian.net/browse/DSS-1435

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
