### PR TITLE
feat(pds-chip): adds brand sentiment and icon prop

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -404,10 +404,14 @@ export namespace Components {
          */
         "componentId": string;
         /**
-          * Determines whether a dot should be displayed on the chip.
+          * Determines whether a dot should be displayed on the chip. Note: This prop is ignored when sentiment is 'brand'.
           * @defaultValue false
          */
         "dot": boolean;
+        /**
+          * The name of the icon to display before the chip text.
+         */
+        "icon"?: string;
         /**
           * Determines whether the chip should be displayed in a larger size.
           * @defaultValue false
@@ -417,9 +421,9 @@ export namespace Components {
           * Defines the color scheme of the chip.
           * @defaultValue 'neutral'
          */
-        "sentiment": 'accent' | 'danger' | 'info' | 'neutral' | 'success' | 'warning';
+        "sentiment": 'accent' | 'brand' | 'danger' | 'info' | 'neutral' | 'success' | 'warning';
         /**
-          * Sets the style variant of the chip.
+          * Sets the style variant of the chip. Note: This prop is ignored when sentiment is 'brand'.
           * @defaultValue 'text'
          */
         "variant": 'text' | 'tag' | 'dropdown';
@@ -2301,10 +2305,14 @@ declare namespace LocalJSX {
          */
         "componentId"?: string;
         /**
-          * Determines whether a dot should be displayed on the chip.
+          * Determines whether a dot should be displayed on the chip. Note: This prop is ignored when sentiment is 'brand'.
           * @defaultValue false
          */
         "dot"?: boolean;
+        /**
+          * The name of the icon to display before the chip text.
+         */
+        "icon"?: string;
         /**
           * Determines whether the chip should be displayed in a larger size.
           * @defaultValue false
@@ -2318,9 +2326,9 @@ declare namespace LocalJSX {
           * Defines the color scheme of the chip.
           * @defaultValue 'neutral'
          */
-        "sentiment"?: 'accent' | 'danger' | 'info' | 'neutral' | 'success' | 'warning';
+        "sentiment"?: 'accent' | 'brand' | 'danger' | 'info' | 'neutral' | 'success' | 'warning';
         /**
-          * Sets the style variant of the chip.
+          * Sets the style variant of the chip. Note: This prop is ignored when sentiment is 'brand'.
           * @defaultValue 'text'
          */
         "variant"?: 'text' | 'tag' | 'dropdown';

--- a/libs/core/src/components/pds-chip/docs/pds-chip.mdx
+++ b/libs/core/src/components/pds-chip/docs/pds-chip.mdx
@@ -70,19 +70,20 @@ The `sentiment` property represents the named color scheme of the chip component
 
 #### Brand
 
->**IMPORTANT**: The `brand` sentiment is a special case where only icon and large are supported. It does not support the `dot`, `dropdown`, or `tag` properties by design.
+> **IMPORTANT**: The `brand` sentiment is a special case where only `icon` and `large` properties are supported.
+> The `dot`, `dropdown`, and `tag` properties are not supported by design.
 
 <DocCanvas client:only
   mdxSource={{
     react: `
     <PdsChip sentiment="brand">Brand</PdsChip>
     <PdsChip sentiment="brand" icon="product">Brand</PdsChip>
-    <PdsChip sentiment="brand" size="large">Brand</PdsChip>
+    <PdsChip sentiment="brand" large>Brand</PdsChip>
     `,
     webComponent: `
     <pds-chip sentiment="brand">Brand</pds-chip>
     <pds-chip sentiment="brand" icon="product">Brand</pds-chip>
-    <pds-chip sentiment="brand" size="large">Brand</pds-chip>
+    <pds-chip sentiment="brand" large>Brand</pds-chip>
     `
 }}>
   <pds-chip sentiment="brand">Brand</pds-chip>

--- a/libs/core/src/components/pds-chip/docs/pds-chip.mdx
+++ b/libs/core/src/components/pds-chip/docs/pds-chip.mdx
@@ -42,6 +42,7 @@ The `sentiment` property represents the named color scheme of the chip component
   mdxSource={{
     react: `
     <PdsChip sentiment="accent">Accent</PdsChip>
+    <PdsChip sentiment="brand">Brand</PdsChip>
     <PdsChip sentiment="danger">Danger</PdsChip>
     <PdsChip sentiment="info">Info</PdsChip>
     <PdsChip sentiment="neutral">Neutral</PdsChip>
@@ -50,6 +51,7 @@ The `sentiment` property represents the named color scheme of the chip component
     `,
     webComponent: `
     <pds-chip sentiment="accent">Accent</pds-chip>
+    <pds-chip sentiment="brand">Brand</pds-chip>
     <pds-chip sentiment="danger">Danger</pds-chip>
     <pds-chip sentiment="info">Info</pds-chip>
     <pds-chip sentiment="neutral">Neutral</pds-chip>
@@ -58,11 +60,34 @@ The `sentiment` property represents the named color scheme of the chip component
     `
 }}>
   <pds-chip sentiment="accent">Accent</pds-chip>
+  <pds-chip sentiment="brand">Brand</pds-chip>
   <pds-chip sentiment="danger">Danger</pds-chip>
   <pds-chip sentiment="info">Info</pds-chip>
   <pds-chip sentiment="neutral">Neutral</pds-chip>
   <pds-chip sentiment="success">Success</pds-chip>
   <pds-chip sentiment="warning">Warning</pds-chip>
+</DocCanvas>
+
+#### Brand
+
+>**IMPORTANT**: The `brand` sentiment is a special case where only icon and large are supported. It does not support the `dot`, `dropdown`, or `tag` properties by design.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <PdsChip sentiment="brand">Brand</PdsChip>
+    <PdsChip sentiment="brand" icon="product">Brand</PdsChip>
+    <PdsChip sentiment="brand" size="large">Brand</PdsChip>
+    `,
+    webComponent: `
+    <pds-chip sentiment="brand">Brand</pds-chip>
+    <pds-chip sentiment="brand" icon="product">Brand</pds-chip>
+    <pds-chip sentiment="brand" size="large">Brand</pds-chip>
+    `
+}}>
+  <pds-chip sentiment="brand">Brand</pds-chip>
+  <pds-chip sentiment="brand" icon="product">Brand</pds-chip>
+  <pds-chip sentiment="brand" large>Brand</pds-chip>
 </DocCanvas>
 
 ### Dot
@@ -94,6 +119,40 @@ A small circular indicator displayed within a chip. Dot colors are determined by
   <pds-chip sentiment="neutral" dot>Neutral</pds-chip>
   <pds-chip sentiment="success" dot>Success</pds-chip>
   <pds-chip sentiment="warning" dot>Warning</pds-chip>
+</DocCanvas>
+
+### Icon
+
+The `icon` property can be used to display an icon within a chip.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <PdsChip sentiment="accent" icon="archive">Accent</PdsChip>
+    <PdsChip sentiment="brand" icon="product">Brand</PdsChip>
+    <PdsChip sentiment="danger" icon="danger">Danger</PdsChip>
+    <PdsChip sentiment="info" icon="info-circle">Info</PdsChip>
+    <PdsChip sentiment="neutral" icon="tag">Neutral</PdsChip>
+    <PdsChip sentiment="success" icon="check">Success</PdsChip>
+    <PdsChip sentiment="warning" icon="check">Warning</PdsChip>
+    `,
+    webComponent: `
+    <pds-chip sentiment="accent" icon="archive">Accent</pds-chip>
+    <pds-chip sentiment="brand" icon="product">Brand</pds-chip>
+    <pds-chip sentiment="danger" icon="danger">Danger</pds-chip>
+    <pds-chip sentiment="info" icon="info-circle">Info</pds-chip>
+    <pds-chip sentiment="neutral" icon="tag">Neutral</pds-chip>
+    <pds-chip sentiment="success" icon="check">Success</pds-chip>
+    <pds-chip sentiment="warning" icon="warning">Warning</pds-chip>
+    `
+}}>
+  <pds-chip sentiment="accent" icon="archive">Accent</pds-chip>
+  <pds-chip sentiment="brand" icon="product">Brand</pds-chip>
+  <pds-chip sentiment="danger" icon="danger">Danger</pds-chip>
+  <pds-chip sentiment="info" icon="info-circle">Info</pds-chip>
+  <pds-chip sentiment="neutral" icon="tag">Neutral</pds-chip>
+  <pds-chip sentiment="success" icon="check">Success</pds-chip>
+  <pds-chip sentiment="warning" icon="warning">Warning</pds-chip>
 </DocCanvas>
 
 ### Dropdown
@@ -164,19 +223,22 @@ Large chips will be displayed with a larger visual footprint compared to the def
 <DocCanvas client:only
   mdxSource={{
     react: `
-    <PdsChip sentiment="accent" variant="text" large>Accent</PdsChip>
+    <PdsChip sentiment="accent" large>Accent</PdsChip>
+    <PdsChip sentiment="brand" large>Brand</PdsChip>
     <PdsChip sentiment="danger" dot large>Danger</PdsChip>
     <PdsChip sentiment="info" variant="dropdown" large>Info</PdsChip>
     <PdsChip sentiment="success" variant="tag" large>Success</PdsChip>
     `,
     webComponent: `
-    <pds-chip sentiment="accent" variant="text" large>Accent</pds-chip>
+    <pds-chip sentiment="accent" large>Accent</pds-chip>
+    <pds-chip sentiment="brand" large>Brand</pds-chip>
     <pds-chip sentiment="danger" dot large>Danger</pds-chip>
     <pds-chip sentiment="info" variant="dropdown" large>Info</pds-chip>
     <pds-chip sentiment="success" variant="tag" large>Success</pds-chip>
     `
 }}>
-  <pds-chip sentiment="accent" variant="text" large>Accent</pds-chip>
+  <pds-chip sentiment="accent" large>Accent</pds-chip>
+  <pds-chip sentiment="brand" large>Brand</pds-chip>
   <pds-chip sentiment="danger" dot large>Danger</pds-chip>
   <pds-chip sentiment="info" variant="dropdown" large>Info</pds-chip>
   <pds-chip sentiment="success" variant="tag" large>Success</pds-chip>

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -4,7 +4,7 @@
   align-items: center;
   border-radius: var(--pine-dimension-sm);
   display: inline-flex;
-  padding-block: var(--pine-dimension-2xs);
+  padding-block: var(--pine-dimension-025);
   padding-inline: var(--pine-dimension-150);
 }
 
@@ -111,7 +111,7 @@ $pds-chip-sentiment-hover: (
   border-radius: var(--pine-dimension-sm);
   cursor: pointer;
   display: flex;
-  padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
+  padding: var(--pine-dimension-025) var(--pine-dimension-150);
 
   &:focus-visible {
     outline: var(--pine-outline-focus);
@@ -155,7 +155,7 @@ $pds-chip-sentiment-hover: (
 // large
 
 :host(.pds-chip--large) {
-  padding-block: var(--pine-dimension-2xs);
+  padding-block: var(--pine-dimension-025);
   padding-inline: var(--pine-dimension-150);
 
   .pds-chip__label, .pds-chip__button {
@@ -170,7 +170,7 @@ $pds-chip-sentiment-hover: (
   padding: var(--pine-dimension-none);
 
   .pds-chip__button {
-    padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
+    padding: var(--pine-dimension-025) var(--pine-dimension-150);
   }
 }
 
@@ -185,7 +185,7 @@ $pds-chip-sentiment-hover: (
     border-radius: calc(var(--pine-dimension-sm) - 1px);
     color: var(--pine-color-text-neutral);
     font-weight: var(--pine-font-weight-medium);
-    padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
+    padding: var(--pine-dimension-025) var(--pine-dimension-150);
     position: relative;
     z-index: 1;
 

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -79,7 +79,6 @@ $pds-chip-sentiment-hover: (
   border-radius: var(--pine-border-radius-full);
   display: inline-block;
   height: var(--pine-dimension-2xs);
-  margin-block-end: var(--pine-dimension-025);
   margin-inline-end: var(--pine-dimension-2xs);
   width: var(--pine-dimension-2xs);
 }
@@ -87,6 +86,10 @@ $pds-chip-sentiment-hover: (
 .pds-chip__label {
   align-items: center;
   display: flex;
+
+  pds-icon {
+    margin-inline-end: var(--pine-dimension-2xs);
+  }
 }
 
 .pds-chip__label, .pds-chip__button {
@@ -98,11 +101,6 @@ $pds-chip-sentiment-hover: (
 
 :host(.pds-chip--dropdown) {
   padding: var(--pine-dimension-none);
-
-  .pds-chip__dot {
-    margin-block-end: calc(var(--pine-dimension-025) / 4);
-    margin-block-start: var(--pine-dimension-025);
-  }
 }
 
 .pds-chip__button {
@@ -120,7 +118,11 @@ $pds-chip-sentiment-hover: (
     outline-offset: var(--pine-border-width);
   }
 
-  pds-icon {
+  pds-icon:first-child {
+    margin-inline-end: var(--pine-dimension-2xs);
+  }
+
+  pds-icon:last-child {
     margin-inline-end: calc(var(--pine-dimension-025) * -1);
     margin-inline-start: var(--pine-dimension-2xs);
   }
@@ -157,11 +159,56 @@ $pds-chip-sentiment-hover: (
   padding-inline: var(--pine-dimension-150);
 
   .pds-chip__label, .pds-chip__button {
-    font: var(--pine-typography-heading-6);
+    font-family: var(--pine-font-family-heading);
+    font-size: var(--pine-font-size-heading-6);
+    font-weight: var(--pine-font-weight-medium);
     letter-spacing: var(--pine-letter-spacing-heading-6);
   }
 }
 
-:host(.pds-chip--large):has(.pds-chip__button) {
+:host(.pds-chip--large.pds-chip--dropdown) {
   padding: var(--pine-dimension-none);
+
+  .pds-chip__button {
+    padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
+  }
+}
+
+:host(.pds-chip--brand) {
+  background: linear-gradient(90deg, #FF3E14 0%, #6B62F2 100%);
+  border: 0;
+  padding: 1px;
+  position: relative;
+
+  .pds-chip__label {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: calc(var(--pine-dimension-sm) - 1px);
+    color: var(--pine-color-text-neutral);
+    font-weight: var(--pine-font-weight-medium);
+    padding: var(--pine-dimension-2xs) var(--pine-dimension-150);
+    position: relative;
+    z-index: 1;
+
+    pds-icon {
+      margin-inline-end: var(--pine-dimension-2xs);
+    }
+  }
+
+  .pds-chip__button, .pds-chip__close {
+    color: var(--pine-color-text-neutral);
+    font-weight: var(--pine-font-weight-medium);
+    position: relative;
+    z-index: 1;
+  }
+
+  .pds-chip__button {
+    pds-icon:first-child {
+      margin-inline-end: var(--pine-dimension-2xs);
+    }
+  }
+
+  // tag close hover colors
+  .pds-chip__close:hover {
+    background: rgba(255, 255, 255, 0.8);
+  }
 }

--- a/libs/core/src/components/pds-chip/pds-chip.tsx
+++ b/libs/core/src/components/pds-chip/pds-chip.tsx
@@ -18,10 +18,15 @@ export class PdsChip {
 
   /**
    * Determines whether a dot should be displayed on the chip.
+   * Note: This prop is ignored when sentiment is 'brand'.
    * @defaultValue false
    */
   @Prop() dot = false;
 
+  /**
+   * The name of the icon to display before the chip text.
+   */
+  @Prop() icon?: string;
 
   /**
    * Determines whether the chip should be displayed in a larger size.
@@ -33,10 +38,11 @@ export class PdsChip {
    * Defines the color scheme of the chip.
    * @defaultValue 'neutral'
    */
-  @Prop() sentiment: 'accent' | 'danger' | 'info' | 'neutral' | 'success' | 'warning' = 'neutral';
+  @Prop() sentiment: 'accent' | 'brand' | 'danger' | 'info' | 'neutral' | 'success' | 'warning' = 'neutral';
 
   /**
    * Sets the style variant of the chip.
+   * Note: This prop is ignored when sentiment is 'brand'.
    * @defaultValue 'text'
    */
   @Prop() variant: 'text' | 'tag' | 'dropdown' = 'text';
@@ -56,9 +62,13 @@ export class PdsChip {
     if (this.large) {
       classNames.push('pds-chip--large');
     }
-    if (this.variant) {
-      classNames.push('pds-chip--' + this.variant);
+
+    // For brand sentiment, always use text variant
+    const effectiveVariant = this.sentiment === 'brand' ? 'text' : this.variant;
+    if (effectiveVariant) {
+      classNames.push('pds-chip--' + effectiveVariant);
     }
+
     if (this.sentiment) {
       classNames.push('pds-chip--' + this.sentiment);
     }
@@ -66,17 +76,33 @@ export class PdsChip {
     return classNames.join(' ');
   }
 
+  private get effectiveVariant() {
+    // For brand sentiment, force text variant behavior
+    return this.sentiment === 'brand' ? 'text' : this.variant;
+  }
+
+  private get iconSize() {
+    // Icon size based on large prop
+    return this.large ? '14px' : '12px';
+  }
+
   private setChipContent() {
-    const isDropdown = this.variant === 'dropdown';
+    const isDropdown = this.effectiveVariant === 'dropdown';
+
+    // For brand sentiment, ignore dot prop
+    const showDot = this.sentiment === 'brand' ? false : this.dot;
+
     const chipContent = isDropdown ? (
       <button class="pds-chip__button" type="button">
-        {this.dot && <i class="pds-chip__dot" aria-hidden="true"></i>}
+        {this.icon && <pds-icon icon={this.icon} size={this.iconSize} aria-hidden="true"></pds-icon>}
+        {showDot && <i class="pds-chip__dot" aria-hidden="true"></i>}
         <slot></slot>
-        <pds-icon icon={downSmall} size="12px" aria-hidden="true"></pds-icon>
+        <pds-icon icon={downSmall} size={this.iconSize} aria-hidden="true"></pds-icon>
       </button>
     ) : (
       <span class="pds-chip__label">
-        {this.dot && <i class="pds-chip__dot" aria-hidden="true"></i>}
+        {this.icon && <pds-icon icon={this.icon} size={this.iconSize} aria-hidden="true"></pds-icon>}
+        {showDot && <i class="pds-chip__dot" aria-hidden="true"></i>}
         <slot></slot>
       </span>
     );
@@ -88,9 +114,9 @@ export class PdsChip {
     return (
       <Host class={this.classNames()} id={this.componentId}>
         {this.setChipContent()}
-        {this.variant === 'tag' && (
+        {this.effectiveVariant === 'tag' && (
           <button class="pds-chip__close" type="button" onClick={this.handleCloseClick} aria-label="Remove">
-            <pds-icon icon={remove} size="12px"></pds-icon>
+            <pds-icon icon={remove} size={this.iconSize}></pds-icon>
           </button>
         )}
       </Host>

--- a/libs/core/src/components/pds-chip/readme.md
+++ b/libs/core/src/components/pds-chip/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                           | Type                                                                    | Default     |
-| ------------- | -------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------- | ----------- |
-| `componentId` | `component-id` | A unique identifier used for the underlying component `id` attribute. | `string`                                                                | `undefined` |
-| `dot`         | `dot`          | Determines whether a dot should be displayed on the chip.             | `boolean`                                                               | `false`     |
-| `large`       | `large`        | Determines whether the chip should be displayed in a larger size.     | `boolean`                                                               | `false`     |
-| `sentiment`   | `sentiment`    | Defines the color scheme of the chip.                                 | `"accent" \| "danger" \| "info" \| "neutral" \| "success" \| "warning"` | `'neutral'` |
-| `variant`     | `variant`      | Sets the style variant of the chip.                                   | `"dropdown" \| "tag" \| "text"`                                         | `'text'`    |
+| Property      | Attribute      | Description                                                                                                     | Type                                                                               | Default     |
+| ------------- | -------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------- |
+| `componentId` | `component-id` | A unique identifier used for the underlying component `id` attribute.                                           | `string`                                                                           | `undefined` |
+| `dot`         | `dot`          | Determines whether a dot should be displayed on the chip. Note: This prop is ignored when sentiment is 'brand'. | `boolean`                                                                          | `false`     |
+| `icon`        | `icon`         | The name of the icon to display before the chip text.                                                           | `string`                                                                           | `undefined` |
+| `large`       | `large`        | Determines whether the chip should be displayed in a larger size.                                               | `boolean`                                                                          | `false`     |
+| `sentiment`   | `sentiment`    | Defines the color scheme of the chip.                                                                           | `"accent" \| "brand" \| "danger" \| "info" \| "neutral" \| "success" \| "warning"` | `'neutral'` |
+| `variant`     | `variant`      | Sets the style variant of the chip. Note: This prop is ignored when sentiment is 'brand'.                       | `"dropdown" \| "tag" \| "text"`                                                    | `'text'`    |
 
 
 ## Events

--- a/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
+++ b/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
@@ -18,6 +18,7 @@ const BaseTemplate = (args) => html`
 <pds-chip
   component-id="${args.componentId}"
   dot="${args.dot}"
+  icon="${args.icon}"
   large="${args.large}"
   sentiment="${args.sentiment}"
   variant="${args.variant}"
@@ -28,6 +29,7 @@ const BaseTemplate = (args) => html`
 export const Default = BaseTemplate.bind();
 Default.args = {
   dot: false,
+  icon: "",
   large: false,
   sentiment: "neutral",
   slot: "label",
@@ -38,6 +40,7 @@ export const Sentiment = BaseTemplate.bind();
 Sentiment.args = {
   dot: false,
   large: false,
+  icon: "",
   sentiment: "success",
   slot: "label",
   variant: "text",
@@ -46,6 +49,17 @@ Sentiment.args = {
 export const Dots = BaseTemplate.bind();
 Dots.args = {
   dot: true,
+  icon: "",
+  large: false,
+  sentiment: "neutral",
+  slot: "label",
+  variant: "text",
+}
+
+export const Icon = BaseTemplate.bind();
+Icon.args = {
+  dot: false,
+  icon: "check",
   large: false,
   sentiment: "neutral",
   slot: "label",
@@ -55,6 +69,7 @@ Dots.args = {
 export const Dropdown = BaseTemplate.bind();
 Dropdown.args = {
   dot: false,
+  icon: "",
   large: false,
   sentiment: "neutral",
   slot: "label",
@@ -64,6 +79,7 @@ Dropdown.args = {
 export const Tag = BaseTemplate.bind();
 Tag.args = {
   dot: false,
+  icon: "",
   large: false,
   sentiment: "neutral",
   slot: "label",
@@ -73,6 +89,7 @@ Tag.args = {
 export const Large = BaseTemplate.bind();
 Large.args = {
   dot: false,
+  icon: "",
   large: true,
   sentiment: "neutral",
   slot: "label",

--- a/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
+++ b/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
@@ -133,6 +133,116 @@ describe('pds-chip', () => {
     `);
   });
 
+  it('renders with icon when icon prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip icon="archive" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--neutral pds-chip--text" icon="archive">
+      <mock:shadow-root>
+        <span class="pds-chip__label">
+          <pds-icon icon="archive" size="12px" aria-hidden="true"></pds-icon>
+          <slot></slot>
+        </span>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
+  it('renders with icon in dropdown variant when icon prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip icon="archive" variant="dropdown" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--neutral pds-chip--dropdown" icon="archive" variant="dropdown">
+      <mock:shadow-root>
+        <button class="pds-chip__button" type="button">
+          <pds-icon icon="archive" size="12px" aria-hidden="true"></pds-icon>
+          <slot></slot>
+          <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>
+        </button>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
+  it('renders with large icon when icon and large props are set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip icon="archive" large="true" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--neutral pds-chip--large pds-chip--text" icon="archive" large="true">
+      <mock:shadow-root>
+        <span class="pds-chip__label">
+          <pds-icon icon="archive" size="14px" aria-hidden="true"></pds-icon>
+          <slot></slot>
+        </span>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
+  it('renders with both icon and dot when both props are set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip icon="archive" dot="true" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--neutral pds-chip--text" icon="archive" dot="true">
+      <mock:shadow-root>
+        <span class="pds-chip__label">
+          <pds-icon icon="archive" size="12px" aria-hidden="true"></pds-icon>
+          <i class="pds-chip__dot" aria-hidden="true"></i>
+          <slot></slot>
+        </span>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
+  it('renders brand sentiment with icon but no dot when icon and dot props are set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip icon="archive" dot="true" sentiment="brand" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--brand pds-chip--text" icon="archive" dot="true" sentiment="brand">
+      <mock:shadow-root>
+        <span class="pds-chip__label">
+          <pds-icon icon="archive" size="12px" aria-hidden="true"></pds-icon>
+          <slot></slot>
+        </span>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
+  it('renders with large icons in tag variant when large prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsChip],
+      html: `<pds-chip variant="tag" large="true" />`,
+    });
+
+    expect(page.root).toEqualHtml(`
+    <pds-chip class="pds-chip pds-chip--neutral pds-chip--large pds-chip--tag" variant="tag" large="true">
+      <mock:shadow-root>
+        <span class="pds-chip__label"><slot></slot></span>
+        <button class="pds-chip__close" type="button" aria-label="Remove" >
+          <pds-icon icon="${removeIcon}" size="14px"></pds-icon>
+        </button>
+      </mock:shadow-root>
+    </pds-chip>
+    `);
+  });
+
   it('renders dot within dropdown when variant is dropdown and dot prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsChip],


### PR DESCRIPTION
# Description

Adds `brand` sentiment and `icon` prop to pds-chip component

![Screenshot 2025-06-11 at 12 32 32 PM](https://github.com/user-attachments/assets/1ba3af26-53ac-4530-8f30-965c7dad6836)


![Screenshot 2025-06-11 at 1 01 06 PM](https://github.com/user-attachments/assets/0f8cb6b2-75b3-429f-a951-b07e3b5266c8)


Fixes https://kajabi.atlassian.net/browse/DSS-1465

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Navigate to Chip documentation, verify brand sentiment and icon prop display and function as expected

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Design has QA'ed and approved this PR
