### PR TITLE
docs: add hide label to select slotted elements

### DIFF
--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -139,21 +139,21 @@ Prepend and append elements are placed outside the input container, next to the 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsInput componentId="pds-input-prepend-append-example" label="Amount" type="text" value="100">
-  <PdsSelect hide-label slot="prepend">
+  <PdsSelect hideLabel slot="prepend">
     <option value="USD">USD</option>
     <option value="EUR">EUR</option>
   </PdsSelect>
-  <PdsSelect hide-label slot="append">
+  <PdsSelect hideLabel slot="append">
     <option value="1">1</option>
     <option value="2">2</option>
   </PdsSelect>
 </PdsInput>`,
     webComponent: `<pds-input component-id="pds-input-prepend-append-example" label="Amount" type="text" value="100">
-  <pds-select hideLabel slot="prepend">
+  <pds-select hide-label slot="prepend">
     <option value="USD">USD</option>
     <option value="EUR">EUR</option>
   </pds-select>
-  <pds-select hideLabel slot="append">
+  <pds-select hide-label slot="append">
     <option value="1">1</option>
     <option value="2">2</option>
   </pds-select>

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -139,32 +139,32 @@ Prepend and append elements are placed outside the input container, next to the 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsInput componentId="pds-input-prepend-append-example" label="Amount" type="text" value="100">
-  <PdsSelect slot="prepend">
+  <PdsSelect hide-label slot="prepend">
     <option value="USD">USD</option>
     <option value="EUR">EUR</option>
   </PdsSelect>
-  <PdsSelect slot="append">
+  <PdsSelect hide-label slot="append">
     <option value="1">1</option>
     <option value="2">2</option>
   </PdsSelect>
 </PdsInput>`,
     webComponent: `<pds-input component-id="pds-input-prepend-append-example" label="Amount" type="text" value="100">
-  <pds-select slot="prepend">
+  <pds-select hideLabel slot="prepend">
     <option value="USD">USD</option>
     <option value="EUR">EUR</option>
   </pds-select>
-  <pds-select slot="append">
+  <pds-select hideLabel slot="append">
     <option value="1">1</option>
     <option value="2">2</option>
   </pds-select>
 </pds-input>`
 }}>
   <pds-input component-id="pds-input-prepend-append-example" label="Amount" type="text" value="100">
-    <pds-select slot="prepend">
+    <pds-select hide-label slot="prepend">
       <option value="USD">USD</option>
       <option value="EUR">EUR</option>
     </pds-select>
-    <pds-select slot="append">
+    <pds-select hide-label slot="append">
       <option value="1">1</option>
       <option value="2">2</option>
     </pds-select>
@@ -195,14 +195,14 @@ Prepend and append elements are placed outside the input container, next to the 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsInput componentId="pds-input-prepend-select" label="Amount" type="text" value="100">
-  <PdsSelect slot="prepend">
+  <PdsSelect hideLabel slot="prepend">
     <option value="USD">USD</option>
     <option value="EUR">EUR</option>
     <option value="GBP">GBP</option>
   </PdsSelect>
 </PdsInput>`,
     webComponent: `<pds-input component-id="pds-input-prepend-select" label="Amount" type="text" value="100">
-    <pds-select slot="prepend">
+    <pds-select hide-label slot="prepend">
       <option value="USD">USD</option>
       <option value="EUR">EUR</option>
       <option value="GBP">GBP</option>
@@ -210,7 +210,7 @@ Prepend and append elements are placed outside the input container, next to the 
   </pds-input>`
 }}>
   <pds-input component-id="pds-input-prepend-select" label="Amount" type="text" value="100">
-    <pds-select slot="prepend">
+    <pds-select hide-label slot="prepend">
       <option value="USD">USD</option>
       <option value="EUR">EUR</option>
       <option value="GBP">GBP</option>
@@ -223,7 +223,7 @@ Prepend and append elements are placed outside the input container, next to the 
   mdxSource={{
     react: `<PdsInput componentId="pds-input-prefix-append" label="Amount" type="text" value="100">
       <PdsIcon name="dollar" slot="prefix"></PdsIcon>
-      <PdsSelect slot="append">
+      <PdsSelect hideLabel slot="append">
         <option value="USD">USD</option>
         <option value="EUR">EUR</option>
         <option value="GBP">GBP</option>
@@ -231,7 +231,7 @@ Prepend and append elements are placed outside the input container, next to the 
     </PdsInput>`,
     webComponent: `<pds-input component-id="pds-input-prefix-append" label="Amount" type="text" value="100">
       <pds-icon name="dollar" slot="prefix"></pds-icon>
-      <pds-select slot="append">
+      <pds-select hide-label slot="append">
         <option value="USD">USD</option>
         <option value="EUR">EUR</option>
         <option value="GBP">GBP</option>
@@ -240,7 +240,7 @@ Prepend and append elements are placed outside the input container, next to the 
   }}>
   <pds-input component-id="pds-input-prefix-append" label="Amount" type="text" value="100">
     <pds-icon name="dollar" slot="prefix"></pds-icon>
-    <pds-select slot="append">
+    <pds-select hide-label slot="append">
       <option value="USD">USD</option>
       <option value="EUR">EUR</option>
       <option value="GBP">GBP</option>


### PR DESCRIPTION
# Description
Add `hide-label` or `hideLabel` to remove extra margin

#### Screenshot
|  LTR  |  RTL  |
|--------|--------|
|![Screenshot 2025-06-26 at 8 14 21 AM](https://github.com/user-attachments/assets/eb791fea-00c9-4113-b72d-c07b7a09a9d4)|![Screenshot 2025-06-26 at 8 16 02 AM](https://github.com/user-attachments/assets/ccdc2a5a-d68b-4d9b-89cf-acc5fffed441)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
