### PR TITLE
feat(pds-property): add property component to system

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -795,7 +795,7 @@ export namespace Components {
         /**
           * The name of the icon to display before the property text.
          */
-        "icon"?: string;
+        "icon": string;
     }
     interface PdsRadio {
         /**

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -787,6 +787,16 @@ export namespace Components {
          */
         "showPercent": boolean;
     }
+    interface PdsProperty {
+        /**
+          * A unique identifier used for the underlying component `id` attribute.
+         */
+        "componentId": string;
+        /**
+          * The name of the icon to display before the property text.
+         */
+        "icon"?: string;
+    }
     interface PdsRadio {
         /**
           * Determines whether or not the radio is checked.
@@ -1646,6 +1656,12 @@ declare global {
         prototype: HTMLPdsProgressElement;
         new (): HTMLPdsProgressElement;
     };
+    interface HTMLPdsPropertyElement extends Components.PdsProperty, HTMLStencilElement {
+    }
+    var HTMLPdsPropertyElement: {
+        prototype: HTMLPdsPropertyElement;
+        new (): HTMLPdsPropertyElement;
+    };
     interface HTMLPdsRadioElementEventMap {
         "pdsRadioChange": boolean;
     }
@@ -1909,6 +1925,7 @@ declare global {
         "pds-modal-header": HTMLPdsModalHeaderElement;
         "pds-popover": HTMLPdsPopoverElement;
         "pds-progress": HTMLPdsProgressElement;
+        "pds-property": HTMLPdsPropertyElement;
         "pds-radio": HTMLPdsRadioElement;
         "pds-row": HTMLPdsRowElement;
         "pds-select": HTMLPdsSelectElement;
@@ -2736,6 +2753,16 @@ declare namespace LocalJSX {
          */
         "showPercent"?: boolean;
     }
+    interface PdsProperty {
+        /**
+          * A unique identifier used for the underlying component `id` attribute.
+         */
+        "componentId"?: string;
+        /**
+          * The name of the icon to display before the property text.
+         */
+        "icon"?: string;
+    }
     interface PdsRadio {
         /**
           * Determines whether or not the radio is checked.
@@ -3333,6 +3360,7 @@ declare namespace LocalJSX {
         "pds-modal-header": PdsModalHeader;
         "pds-popover": PdsPopover;
         "pds-progress": PdsProgress;
+        "pds-property": PdsProperty;
         "pds-radio": PdsRadio;
         "pds-row": PdsRow;
         "pds-select": PdsSelect;
@@ -3385,6 +3413,7 @@ declare module "@stencil/core" {
             "pds-modal-header": LocalJSX.PdsModalHeader & JSXBase.HTMLAttributes<HTMLPdsModalHeaderElement>;
             "pds-popover": LocalJSX.PdsPopover & JSXBase.HTMLAttributes<HTMLPdsPopoverElement>;
             "pds-progress": LocalJSX.PdsProgress & JSXBase.HTMLAttributes<HTMLPdsProgressElement>;
+            "pds-property": LocalJSX.PdsProperty & JSXBase.HTMLAttributes<HTMLPdsPropertyElement>;
             "pds-radio": LocalJSX.PdsRadio & JSXBase.HTMLAttributes<HTMLPdsRadioElement>;
             "pds-row": LocalJSX.PdsRow & JSXBase.HTMLAttributes<HTMLPdsRowElement>;
             "pds-select": LocalJSX.PdsSelect & JSXBase.HTMLAttributes<HTMLPdsSelectElement>;

--- a/libs/core/src/components/pds-box/readme.md
+++ b/libs/core/src/components/pds-box/readme.md
@@ -54,12 +54,14 @@
 
  - [pds-alert](../pds-alert)
  - [pds-dropdown-menu](../pds-dropdown-menu)
+ - [pds-property](../pds-property)
 
 ### Graph
 ```mermaid
 graph TD;
   pds-alert --> pds-box
   pds-dropdown-menu --> pds-box
+  pds-property --> pds-box
   style pds-box fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/libs/core/src/components/pds-property/docs/pds-property.mdx
+++ b/libs/core/src/components/pds-property/docs/pds-property.mdx
@@ -1,0 +1,66 @@
+import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
+import { components } from '../../../../dist/docs.json';
+
+# Property
+
+The Property component displays an icon and text together in a horizontal layout. It's useful for showing key-value pairs, status indicators, or labeled information.
+
+## Guidelines
+
+### When to use
+
+- Displaying key-value pairs or metadata with visual context.
+- Showing status indicators with accompanying text.
+- Providing labeled information with an icon for better visual recognition.
+- Creating compact property displays in lists, cards, or forms.
+
+### When not to use
+
+- For standalone text that doesn't benefit from an icon.
+- When space is extremely limited and the icon would cause clutter.
+- For complex layouts where a custom solution would be more appropriate.
+
+### Accessibility
+
+The Property component is designed with accessibility in mind:
+
+- Icons are marked with `aria-hidden="true"` as they are decorative and provide visual context rather than essential information.
+- Text content is properly exposed to screen readers through both prop and slot content.
+- The component supports proper keyboard navigation patterns when used in interactive contexts.
+
+## Properties
+
+<DocArgsTable componentName="pds-property" docSource={components} />
+
+### Default
+
+Basic property with icon and text.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsProperty icon="check-circle">Property text</PdsProperty>',
+    webComponent: '<pds-property icon="check-circle">Property text</pds-property>'
+}}>
+  <pds-property icon="check-circle">Property text</pds-property>
+</DocCanvas>
+
+### Various Icons
+
+Examples of properties with different icons for different contexts.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsProperty icon="user">John Doe</PdsProperty>
+<PdsProperty icon="location">San Francisco, CA</PdsProperty>
+<PdsProperty icon="calendarDate">March 15, 2024</PdsProperty>
+<PdsProperty icon="tag">Active</PdsProperty>`,
+    webComponent: `<pds-property icon="user">John Doe</pds-property>
+<pds-property icon="location">San Francisco, CA</pds-property>
+<pds-property icon="calendar-date">March 15, 2024</pds-property>
+<pds-property icon="tag">Active</pds-property>`
+}}>
+  <pds-property icon="user">John Doe</pds-property>
+  <pds-property icon="location">San Francisco, CA</pds-property>
+  <pds-property icon="calendar-date">March 15, 2024</pds-property>
+  <pds-property icon="tag">Active</pds-property>
+</DocCanvas>

--- a/libs/core/src/components/pds-property/docs/pds-property.mdx
+++ b/libs/core/src/components/pds-property/docs/pds-property.mdx
@@ -3,30 +3,29 @@ import { components } from '../../../../dist/docs.json';
 
 # Property
 
-The Property component displays an icon and text together in a horizontal layout. It's useful for showing key-value pairs, status indicators, or labeled information.
+The Property component displays an icon and text together in a horizontal layout. It's useful for showing key-value pairs, status indicators, or labeled information. The component always displays an icon - if no icon is specified, it defaults to a star icon.
 
 ## Guidelines
 
 ### When to use
 
-- Displaying key-value pairs or metadata with visual context.
-- Showing status indicators with accompanying text.
-- Providing labeled information with an icon for better visual recognition.
-- Creating compact property displays in lists, cards, or forms.
+- Display labeled information or metadata with consistent visual treatment
+- Show key-value pairs, properties, or attributes with icon context
+- Create status indicators or tags with accompanying text
+- Maintain consistent spacing and alignment between icons and text
 
 ### When not to use
 
-- For standalone text that doesn't benefit from an icon.
-- When space is extremely limited and the icon would cause clutter.
-- For complex layouts where a custom solution would be more appropriate.
+- For plain text content that doesn't benefit from an icon
+- When you need interactive functionality (this is display-only)
+- For complex layouts requiring custom styling or multiple elements
+- When the icon would be redundant or confusing to users
 
 ### Accessibility
 
 The Property component is designed with accessibility in mind:
 
 - Icons are marked with `aria-hidden="true"` as they are decorative and provide visual context rather than essential information.
-- Text content is properly exposed to screen readers through both prop and slot content.
-- The component supports proper keyboard navigation patterns when used in interactive contexts.
 
 ## Properties
 
@@ -34,7 +33,19 @@ The Property component is designed with accessibility in mind:
 
 ### Default
 
-Basic property with icon and text.
+Basic property with default star icon when no icon is specified.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsProperty>Property text</PdsProperty>',
+    webComponent: '<pds-property>Property text</pds-property>'
+}}>
+  <pds-property>Property text</pds-property>
+</DocCanvas>
+
+### With Custom Icon
+
+Property with a custom icon.
 
 <DocCanvas client:only
   mdxSource={{
@@ -51,16 +62,16 @@ Examples of properties with different icons for different contexts.
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsProperty icon="user">John Doe</PdsProperty>
-<PdsProperty icon="location">San Francisco, CA</PdsProperty>
-<PdsProperty icon="calendarDate">March 15, 2024</PdsProperty>
+<PdsProperty icon="location">Newport Beach, CA</PdsProperty>
+<PdsProperty icon="calendarDate">March 15, 2025</PdsProperty>
 <PdsProperty icon="tag">Active</PdsProperty>`,
     webComponent: `<pds-property icon="user">John Doe</pds-property>
-<pds-property icon="location">San Francisco, CA</pds-property>
-<pds-property icon="calendar-date">March 15, 2024</pds-property>
+<pds-property icon="location">Newport Beach, CA</pds-property>
+<pds-property icon="calendar-date">March 15, 2025</pds-property>
 <pds-property icon="tag">Active</pds-property>`
 }}>
   <pds-property icon="user">John Doe</pds-property>
-  <pds-property icon="location">San Francisco, CA</pds-property>
-  <pds-property icon="calendar-date">March 15, 2024</pds-property>
+  <pds-property icon="location">Newport Beach, CA</pds-property>
+  <pds-property icon="calendar-date">March 15, 2025</pds-property>
   <pds-property icon="tag">Active</pds-property>
 </DocCanvas>

--- a/libs/core/src/components/pds-property/pds-property.scss
+++ b/libs/core/src/components/pds-property/pds-property.scss
@@ -1,0 +1,29 @@
+:host {
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.pds-property {
+  align-items: center;
+  color: var(--pine-color-text-message);
+  display: inline-flex;
+  font: var(--pine-typography-body-default);
+  gap: var(--pine-dimension-xs);
+}
+
+.pds-property__icon {
+  pds-icon {
+    color: var(--pine-color-text-message);
+    fill: currentColor;
+  }
+}
+
+.pds-property__text {
+  flex-basis: 100%;
+  line-height: 1.5;
+
+  span {
+    color: inherit;
+    font: inherit;
+  }
+}

--- a/libs/core/src/components/pds-property/pds-property.scss
+++ b/libs/core/src/components/pds-property/pds-property.scss
@@ -1,29 +1,4 @@
 :host {
-  display: inline-flex;
-  vertical-align: middle;
-}
-
-.pds-property {
-  align-items: center;
   color: var(--pine-color-text-message);
-  display: inline-flex;
-  font: var(--pine-typography-body-default);
-  gap: var(--pine-dimension-xs);
-}
-
-.pds-property__icon {
-  pds-icon {
-    color: var(--pine-color-text-message);
-    fill: currentColor;
-  }
-}
-
-.pds-property__text {
-  flex-basis: 100%;
-  line-height: 1.5;
-
-  span {
-    color: inherit;
-    font: inherit;
-  }
+  font: var(--pine-typography-body-medium);
 }

--- a/libs/core/src/components/pds-property/pds-property.tsx
+++ b/libs/core/src/components/pds-property/pds-property.tsx
@@ -18,24 +18,14 @@ export class PdsProperty {
   /**
    * The name of the icon to display before the property text.
    */
-  @Prop() icon?: string;
-
-  private classNames() {
-    return 'pds-property';
-  }
+  @Prop() icon: string = 'star';
 
   render() {
     return (
-      <Host class={this.classNames()} id={this.componentId}>
+      <Host id={this.componentId}>
         <pds-box align-items="center" gap="xs">
-          {this.icon && (
-            <pds-box align-items="center" justify-content="center" flex-shrink="0" class="pds-property__icon">
-              <pds-icon icon={this.icon} size="16px" aria-hidden="true"></pds-icon>
-            </pds-box>
-          )}
-          <pds-box align-items="center" class="pds-property__text">
-            <slot />
-          </pds-box>
+          <pds-icon icon={this.icon} size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+          <slot />
         </pds-box>
       </Host>
     );

--- a/libs/core/src/components/pds-property/pds-property.tsx
+++ b/libs/core/src/components/pds-property/pds-property.tsx
@@ -1,0 +1,43 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+/**
+ * @slot (default) - The property text content.
+ */
+
+@Component({
+  tag: 'pds-property',
+  styleUrls: ['pds-property.scss'],
+  shadow: true,
+})
+export class PdsProperty {
+  /**
+   * A unique identifier used for the underlying component `id` attribute.
+   */
+  @Prop() componentId: string;
+
+  /**
+   * The name of the icon to display before the property text.
+   */
+  @Prop() icon?: string;
+
+  private classNames() {
+    return 'pds-property';
+  }
+
+  render() {
+    return (
+      <Host class={this.classNames()} id={this.componentId}>
+        <pds-box align-items="center" gap="xs">
+          {this.icon && (
+            <pds-box align-items="center" justify-content="center" flex-shrink="0" class="pds-property__icon">
+              <pds-icon icon={this.icon} size="16px" aria-hidden="true"></pds-icon>
+            </pds-box>
+          )}
+          <pds-box align-items="center" class="pds-property__text">
+            <slot />
+          </pds-box>
+        </pds-box>
+      </Host>
+    );
+  }
+}

--- a/libs/core/src/components/pds-property/readme.md
+++ b/libs/core/src/components/pds-property/readme.md
@@ -1,0 +1,40 @@
+# pds-property
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute      | Description                                                           | Type     | Default     |
+| ------------- | -------------- | --------------------------------------------------------------------- | -------- | ----------- |
+| `componentId` | `component-id` | A unique identifier used for the underlying component `id` attribute. | `string` | `undefined` |
+| `icon`        | `icon`         | The name of the icon to display before the property text.             | `string` | `undefined` |
+
+
+## Slots
+
+| Slot          | Description                |
+| ------------- | -------------------------- |
+| `"(default)"` | The property text content. |
+
+
+## Dependencies
+
+### Depends on
+
+- [pds-box](../pds-box)
+- pds-icon
+
+### Graph
+```mermaid
+graph TD;
+  pds-property --> pds-box
+  pds-property --> pds-icon
+  style pds-property fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/libs/core/src/components/pds-property/readme.md
+++ b/libs/core/src/components/pds-property/readme.md
@@ -10,7 +10,7 @@
 | Property      | Attribute      | Description                                                           | Type     | Default     |
 | ------------- | -------------- | --------------------------------------------------------------------- | -------- | ----------- |
 | `componentId` | `component-id` | A unique identifier used for the underlying component `id` attribute. | `string` | `undefined` |
-| `icon`        | `icon`         | The name of the icon to display before the property text.             | `string` | `undefined` |
+| `icon`        | `icon`         | The name of the icon to display before the property text.             | `string` | `'star'`    |
 
 
 ## Slots

--- a/libs/core/src/components/pds-property/stories/pds-property.docs.mdx
+++ b/libs/core/src/components/pds-property/stories/pds-property.docs.mdx
@@ -1,0 +1,15 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+
+import * as stories from './pds-property.stories.js';
+
+import Docs from '../docs/pds-property.mdx';
+
+<Meta of={stories} />
+
+<Docs />
+
+## Playground
+
+<Canvas of={stories.Default} />
+
+<Controls of={stories.Default} />

--- a/libs/core/src/components/pds-property/stories/pds-property.stories.js
+++ b/libs/core/src/components/pds-property/stories/pds-property.stories.js
@@ -4,36 +4,17 @@ import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
   argTypes: extractArgTypes('pds-property'),
-  args: {
-    icon: null,
-    text: null,
-  },
   component: 'pds-property',
   decorators: [withActions],
   title: 'components/Property',
 };
 
 const BaseTemplate = (args) => html`
-  <pds-property
-    component-id=${args.componentId}
-    icon=${args.icon}
-  >
-    ${args.text}
-  </pds-property>`;
+  <pds-property component-id=${args.componentId} icon=${args.icon}>${args.text}</pds-property>`;
 
 export const Default = BaseTemplate.bind();
 Default.args = {
-  icon: 'check-circle',
+  componentId: 'property-1',
+  icon: 'star',
   text: 'Property text',
-};
-
-export const WithoutIcon = BaseTemplate.bind();
-WithoutIcon.args = {
-  text: 'Property text without icon',
-};
-
-export const LongText = BaseTemplate.bind();
-LongText.args = {
-  icon: 'warning-triangle',
-  text: 'This is a longer property text that might wrap to multiple lines or be truncated depending on the container width',
 };

--- a/libs/core/src/components/pds-property/stories/pds-property.stories.js
+++ b/libs/core/src/components/pds-property/stories/pds-property.stories.js
@@ -1,0 +1,39 @@
+import { html } from 'lit';
+import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
+import { withActions } from '@storybook/addon-actions/decorator';
+
+export default {
+  argTypes: extractArgTypes('pds-property'),
+  args: {
+    icon: null,
+    text: null,
+  },
+  component: 'pds-property',
+  decorators: [withActions],
+  title: 'components/Property',
+};
+
+const BaseTemplate = (args) => html`
+  <pds-property
+    component-id=${args.componentId}
+    icon=${args.icon}
+  >
+    ${args.text}
+  </pds-property>`;
+
+export const Default = BaseTemplate.bind();
+Default.args = {
+  icon: 'check-circle',
+  text: 'Property text',
+};
+
+export const WithoutIcon = BaseTemplate.bind();
+WithoutIcon.args = {
+  text: 'Property text without icon',
+};
+
+export const LongText = BaseTemplate.bind();
+LongText.args = {
+  icon: 'warning-triangle',
+  text: 'This is a longer property text that might wrap to multiple lines or be truncated depending on the container width',
+};

--- a/libs/core/src/components/pds-property/test/pds-property.e2e.ts
+++ b/libs/core/src/components/pds-property/test/pds-property.e2e.ts
@@ -3,10 +3,10 @@ import { newE2EPage } from '@stencil/core/testing';
 describe('pds-property', () => {
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-property text="Property text"></pds-property>');
+    await page.setContent('<pds-property>Property text</pds-property>');
 
     const element = await page.find('pds-property');
-    expect(element).toHaveClass('pds-property');
+    expect(element).toBeTruthy();
   });
 
       it('renders with icon and text', async () => {
@@ -14,7 +14,7 @@ describe('pds-property', () => {
     await page.setContent('<pds-property icon="check-circle">Property text</pds-property>');
 
     const element = await page.find('pds-property');
-    expect(element).toHaveClass('pds-property');
+    expect(element).toBeTruthy();
 
     const icon = await page.find('pds-property >>> pds-icon');
     expect(icon).toBeTruthy();
@@ -33,21 +33,23 @@ describe('pds-property', () => {
     `);
 
     const element = await page.find('pds-property');
-    expect(element).toHaveClass('pds-property');
+    expect(element).toBeTruthy();
 
     const slotContent = await page.find('pds-property span');
     expect(slotContent.textContent).toBe('Slot content');
   });
 
-  it('renders without icon', async () => {
+  it('renders with default star icon when no icon specified', async () => {
     const page = await newE2EPage();
     await page.setContent('<pds-property>Property text without icon</pds-property>');
 
     const element = await page.find('pds-property');
-    expect(element).toHaveClass('pds-property');
+    expect(element).toBeTruthy();
 
     const icon = await page.find('pds-property >>> pds-icon');
-    expect(icon).toBeFalsy();
+    expect(icon).toBeTruthy();
+    const iconName = await icon.getProperty('icon');
+    expect(iconName).toBe('star');
 
     expect(element.textContent).toBe('Property text without icon');
   });

--- a/libs/core/src/components/pds-property/test/pds-property.e2e.ts
+++ b/libs/core/src/components/pds-property/test/pds-property.e2e.ts
@@ -1,0 +1,54 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pds-property', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-property text="Property text"></pds-property>');
+
+    const element = await page.find('pds-property');
+    expect(element).toHaveClass('pds-property');
+  });
+
+      it('renders with icon and text', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-property icon="check-circle">Property text</pds-property>');
+
+    const element = await page.find('pds-property');
+    expect(element).toHaveClass('pds-property');
+
+    const icon = await page.find('pds-property >>> pds-icon');
+    expect(icon).toBeTruthy();
+    const iconName = await icon.getProperty('icon');
+    expect(iconName).toBe('check-circle');
+
+    expect(element.textContent).toBe('Property text');
+  });
+
+    it('renders with slot content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-property icon="info-circle">
+        <span>Slot content</span>
+      </pds-property>
+    `);
+
+    const element = await page.find('pds-property');
+    expect(element).toHaveClass('pds-property');
+
+    const slotContent = await page.find('pds-property span');
+    expect(slotContent.textContent).toBe('Slot content');
+  });
+
+  it('renders without icon', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-property>Property text without icon</pds-property>');
+
+    const element = await page.find('pds-property');
+    expect(element).toHaveClass('pds-property');
+
+    const icon = await page.find('pds-property >>> pds-icon');
+    expect(icon).toBeFalsy();
+
+    expect(element.textContent).toBe('Property text without icon');
+  });
+});

--- a/libs/core/src/components/pds-property/test/pds-property.spec.tsx
+++ b/libs/core/src/components/pds-property/test/pds-property.spec.tsx
@@ -8,12 +8,11 @@ describe('pds-property', () => {
       html: `<pds-property>Property text</pds-property>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-property class="pds-property">
+      <pds-property>
         <mock:shadow-root>
           <pds-box align-items="center" gap="xs">
-            <pds-box align-items="center" class="pds-property__text">
-              <slot></slot>
-            </pds-box>
+            <pds-icon icon="star" size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+            <slot></slot>
           </pds-box>
         </mock:shadow-root>
         Property text
@@ -27,15 +26,11 @@ describe('pds-property', () => {
       html: `<pds-property icon="check-circle">Property text</pds-property>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-property class="pds-property" icon="check-circle">
+      <pds-property icon="check-circle">
         <mock:shadow-root>
           <pds-box align-items="center" gap="xs">
-            <pds-box align-items="center" class="pds-property__icon" flex-shrink="0" justify-content="center">
-              <pds-icon icon="check-circle" size="16px" aria-hidden="true"></pds-icon>
-            </pds-box>
-            <pds-box align-items="center" class="pds-property__text">
-              <slot></slot>
-            </pds-box>
+            <pds-icon icon="check-circle" size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+            <slot></slot>
           </pds-box>
         </mock:shadow-root>
         Property text
@@ -51,15 +46,11 @@ describe('pds-property', () => {
       </pds-property>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-property class="pds-property" icon="info-circle">
+      <pds-property icon="info-circle">
         <mock:shadow-root>
           <pds-box align-items="center" gap="xs">
-            <pds-box align-items="center" class="pds-property__icon" flex-shrink="0" justify-content="center">
-              <pds-icon icon="info-circle" size="16px" aria-hidden="true"></pds-icon>
-            </pds-box>
-            <pds-box align-items="center" class="pds-property__text">
-              <slot></slot>
-            </pds-box>
+            <pds-icon icon="info-circle" size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+            <slot></slot>
           </pds-box>
         </mock:shadow-root>
         <span>Complex slot content</span>
@@ -67,18 +58,17 @@ describe('pds-property', () => {
     `);
   });
 
-  it('renders without icon', async () => {
+  it('renders without icon (uses default star)', async () => {
     const page = await newSpecPage({
       components: [PdsProperty],
       html: `<pds-property>Property text without icon</pds-property>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-property class="pds-property">
+      <pds-property>
         <mock:shadow-root>
           <pds-box align-items="center" gap="xs">
-            <pds-box align-items="center" class="pds-property__text">
-              <slot></slot>
-            </pds-box>
+            <pds-icon icon="star" size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+            <slot></slot>
           </pds-box>
         </mock:shadow-root>
         Property text without icon
@@ -92,12 +82,11 @@ describe('pds-property', () => {
       html: `<pds-property component-id="test-property">Property text</pds-property>`,
     });
     expect(page.root).toEqualHtml(`
-      <pds-property class="pds-property" component-id="test-property" id="test-property">
+      <pds-property component-id="test-property" id="test-property">
         <mock:shadow-root>
           <pds-box align-items="center" gap="xs">
-            <pds-box align-items="center" class="pds-property__text">
-              <slot></slot>
-            </pds-box>
+            <pds-icon icon="star" size="var(--pine-dimension-sm)" aria-hidden="true"></pds-icon>
+            <slot></slot>
           </pds-box>
         </mock:shadow-root>
         Property text

--- a/libs/core/src/components/pds-property/test/pds-property.spec.tsx
+++ b/libs/core/src/components/pds-property/test/pds-property.spec.tsx
@@ -1,0 +1,107 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PdsProperty } from '../pds-property';
+
+describe('pds-property', () => {
+  it('renders with slot content', async () => {
+    const page = await newSpecPage({
+      components: [PdsProperty],
+      html: `<pds-property>Property text</pds-property>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-property class="pds-property">
+        <mock:shadow-root>
+          <pds-box align-items="center" gap="xs">
+            <pds-box align-items="center" class="pds-property__text">
+              <slot></slot>
+            </pds-box>
+          </pds-box>
+        </mock:shadow-root>
+        Property text
+      </pds-property>
+    `);
+  });
+
+  it('renders with icon and slot content', async () => {
+    const page = await newSpecPage({
+      components: [PdsProperty],
+      html: `<pds-property icon="check-circle">Property text</pds-property>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-property class="pds-property" icon="check-circle">
+        <mock:shadow-root>
+          <pds-box align-items="center" gap="xs">
+            <pds-box align-items="center" class="pds-property__icon" flex-shrink="0" justify-content="center">
+              <pds-icon icon="check-circle" size="16px" aria-hidden="true"></pds-icon>
+            </pds-box>
+            <pds-box align-items="center" class="pds-property__text">
+              <slot></slot>
+            </pds-box>
+          </pds-box>
+        </mock:shadow-root>
+        Property text
+      </pds-property>
+    `);
+  });
+
+  it('renders with complex slot content', async () => {
+    const page = await newSpecPage({
+      components: [PdsProperty],
+      html: `<pds-property icon="info-circle">
+        <span>Complex slot content</span>
+      </pds-property>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-property class="pds-property" icon="info-circle">
+        <mock:shadow-root>
+          <pds-box align-items="center" gap="xs">
+            <pds-box align-items="center" class="pds-property__icon" flex-shrink="0" justify-content="center">
+              <pds-icon icon="info-circle" size="16px" aria-hidden="true"></pds-icon>
+            </pds-box>
+            <pds-box align-items="center" class="pds-property__text">
+              <slot></slot>
+            </pds-box>
+          </pds-box>
+        </mock:shadow-root>
+        <span>Complex slot content</span>
+      </pds-property>
+    `);
+  });
+
+  it('renders without icon', async () => {
+    const page = await newSpecPage({
+      components: [PdsProperty],
+      html: `<pds-property>Property text without icon</pds-property>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-property class="pds-property">
+        <mock:shadow-root>
+          <pds-box align-items="center" gap="xs">
+            <pds-box align-items="center" class="pds-property__text">
+              <slot></slot>
+            </pds-box>
+          </pds-box>
+        </mock:shadow-root>
+        Property text without icon
+      </pds-property>
+    `);
+  });
+
+  it('renders with componentId', async () => {
+    const page = await newSpecPage({
+      components: [PdsProperty],
+      html: `<pds-property component-id="test-property">Property text</pds-property>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pds-property class="pds-property" component-id="test-property" id="test-property">
+        <mock:shadow-root>
+          <pds-box align-items="center" gap="xs">
+            <pds-box align-items="center" class="pds-property__text">
+              <slot></slot>
+            </pds-box>
+          </pds-box>
+        </mock:shadow-root>
+        Property text
+      </pds-property>
+    `);
+  });
+});

--- a/libs/react/src/components/proxies.ts
+++ b/libs/react/src/components/proxies.ts
@@ -28,6 +28,7 @@ import { defineCustomElement as definePdsModalFooter } from '@pine-ds/core/compo
 import { defineCustomElement as definePdsModalHeader } from '@pine-ds/core/components/pds-modal-header.js';
 import { defineCustomElement as definePdsPopover } from '@pine-ds/core/components/pds-popover.js';
 import { defineCustomElement as definePdsProgress } from '@pine-ds/core/components/pds-progress.js';
+import { defineCustomElement as definePdsProperty } from '@pine-ds/core/components/pds-property.js';
 import { defineCustomElement as definePdsRadio } from '@pine-ds/core/components/pds-radio.js';
 import { defineCustomElement as definePdsRow } from '@pine-ds/core/components/pds-row.js';
 import { defineCustomElement as definePdsSelect } from '@pine-ds/core/components/pds-select.js';
@@ -71,6 +72,7 @@ export const PdsModalFooter = /*@__PURE__*/createReactComponent<JSX.PdsModalFoot
 export const PdsModalHeader = /*@__PURE__*/createReactComponent<JSX.PdsModalHeader, HTMLPdsModalHeaderElement>('pds-modal-header', undefined, undefined, definePdsModalHeader);
 export const PdsPopover = /*@__PURE__*/createReactComponent<JSX.PdsPopover, HTMLPdsPopoverElement>('pds-popover', undefined, undefined, definePdsPopover);
 export const PdsProgress = /*@__PURE__*/createReactComponent<JSX.PdsProgress, HTMLPdsProgressElement>('pds-progress', undefined, undefined, definePdsProgress);
+export const PdsProperty = /*@__PURE__*/createReactComponent<JSX.PdsProperty, HTMLPdsPropertyElement>('pds-property', undefined, undefined, definePdsProperty);
 export const PdsRadio = /*@__PURE__*/createReactComponent<JSX.PdsRadio, HTMLPdsRadioElement>('pds-radio', undefined, undefined, definePdsRadio);
 export const PdsRow = /*@__PURE__*/createReactComponent<JSX.PdsRow, HTMLPdsRowElement>('pds-row', undefined, undefined, definePdsRow);
 export const PdsSelect = /*@__PURE__*/createReactComponent<JSX.PdsSelect, HTMLPdsSelectElement>('pds-select', undefined, undefined, definePdsSelect);


### PR DESCRIPTION
# Description

This PR introduces the `pds-property` component, a simple display component that renders an icon and text together in a horizontal layout. The component is designed to display key-value pairs, status indicators, or labeled information with a consistent visual treatment. The `icon` prop is optional and defaults to "star" when not specified, ensuring the component always displays with appropriate visual context. This component is useful for creating compact properties where labeled information needs consistent spacing and alignment.

Fixes [DSS-1480](https://kajabi.atlassian.net/browse/DSS-1480)

|  pds-property Screenshot   |
|--------|
|<img width="651" height="276" alt="Screenshot 2025-07-14 at 1 53 21 PM" src="https://github.com/user-attachments/assets/2e3ac1e5-4d61-44fd-8d29-c6aa9e09a3b5" />| 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. Spin up local Pine Storybook
2. Navigate to the [property component](http://localhost:6006/?path=/docs/components-property--docs) and verify it looks and functions as expected.

- [x] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1480]: https://kajabi.atlassian.net/browse/DSS-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ