### PR TITLE
feat(typography): standardize form label typography

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -147,7 +147,6 @@
 
 .pds-input__label {
   color: var(--pine-color-text-active);
-  font: var(--pine-typography-body-sm-medium);
   margin-block-end: var(--pine-dimension-2xs);
 }
 


### PR DESCRIPTION

# Standardize Label Typography Across Form Components (DSS-1475)

## Summary
This PR standardizes the label text styling across `pds-input`, `pds-select`, and `pds-textarea` components by removing a conflicting font override from the pds-input component. Previously, `pds-input` had a custom font property that overrode the shared typography token, causing inconsistent label sizes across form components.

**Key Change**: Removed `font: var(--pine-typography-body-sm-medium);` from `.pds-input__label` in `pds-input.scss`, allowing all three components to consistently use `var(--pine-typography-body-medium)` from the shared `label.scss` utility.

## Review & Testing Checklist for Human
- [ ] **Visual verification**: Compare label typography across pds-input, pds-select, and pds-textarea in both Storybook and actual applications
- [ ] **Component states testing**: Verify consistent typography in normal, disabled, and error states for all three components
- [ ] **CI failure assessment**: Confirm that the failing `test-specs (18)` check is indeed unrelated to this typography change (appears to be a flaky pds-tabs e2e test)
- [ ] **Layout regression check**: Ensure the typography change doesn't break existing layouts or cause unexpected spacing issues

**Recommended Test Plan**: 
1. Open Storybook and visually compare all three form components side-by-side
2. Test in a real application with various form states
3. Check that labels maintain consistent visual hierarchy with other text elements

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["libs/core/src/global/styles/utils/label.scss<br/>Contains: font: var(--pine-typography-body-medium)"]:::context
    B["libs/core/src/components/pds-input/pds-input.scss<br/>REMOVED: font override"]:::major-edit
    C["libs/core/src/components/pds-select/pds-select.scss<br/>Imports label.scss"]:::context
    D["libs/core/src/components/pds-textarea/pds-textarea.scss<br/>Imports label.scss"]:::context
    
    A -->|"provides typography"| B
    A -->|"provides typography"| C
    A -->|"provides typography"| D
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#F5F5F5
```

### Notes
- The CI failure appears to be a flaky test in `pds-tabs.e2e.ts` unrelated to typography changes
- All typography-related local tests pass successfully
- This change aligns with the Pine design system's goal of consistent typography tokens
- Session requested by: phillip.lovelace@kajabi.com (@pixelflips)
- Link to Devin run: https://app.devin.ai/sessions/90d87aeb41294b51ac2e1546c4edbbd9
