### PR TITLE
feat(pds-text): add CSS part support to component

### DIFF
--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -1,6 +1,9 @@
 import { Component, h, Prop, Element } from '@stencil/core';
 import { setColor } from '../../utils/utils';
 
+/**
+ * @part content - The text content container
+ */
 @Component({
   tag: 'pds-text',
   styleUrl: 'pds-text.scss',
@@ -105,7 +108,7 @@ export class PdsText {
     `;
 
     return (
-      <Tag style={this.color && setColor(this.color)} class={typeClasses}>
+      <Tag style={this.color && setColor(this.color)} class={typeClasses} part="content">
         <slot />
       </Tag>
     );

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -20,6 +20,13 @@
 | `weight`     | `weight`     | Sets the font weight.                                                            | `"bold" \| "extra-light" \| "light" \| "medium" \| "regular" \| "semibold"`                              | `undefined` |
 
 
+## Shadow Parts
+
+| Part        | Description                |
+| ----------- | -------------------------- |
+| `"content"` | The text content container |
+
+
 ## Dependencies
 
 ### Used by

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -10,7 +10,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1">
         <mock:shadow-root>
-          <h1 class="pds-text"><slot></slot></h1>
+          <h1 class="pds-text" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `);
@@ -24,7 +24,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1" align="center">
         <mock:shadow-root>
-          <h1 class="pds-text pds-text--align-center"><slot></slot></h1>
+          <h1 class="pds-text pds-text--align-center" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `);
@@ -38,7 +38,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1" color="accent">
         <mock:shadow-root>
-          <h1 class="pds-text" style="--color: var(--pine-color-text-accent);"><slot></slot></h1>
+          <h1 class="pds-text" style="--color: var(--pine-color-text-accent);" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `)
@@ -52,7 +52,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1" color="var(--pine-color-green-400)">
         <mock:shadow-root>
-          <h1 class="pds-text" style="--color: var(--pine-color-green-400);"><slot></slot></h1>
+          <h1 class="pds-text" style="--color: var(--pine-color-green-400);" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `)
@@ -66,7 +66,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1" size="xl">
         <mock:shadow-root>
-          <h1 class="pds-text pds-text--size-xl"><slot></slot></h1>
+          <h1 class="pds-text pds-text--size-xl" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `)
@@ -80,7 +80,7 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="h1" weight="bold">
         <mock:shadow-root>
-          <h1 class="pds-text pds-text--weight-bold"><slot></slot></h1>
+          <h1 class="pds-text pds-text--weight-bold" part="content"><slot></slot></h1>
         </mock:shadow-root>
       </pds-text>
     `)
@@ -94,9 +94,26 @@ describe('pds-text', () => {
     expect(page.root).toEqualHtml(`
       <pds-text tag="p" decoration="underline-dotted">
         <mock:shadow-root>
-          <p class="pds-text pds-text--decoration-underline-dotted"><slot></slot></p>
+          <p class="pds-text pds-text--decoration-underline-dotted" part="content"><slot></slot></p>
         </mock:shadow-root>
       </pds-text>
     `)
+  });
+
+  it('renders with part attribute for external CSS targeting', async () => {
+    const page = await newSpecPage({
+      components: [PdsText],
+      html: `<pds-text tag="p">Test content</pds-text>`,
+    });
+    
+    expect(page.root).toBeTruthy();
+    expect(page.root!.shadowRoot).toBeTruthy();
+    
+    const shadowRoot = page.root!.shadowRoot!;
+    const contentElement = shadowRoot.querySelector('[part="content"]');
+    
+    expect(contentElement).toBeTruthy();
+    expect(contentElement!.getAttribute('part')).toBe('content');
+    expect(contentElement!.tagName.toLowerCase()).toBe('p');
   });
 });


### PR DESCRIPTION
# feat: add CSS part support to pds-text component (DSS-1476)

## Summary

This PR adds CSS part support to the `pds-text` component by:
- Adding `part="content"` attribute to the slot element to enable external CSS targeting via `::part(content)`
- Adding JSDoc `@part` annotation for proper documentation
- Updating all existing tests to validate the part attribute presence
- Adding a new test case to verify external CSS targeting capability

This change brings the `pds-text` component in line with other Pine components (like `pds-button`, `pds-link`, `pds-avatar`) that already support CSS parts for controlled customization while maintaining encapsulation.

## Review & Testing Checklist for Human

- [ ] **Verify CSS part functionality works** - Test that external CSS can successfully target `pds-text::part(content)` in a real environment
- [ ] **Check all CI tests pass** - Ensure the updated test expectations are correct and no tests were missed
- [ ] **Validate component functionality** - Test that the pds-text component still works correctly with various props (size, weight, color, etc.)
- [ ] **Verify consistency with other components** - Check that the implementation matches the CSS part pattern used in pds-button, pds-link, and other components

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["pds-text.tsx<br/>Main component file"]:::major-edit
    B["pds-text.spec.tsx<br/>Test file"]:::major-edit
    C["readme.md<br/>Auto-generated docs"]:::minor-edit
    D["pds-button.tsx<br/>Reference component"]:::context
    E["pds-link.tsx<br/>Reference component"]:::context
    
    A -->|"Updated render method<br/>Added part attribute"| B
    A -->|"Added JSDoc @part<br/>annotation"| C
    D -->|"Pattern reference<br/>for part implementation"| A
    E -->|"Pattern reference<br/>for part implementation"| A
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Environment limitations**: I was unable to run tests locally due to Chrome/Puppeteer setup issues, so the test updates need verification in CI
- **Implementation follows existing patterns**: The CSS part implementation mirrors the approach used in pds-button, pds-link, and pds-avatar components
- **Backward compatibility**: This change is additive and doesn't break existing functionality
- **Testing approach**: All existing tests were updated to include the new part attribute, and a new test was added to verify CSS part targeting works

**Link to Devin run**: https://app.devin.ai/sessions/b5b3b03857574b7db952519b6b6f4a57  
**Requested by**: phillip.lovelace@kajabi.com (@pixelflips)
**Jira ticket**: https://kajabi.atlassian.net/browse/DSS-1476
