### PR TITLE
fix: correct Sass deprecation warnings

### DIFF
--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -1,4 +1,4 @@
-@import './pds-box.mixins';
+@use './pds-box.mixins' as *;
 
 pds-box {
   --border-width-default: var(--pine-border-width-thin);

--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -1,3 +1,5 @@
+@use 'sass:map';
+
 :host {
   --sizing-close: var(--pine-dimension-125);
 
@@ -52,25 +54,25 @@ $pds-chip-sentiment-hover: (
     // dot colors
     .pds-chip__dot {
       /* stylelint-disable-next-line */
-      background: map-get($pds-chip-sentiment-dots, $sentiment);
+      background: map.get($pds-chip-sentiment-dots, $sentiment);
     }
 
     .pds-chip__label, .pds-chip__button, .pds-chip__close {
       /* stylelint-disable-next-line */
-      color: map-get($pds-chip-sentiment-text, $sentiment);
+      color: map.get($pds-chip-sentiment-text, $sentiment);
       font-weight: var(--pine-font-weight-medium);
     }
 
     // tag close hover colors
     .pds-chip__close:hover {
       /* stylelint-disable-next-line */
-      background: map-get($pds-chip-sentiment-hover, $sentiment);
+      background: map.get($pds-chip-sentiment-hover, $sentiment);
     }
   }
   // dropdown hover colors
   :host(.pds-chip--#{$sentiment}.pds-chip--dropdown:hover) {
     /* stylelint-disable-next-line */
-    background: map-get($pds-chip-sentiment-hover, $sentiment);
+    background: map.get($pds-chip-sentiment-hover, $sentiment);
   }
 }
 


### PR DESCRIPTION
# Fix Sass deprecation warnings for Dart Sass 3.0.0 compatibility

## Summary

This PR addresses Sass deprecation warnings that will become errors in Dart Sass 3.0.0 by updating deprecated syntax to modern equivalents. The changes affect two core component files:

- **pds-chip.scss**: Added `@use 'sass:map'` import and replaced 4 instances of `map-get()` with `map.get()`
- **pds-box.scss**: Updated `@import './pds-box.mixins'` to `@use './pds-box.mixins' as *`

These are purely syntactic changes with equivalent behavior - no logic or styling modifications were made.

**Ticket**: [DSS-1477](https://kajabi.atlassian.net/browse/DSS-1477)

## Review & Testing Checklist for Human

- [ ] **Visual regression check**: Verify chip and box components render identically to before (test various chip sentiments, box layouts)
- [ ] **Build verification**: Confirm `npx nx run @pine-ds/core:build` completes without Sass deprecation warnings
- [ ] **Syntax completeness**: Spot-check that all old syntax patterns were properly updated in both files

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Pine Design System"
        chip["libs/core/src/components/<br/>pds-chip/pds-chip.scss"]:::major-edit
        box["libs/core/src/components/<br/>pds-box/pds-box.scss"]:::major-edit
        mixins["libs/core/src/components/<br/>pds-box/pds-box.mixins"]:::context
        build["@pine-ds/core:build"]:::context
    end
    
    chip -->|"@use 'sass:map'<br/>map.get() syntax"| build
    box -->|"@use syntax"| mixins
    mixins --> build
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- Build passed successfully after changes, indicating no syntax errors
- Changes follow standard Sass modernization patterns documented in Dart Sass migration guides
- Only two component files were modified to maintain focused scope
- All deprecated syntax instances were systematically updated

**Session**: https://app.devin.ai/sessions/caf53de2eae3418fb3a6ae8d34ded1bc  
**Requested by**: @pixelflips


[DSS-1477]: https://kajabi.atlassian.net/browse/DSS-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ