### PR TITLE
feat: action slot for pds-input, pds-select, & pds-textarea

### DIFF
--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -133,6 +133,67 @@ A prefix or suffix can be added to the input field to provide additional context
   </pds-input>
 </DocCanvas>
 
+### Action Slot
+
+The action slot allows you to add helpful content next to the input label, such as links or help buttons. This is useful for providing additional context or quick actions related to the field.
+
+**Action Link**
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsInput componentId="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
+  <PdsLink slot="action" href="#" variant="inline" size="sm">Forgot password?</PdsLink>
+</PdsInput>`,
+    webComponent: `<pds-input component-id="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
+  <pds-link slot="action" href="#" variant="inline" size="sm">Forgot password?</pds-link>
+</pds-input>`
+  }}>
+  <pds-input component-id="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
+    <pds-link slot="action" href="#" variant="inline" size="sm">Forgot?</pds-link>
+  </pds-input>
+</DocCanvas>
+
+**Action Button**
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsInput componentId="pds-input-action-button" label="API Key" type="text" value="sk_test_123456789">
+  <PdsButton slot="action" variant="unstyled">Copy</PdsButton>
+</PdsInput>`,
+    webComponent: `<pds-input component-id="pds-input-action-button" label="API Key" type="text" value="sk_test_123456789">
+  <pds-button slot="action" variant="unstyled">Copy</pds-button>
+</pds-input>`
+  }}>
+  <pds-input component-id="pds-input-action-button" label="API Key" type="text" value="sk_test_123456789">
+    <pds-button slot="action" variant="unstyled">Copy</pds-button>
+  </pds-input>
+</DocCanvas>
+
+**Action with Tooltip**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsInput componentId="pds-input-action-button-tooltip" label="Account ID" type="text" value="123456789">
+  <PdsTooltip slot="action" align="bottom-start">
+    <PdsIcon name="question-circle"></PdsIcon>
+    <span slot="content">Find your account ID in your account page</span>
+  </PdsTooltip>
+</PdsInput>`,
+    webComponent: `<pds-input component-id="pds-input-action-button" label="API Key" type="text" value="sk_test_123456789">
+  <pds-tooltip slot="action" align="bottom-start">
+    <pds-icon name="question-circle"></pds-icon>
+    <span slot="content">Find your account ID in the URL of your account page</span>
+  </pds-tooltip>
+</pds-input>`
+  }}>
+  <pds-input component-id="pds-input-action-button-tooltip" label="Account ID" type="text" value="123456789">
+    <pds-tooltip slot="action" align="bottom-start">
+      <pds-icon name="question-circle"></pds-icon>
+      <span slot="content">Find your account ID in your account page</span>
+    </pds-tooltip>
+  </pds-input>
+</DocCanvas>
+
+
+
 ### Prepend and Append
 Prepend and append elements are placed outside the input container, next to the input field. These are typically used for larger elements or controls that need to be visually separated from the input.
 

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -141,14 +141,14 @@ The action slot allows you to add helpful content next to the input label, such 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsInput componentId="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
-  <PdsLink slot="action" href="#" variant="inline" size="sm">Forgot password?</PdsLink>
+  <PdsLink slot="action" href="#" variant="inline">Forgot?</PdsLink
 </PdsInput>`,
     webComponent: `<pds-input component-id="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
-  <pds-link slot="action" href="#" variant="inline" size="sm">Forgot password?</pds-link>
+  <pds-link slot="action" href="#" variant="inline">Forgot?</pds-link>
 </pds-input>`
   }}>
   <pds-input component-id="pds-input-action-link" label="Password" type="password" placeholder="Enter your password">
-    <pds-link slot="action" href="#" variant="inline" size="sm">Forgot?</pds-link>
+    <pds-link slot="action" href="#" variant="inline">Forgot?</pds-link>
   </pds-input>
 </DocCanvas>
 
@@ -172,20 +172,20 @@ The action slot allows you to add helpful content next to the input label, such 
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsInput componentId="pds-input-action-button-tooltip" label="Account ID" type="text" value="123456789">
-  <PdsTooltip slot="action" align="bottom-start">
+  <PdsTooltip slot="action">
     <PdsIcon name="question-circle"></PdsIcon>
     <span slot="content">Find your account ID in your account page</span>
   </PdsTooltip>
 </PdsInput>`,
-    webComponent: `<pds-input component-id="pds-input-action-button" label="API Key" type="text" value="sk_test_123456789">
-  <pds-tooltip slot="action" align="bottom-start">
+    webComponent: `<pds-input component-id="pds-input-action-button-tooltip" label="Account ID" type="text" value="123456789">
+  <pds-tooltip slot="action">
     <pds-icon name="question-circle"></pds-icon>
     <span slot="content">Find your account ID in the URL of your account page</span>
   </pds-tooltip>
 </pds-input>`
   }}>
   <pds-input component-id="pds-input-action-button-tooltip" label="Account ID" type="text" value="123456789">
-    <pds-tooltip slot="action" align="bottom-start">
+    <pds-tooltip slot="action">
       <pds-icon name="question-circle"></pds-icon>
       <span slot="content">Find your account ID in your account page</span>
     </pds-tooltip>

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -145,9 +145,28 @@
   gap: var(--pine-dimension-2xs);
 }
 
+.pds-input__label-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-block-end: var(--pine-dimension-2xs);
+}
+
 .pds-input__label {
   color: var(--pine-color-text-active);
   margin-block-end: var(--pine-dimension-2xs);
+}
+
+// When label is inside wrapper, remove its margin
+.pds-input__label-wrapper .pds-input__label {
+  margin-block-end: 0;
+}
+
+.pds-input__action {
+  align-items: center;
+  display: flex;
+  gap: var(--pine-dimension-xs);
+  margin-inline-start: var(--pine-dimension-xs);
 }
 
 .pds-input__field-wrapper {

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -11,6 +11,7 @@ import { danger } from '@pine-ds/icons/icons';
  * @slot prefix - Content that is displayed visually within the input field before the input field
  * @slot prepend - Content to be displayed before the input field
  * @slot suffix - Content that is displayed visually within the input field after the input field
+ * @slot action - Content to be displayed in the label area, typically for help icons or links
  */
 @Component({
   tag: 'pds-input',
@@ -47,6 +48,11 @@ export class PdsInput {
    * If true, the input has append content (focusable)
    */
   @State() hasAppend = false;
+
+  /**
+   * If true, the input has action content in the label area
+   */
+  @State() hasAction = false;
 
   /**
    * Emitted when the input loses focus.
@@ -251,6 +257,18 @@ export class PdsInput {
     return null;
   }
 
+  private renderAction() {
+    const hasAction = this.el.querySelector('[slot="action"]') !== null;
+    if (hasAction) {
+      return (
+        <div class="pds-input__action" part="action">
+          <slot name="action"></slot>
+        </div>
+      );
+    }
+    return null;
+  }
+
   componentWillLoad() {
     this.inheritedAttributes = {
       ...inheritAriaAttributes(this.el)
@@ -259,6 +277,7 @@ export class PdsInput {
     this.hasSuffix = this.el.querySelector('[slot="suffix"]') !== null;
     this.hasPrepend = this.el.querySelector('[slot="prepend"]') !== null;
     this.hasAppend = this.el.querySelector('[slot="append"]') !== null;
+    this.hasAction = this.el.querySelector('[slot="action"]') !== null;
 
     // Store the original pdsInput event emitter
     this.originalPdsInput = this.pdsInput;
@@ -393,13 +412,17 @@ export class PdsInput {
         has-suffix={this.hasSuffix ? 'true' : null}
         has-prepend={this.hasPrepend ? 'true' : null}
         has-append={this.hasAppend ? 'true' : null}
+        has-action={this.hasAction ? 'true' : null}
       >
         <div class="pds-input">
           {label && (
-            <label htmlFor={componentId} class="pds-input__label">
-              {label}
-              {this.required && <span class="pds-input__required-indicator"> *</span>}
-            </label>
+            <div class="pds-input__label-wrapper">
+              <label htmlFor={componentId} class="pds-input__label">
+                {label}
+                {this.required && <span class="pds-input__required-indicator"> *</span>}
+              </label>
+              {this.renderAction()}
+            </div>
           )}
 
           <div class={inputWrapperClasses}>

--- a/libs/core/src/components/pds-input/readme.md
+++ b/libs/core/src/components/pds-input/readme.md
@@ -59,6 +59,7 @@ Type: `Promise<void>`
 
 | Slot        | Description                                                                      |
 | ----------- | -------------------------------------------------------------------------------- |
+| `"action"`  | Content to be displayed in the label area, typically for help icons or links     |
 | `"append"`  | Content to be displayed after the input field                                    |
 | `"prefix"`  | Content that is displayed visually within the input field before the input field |
 | `"prepend"` | Content to be displayed before the input field                                   |
@@ -69,6 +70,7 @@ Type: `Promise<void>`
 
 | Part        | Description |
 | ----------- | ----------- |
+| `"action"`  |             |
 | `"append"`  |             |
 | `"prefix"`  |             |
 | `"prepend"` |             |

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -52,10 +52,11 @@ const BaseTemplate = (args) => html`<pds-input
   required="${args.required}"
   type="${args.type}"
   value="${args.value}">
-  ${args.prefix}
-  ${args.suffix}
-  ${args.prepend}
-  ${args.append}
+  ${args.prefix || ''}
+  ${args.suffix || ''}
+  ${args.prepend || ''}
+  ${args.append || ''}
+  ${args.action || ''}
 </pds-input>`;
 
 export const Text = BaseTemplate.bind({});
@@ -208,3 +209,44 @@ withPrependAndSuffix.args = {
   `,
   suffix: html`<pds-button slot="suffix" variant="unstyled" class="pds-input__suffix"><pds-icon name="remove-circle" size="small"></pds-icon></pds-button>`,
 };
+
+export const withActionLink = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-action-link"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Password"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="true"
+  type="password"
+  value="${args.value}">
+  <pds-link href="#" slot="action">
+    Forgot password?
+  </pds-link>
+</pds-input>`;
+
+export const withActionButton = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-action-button"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="Choose a unique username"
+  invalid="${args.invalid}"
+  label="Username"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="text"
+  value="${args.value}">
+  <pds-button slot="action" variant="unstyled">
+    <pds-icon name="question-circle"></pds-icon>
+  </pds-button>
+</pds-input>`;
+

--- a/libs/core/src/components/pds-input/test/pds-input.e2e.ts
+++ b/libs/core/src/components/pds-input/test/pds-input.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from "@stencil/core/testing";
+import { newE2EPage } from '@stencil/core/testing';
 
 describe('pds-input', () => {
   it('renders toggle of disabled state', async () => {
@@ -102,5 +102,41 @@ describe('pds-input', () => {
 
     expect(inputSpy).toHaveReceivedEvent();
     expect(inputSpy.events[0].detail.value).toBe('yoda-yoda');
+  });
+
+  it('renders action slot content when provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-input label="Email">
+          <a slot="action" href="#">Forgot password?</a>
+        </pds-input>
+      `);
+
+    const actionSlot = await page.find('pds-input >>> .pds-input__action');
+    expect(actionSlot).not.toBeNull();
+
+    const slotContent = await page.find('pds-input a[slot="action"]');
+    expect(await slotContent.innerText).toBe('Forgot password?');
+  });
+
+  it('does not render action wrapper when no action content is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-input label="Email"></pds-input>');
+
+    const actionSlot = await page.find('pds-input >>> .pds-input__action');
+    expect(actionSlot).toBeNull();
+  });
+
+  it('sets has-action attribute when action slot has content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-input label="Username">
+          <button slot="action">Help</button>
+        </pds-input>
+      `);
+
+    const component = await page.find('pds-input');
+    expect(component).toHaveAttribute('has-action');
+    expect(await component.getAttribute('has-action')).toBe('true');
   });
 });

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -29,9 +29,11 @@ describe('pds-input', () => {
     <pds-input component-id="field-1" label="Name" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label class="pds-input__label" htmlFor="field-1">
-            Name
-          </label>
+          <div class="pds-input__label-wrapper">
+            <label class="pds-input__label" htmlFor="field-1">
+              Name
+            </label>
+          </div>
           <div class="pds-input__field-wrapper">
             <input id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
           </div>
@@ -125,9 +127,11 @@ describe('pds-input', () => {
     <pds-input component-id="pds-input-invalid" invalid="true" label="Name" value="Frank Dux">
       <mock:shadow-root>
         <div class="pds-input">
-          <label class="pds-input__label" htmlFor="pds-input-invalid">
-            Name
-          </label>
+          <div class="pds-input__label-wrapper">
+            <label class="pds-input__label" htmlFor="pds-input-invalid">
+              Name
+            </label>
+          </div>
           <div class="has-error pds-input__field-wrapper">
             <input aria-invalid="true" id="pds-input-invalid" class="pds-input__field" type="text" value="Frank Dux" />
           </div>
@@ -597,5 +601,155 @@ describe('pds-input', () => {
       expect(root.style.getPropertyValue('--prefix-width')).toBe('100px');
       expect(root.style.getPropertyValue('--suffix-width')).toBe('120px');
     }
+  });
+
+  describe('action slot', () => {
+    it('renders action slot content when provided', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1" label="Email">
+            <span slot="action">Help</span>
+          </pds-input>
+        `
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-input component-id="field-1" has-action="true" label="Email">
+          <mock:shadow-root>
+            <div class="pds-input">
+              <div class="pds-input__label-wrapper">
+                <label class="pds-input__label" htmlFor="field-1">
+                  Email
+                </label>
+                <div class="pds-input__action" part="action">
+                  <slot name="action"></slot>
+                </div>
+              </div>
+              <div class="pds-input__field-wrapper">
+                <input id="field-1" class="pds-input__field" type="text" value="" />
+              </div>
+            </div>
+          </mock:shadow-root>
+          <span slot="action">Help</span>
+        </pds-input>
+      `);
+    });
+
+    it('does not render action slot when no content is provided', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsInput],
+        html: `<pds-input component-id="field-1" label="Email"></pds-input>`
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-input component-id="field-1" label="Email">
+          <mock:shadow-root>
+            <div class="pds-input">
+              <div class="pds-input__label-wrapper">
+                <label class="pds-input__label" htmlFor="field-1">
+                  Email
+                </label>
+              </div>
+              <div class="pds-input__field-wrapper">
+                <input id="field-1" class="pds-input__field" type="text" value="" />
+              </div>
+            </div>
+          </mock:shadow-root>
+        </pds-input>
+      `);
+    });
+
+    it('sets has-action attribute when action slot content is present', async () => {
+      const page = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1" label="Password">
+            <a slot="action" href="#">Forgot password?</a>
+          </pds-input>
+        `
+      });
+
+      const root = page.root;
+      expect(root?.getAttribute('has-action')).toBe('true');
+    });
+
+    it('properly detects action slot presence in componentWillLoad', async () => {
+      const page = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1" label="Username">
+            <button slot="action">Help</button>
+          </pds-input>
+        `
+      });
+
+      const component = page.rootInstance;
+      expect(component.hasAction).toBe(true);
+    });
+
+    it('renders action slot with complex content', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1" label="API Key">
+            <button slot="action" type="button">
+              <span>Copy</span>
+            </button>
+          </pds-input>
+        `
+      });
+
+      const actionWrapper = root?.shadowRoot?.querySelector('.pds-input__action');
+      expect(actionWrapper).not.toBeNull();
+      expect(actionWrapper?.getAttribute('part')).toBe('action');
+    });
+
+    it('does not render label wrapper when no label is provided', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1">
+            <span slot="action">Help</span>
+          </pds-input>
+        `
+      });
+
+      const labelWrapper = root?.shadowRoot?.querySelector('.pds-input__label-wrapper');
+      expect(labelWrapper).toBeNull();
+    });
+
+    it('renders action slot alongside required indicator', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1" label="Email" required>
+            <span slot="action">Info</span>
+          </pds-input>
+        `
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-input component-id="field-1" has-action="true" label="Email" required>
+          <mock:shadow-root>
+            <div class="pds-input">
+              <div class="pds-input__label-wrapper">
+                <label class="pds-input__label" htmlFor="field-1">
+                  Email
+                  <span class="pds-input__required-indicator"> *</span>
+                </label>
+                <div class="pds-input__action" part="action">
+                  <slot name="action"></slot>
+                </div>
+              </div>
+              <div class="pds-input__field-wrapper">
+                <input id="field-1" class="pds-input__field" type="text" value="" required />
+              </div>
+            </div>
+          </mock:shadow-root>
+          <span slot="action">Info</span>
+        </pds-input>
+      `);
+    });
   });
 });

--- a/libs/core/src/components/pds-select/docs/pds-select.mdx
+++ b/libs/core/src/components/pds-select/docs/pds-select.mdx
@@ -34,14 +34,14 @@ The default state of the select component displays a label alongside a list of o
   client:only
   mdxSource={{
     react: `
-      <PdsSelect componentId="pds-select-default-example" label="Name" value="paul">
+      <PdsSelect componentId="pds-select-default-example" label="Name" name="name" value="paul">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select component-id="pds-select-default-example" label="Name" value="paul">
+      <pds-select component-id="pds-select-default-example" label="Name" name="name" value="paul">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -50,7 +50,7 @@ The default state of the select component displays a label alongside a list of o
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select component-id="pds-select-default-example" label="Name" value="paul">
+    <pds-select component-id="pds-select-default-example" label="Name" name="name" value="paul">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -67,14 +67,14 @@ When the select component is disabled, it prevents any user interaction. As a re
   client:only
   mdxSource={{
     react: `
-      <PdsSelect componentId="pds-select-disabled-example" disabled="true" label="Name" value="george">
+      <PdsSelect componentId="pds-select-disabled-example" disabled="true" label="Name" name="name" value="george">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select component-id="pds-select-disabled-example" disabled="true" label="Name" value="george">
+      <pds-select component-id="pds-select-disabled-example" disabled="true" label="Name" name="name" value="george">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -83,7 +83,7 @@ When the select component is disabled, it prevents any user interaction. As a re
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select component-id="pds-select-disabled-example" disabled="true" label="Name" value="george">
+    <pds-select component-id="pds-select-disabled-example" disabled="true" label="Name" name="name" value="george">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -100,14 +100,14 @@ A helper message provides additional context or instructions for the user and ap
   client:only
   mdxSource={{
     react: `
-      <PdsSelect componentId="pds-select-with-message-example" label="Name" helper-message="This is a helper message to convey extra context for the select" value="john">
+      <PdsSelect componentId="pds-select-with-message-example" label="Name" helperMessage="This is a helper message to convey extra context for the select" name="name" value="john">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select component-id="pds-select-with-message-example" label="Name" helper-message="This is a helper message to convey extra context for the select" value="john">
+      <pds-select component-id="pds-select-with-message-example" label="Name" helper-message="This is a helper message to convey extra context for the select" name="name" value="john">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -116,7 +116,7 @@ A helper message provides additional context or instructions for the user and ap
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select component-id="pds-select-with-message-example" helper-message="This is a helper message to convey extra context for the select" label="Name" value="john">
+    <pds-select component-id="pds-select-with-message-example" helper-message="This is a helper message to convey extra context for the select" label="Name" name="name" value="john">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -133,14 +133,14 @@ The select component is shown invalid along with an error message, providing fee
   client:only
   mdxSource={{
     react: `
-      <PdsSelect componentId="pds-select-invalid-example" label="Name" invalid="true" error-message="This is an error message to convey extra context for the select" value="ringo">
+      <PdsSelect componentId="pds-select-invalid-example" label="Name" invalid="true" errorMessage="This is an error message to convey extra context for the select" name="name" value="ringo">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select component-id="pds-select-invalid-example" label="Name" invalid="true" error-message="This is an error message to convey extra context for the select" value="ringo">
+      <pds-select component-id="pds-select-invalid-example" label="Name" invalid="true" error-message="This is an error message to convey extra context for the select" name="name" value="ringo">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -149,7 +149,7 @@ The select component is shown invalid along with an error message, providing fee
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select component-id="pds-select-invalid-example" invalid="true" error-message="This is an error message to convey extra context for the select" label="Name" value="ringo">
+    <pds-select component-id="pds-select-invalid-example" invalid="true" error-message="This is an error message to convey extra context for the select" label="Name" name="name" value="ringo">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -160,20 +160,20 @@ The select component is shown invalid along with an error message, providing fee
 
 ### Autocomplete
 
-With the autocomplete attribute enabled, the select component allows browsers to suggest previously entered values, improving the user’s input experience. This feature helps users fill out forms more quickly and accurately by displaying potential matches based on their past selections or input history.
+With the autocomplete attribute enabled, the select component allows browsers to suggest previously entered values, improving the user's input experience. This feature helps users fill out forms more quickly and accurately by displaying potential matches based on their past selections or input history.
 
 <DocCanvas
   client:only
   mdxSource={{
     react: `
-      <PdsSelect autocomplete="on" componentId="pds-select-autocomplete-example" label="Name" value="paul">
+      <PdsSelect autocomplete="on" componentId="pds-select-autocomplete-example" label="Name" name="name" value="paul">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select autocomplete="on" component-id="pds-select-autocomplete-example" label="Name" value="paul">
+      <pds-select autocomplete="on" component-id="pds-select-autocomplete-example" label="Name" name="name" value="paul">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -182,7 +182,7 @@ With the autocomplete attribute enabled, the select component allows browsers to
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select autocomplete="on" component-id="pds-select-autocomplete-example" label="Name" value="paul">
+    <pds-select autocomplete="on" component-id="pds-select-autocomplete-example" label="Name" name="name" value="paul">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -201,14 +201,14 @@ With the `multiple` attribute enabled, the select component allows users to sele
   client:only
   mdxSource={{
     react: `
-      <PdsSelect multiple componentId="pds-select-multiple-example" label="Name">
+      <PdsSelect multiple componentId="pds-select-multiple-example" label="Name" name="name">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
         <option value="ringo">Ringo Starr</option>
       </PdsSelect>`,
     webComponent: `
-      <pds-select multiple component-id="pds-select-multiple-example" label="Name">
+      <pds-select multiple component-id="pds-select-multiple-example" label="Name" name="name">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
         <option value="george">George Harrison</option>
@@ -217,7 +217,7 @@ With the `multiple` attribute enabled, the select component allows users to sele
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select multiple component-id="pds-select-multiple-example" label="Name">
+    <pds-select multiple component-id="pds-select-multiple-example" label="Name" name="name">
       <option value="paul">Paul McCartney</option>
       <option value="john">John Lennon</option>
       <option value="george">George Harrison</option>
@@ -234,7 +234,7 @@ The `optgroup` element allows for grouping related options within the select com
   client:only
   mdxSource={{
     react: `
-      <PdsSelect componentId="pds-select-optgroup-example" label="Name" value="george">
+      <PdsSelect componentId="pds-select-optgroup-example" label="Name" name="name" value="george">
         <optgroup label="Correct answers">
           <option value="paul">Paul McCartney</option>
           <option value="john">John Lennon</option>
@@ -245,7 +245,7 @@ The `optgroup` element allows for grouping related options within the select com
         </optgroup>
       </PdsSelect>`,
     webComponent: `
-      <pds-select component-id="pds-select-optgroup-example" label="Name" value="george">
+      <pds-select component-id="pds-select-optgroup-example" label="Name" name="name" value="george">
         <optgroup label="Correct answers">
           <option value="paul">Paul McCartney</option>
           <option value="john">John Lennon</option>
@@ -258,7 +258,7 @@ The `optgroup` element allows for grouping related options within the select com
   }}
 >
   <div style={{ padding: '20px', width: '100%' }}>
-    <pds-select component-id="pds-select-optgroup-example" label="Name" value="george">
+    <pds-select component-id="pds-select-optgroup-example" label="Name" name="name" value="george">
       <optgroup label="Correct answers">
         <option value="paul">Paul McCartney</option>
         <option value="john">John Lennon</option>
@@ -339,7 +339,7 @@ The action slot allows you to add helpful content next to the select label, such
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsSelect componentId="pds-select-action-tooltip" label="Country" name="country" required>
-  <PdsTooltip slot="action" align="bottom-start">
+  <PdsTooltip slot="action" placement="bottom-start">
     <PdsIcon name="question-circle"></PdsIcon>
     <span slot="content">Select your country of residence for shipping purposes</span>
   </PdsTooltip>
@@ -350,7 +350,7 @@ The action slot allows you to add helpful content next to the select label, such
   <option value="au">Australia</option>
 </PdsSelect>`,
     webComponent: `<pds-select component-id="pds-select-action-tooltip" label="Country" name="country" required>
-  <pds-tooltip slot="action" align="bottom-start">
+  <pds-tooltip slot="action" placement="bottom-start">
     <pds-icon name="question-circle"></pds-icon>
     <span slot="content">Select your country of residence for shipping purposes</span>
   </pds-tooltip>

--- a/libs/core/src/components/pds-select/docs/pds-select.mdx
+++ b/libs/core/src/components/pds-select/docs/pds-select.mdx
@@ -271,6 +271,109 @@ The `optgroup` element allows for grouping related options within the select com
   </div>
 </DocCanvas>
 
+### Action Slot
+
+The action slot allows you to add helpful content next to the select label, such as links or help buttons. This is useful for providing additional context or quick actions related to the selection.
+
+**Action Link**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsSelect componentId="pds-select-action-link" label="Timezone" name="timezone">
+  <PdsLink href="#" slot="action">Auto-detect</PdsLink>
+  <option value="">Select timezone</option>
+  <option value="est">Eastern Time (EST)</option>
+  <option value="cst">Central Time (CST)</option>
+  <option value="mst">Mountain Time (MST)</option>
+  <option value="pst">Pacific Time (PST)</option>
+</PdsSelect>`,
+    webComponent: `<pds-select component-id="pds-select-action-link" label="Timezone" name="timezone">
+  <pds-link href="#" slot="action">Auto-detect</pds-link>
+  <option value="">Select timezone</option>
+  <option value="est">Eastern Time (EST)</option>
+  <option value="cst">Central Time (CST)</option>
+  <option value="mst">Mountain Time (MST)</option>
+  <option value="pst">Pacific Time (PST)</option>
+</pds-select>`
+}}>
+  <pds-select component-id="pds-select-action-link" label="Timezone" name="timezone">
+    <pds-link href="#" slot="action">Auto-detect</pds-link>
+    <option value="">Select timezone</option>
+    <option value="est">Eastern Time (EST)</option>
+    <option value="cst">Central Time (CST)</option>
+    <option value="mst">Mountain Time (MST)</option>
+    <option value="pst">Pacific Time (PST)</option>
+  </pds-select>
+</DocCanvas>
+
+**Action Button**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsSelect componentId="pds-select-action-button" label="Language" name="language">
+  <PdsButton slot="action" variant="unstyled">Translate</PdsButton>
+  <option value="en">English</option>
+  <option value="es">Español</option>
+  <option value="fr">Français</option>
+  <option value="de">Deutsch</option>
+</PdsSelect>`,
+    webComponent: `<pds-select component-id="pds-select-action-button" label="Language" name="language">
+  <pds-button slot="action" variant="unstyled">Translate</pds-button>
+  <option value="en">English</option>
+  <option value="es">Español</option>
+  <option value="fr">Français</option>
+  <option value="de">Deutsch</option>
+</pds-select>`
+}}>
+  <pds-select component-id="pds-select-action-button" label="Language" name="language">
+    <pds-button slot="action" variant="unstyled">Translate</pds-button>
+    <option value="en">English</option>
+    <option value="es">Español</option>
+    <option value="fr">Français</option>
+    <option value="de">Deutsch</option>
+  </pds-select>
+</DocCanvas>
+
+**Action with Tooltip**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsSelect componentId="pds-select-action-tooltip" label="Country" name="country" required>
+  <PdsTooltip slot="action" align="bottom-start">
+    <PdsIcon name="question-circle"></PdsIcon>
+    <span slot="content">Select your country of residence for shipping purposes</span>
+  </PdsTooltip>
+  <option value="">Choose a country</option>
+  <option value="us">United States</option>
+  <option value="ca">Canada</option>
+  <option value="uk">United Kingdom</option>
+  <option value="au">Australia</option>
+</PdsSelect>`,
+    webComponent: `<pds-select component-id="pds-select-action-tooltip" label="Country" name="country" required>
+  <pds-tooltip slot="action" align="bottom-start">
+    <pds-icon name="question-circle"></pds-icon>
+    <span slot="content">Select your country of residence for shipping purposes</span>
+  </pds-tooltip>
+  <option value="">Choose a country</option>
+  <option value="us">United States</option>
+  <option value="ca">Canada</option>
+  <option value="uk">United Kingdom</option>
+  <option value="au">Australia</option>
+</pds-select>`
+}}>
+  <pds-select component-id="pds-select-action-tooltip" label="Country" name="country" required>
+    <pds-tooltip slot="action" align="bottom-start">
+      <pds-icon name="question-circle"></pds-icon>
+      <span slot="content">Select your country of residence for shipping purposes</span>
+    </pds-tooltip>
+    <option value="">Choose a country</option>
+    <option value="us">United States</option>
+    <option value="ca">Canada</option>
+    <option value="uk">United Kingdom</option>
+    <option value="au">Australia</option>
+  </pds-select>
+</DocCanvas>
+
 ## Additional Resources
 
 [MDN Web Docs: Select](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -29,9 +29,28 @@
   width: 100%;
 }
 
-label {
+.pds-select__label-wrapper {
+  align-items: center;
+  display: flex;
   grid-area: label;
+  justify-content: space-between;
   margin-block-end: var(--pine-dimension-2xs);
+}
+
+.pds-select__action {
+  align-items: center;
+  display: flex;
+  gap: var(--pine-dimension-xs);
+  margin-inline-start: var(--pine-dimension-xs);
+}
+
+label {
+  margin-block-end: var(--pine-dimension-2xs);
+}
+
+// When label is inside wrapper, remove its margin
+.pds-select__label-wrapper label {
+  margin-block-end: 0;
 }
 
 select {

--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -1,7 +1,10 @@
-import { Component, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
 import { messageId } from '../../utils/form';
 import { danger, enlarge } from '@pine-ds/icons/icons';
 
+/**
+ * @slot action - Content to be displayed in the label area, typically for help icons or links
+ */
 @Component({
   tag: 'pds-select',
   styleUrls: ['pds-select.tokens.scss', '../../global/styles/utils/label.scss', 'pds-select.scss'],
@@ -11,6 +14,8 @@ export class PdsSelect {
 
   private selectEl!: HTMLSelectElement;
   private slotContainer!: HTMLDivElement;
+
+  @Element() el: HTMLPdsSelectElement;
 
   /**
    * Specifies if and how the browser provides `autocomplete` assistance for the field.
@@ -201,16 +206,33 @@ export class PdsSelect {
     return classNames.join('  ');
   }
 
+  private renderAction() {
+    const hasAction = this.el.querySelector('[slot="action"]') !== null;
+    if (hasAction) {
+      return (
+        <div class="pds-select__action" part="action">
+          <slot name="action"></slot>
+        </div>
+      );
+    }
+    return null;
+  }
+
   render() {
+    const hasAction = this.el.querySelector('[slot="action"]') !== null;
+
     return (
-      <Host aria-disabled={this.disabled ? 'true' : null} class={this.classNames()}>
+      <Host aria-disabled={this.disabled ? 'true' : null} class={this.classNames()} has-action={hasAction && !this.hideLabel ? 'true' : null}>
         <div class="pds-select">
           {!this.hideLabel && (
-            <label htmlFor={this.componentId}>
-              <span class={this.hideLabel ? 'visually-hidden' : ''}>
-                {this.label}
-              </span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlFor={this.componentId}>
+                <span class={this.hideLabel ? 'visually-hidden' : ''}>
+                  {this.label}
+                </span>
+              </label>
+              {hasAction && this.renderAction()}
+            </div>
           )}
           <select
             aria-label={this.hideLabel ? this.label : undefined}

--- a/libs/core/src/components/pds-select/readme.md
+++ b/libs/core/src/components/pds-select/readme.md
@@ -30,10 +30,18 @@
 | `pdsSelectChange` | Emitted when a keyboard input occurs. | `CustomEvent<InputEvent>` |
 
 
+## Slots
+
+| Slot       | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `"action"` | Content to be displayed in the label area, typically for help icons or links |
+
+
 ## Shadow Parts
 
 | Part       | Description |
 | ---------- | ----------- |
+| `"action"` |             |
 | `"select"` |             |
 
 

--- a/libs/core/src/components/pds-select/stories/pds-select.stories.js
+++ b/libs/core/src/components/pds-select/stories/pds-select.stories.js
@@ -62,6 +62,7 @@ const BaseTemplate = (args) =>
     type="${args.type}"
     value="${args.value}"
   >
+    ${args.action || ''}
     ${options.map((option) => html`<option value="${option.value}">${option.label}</option>`)}
   </pds-select>`;
 
@@ -80,6 +81,7 @@ const OptgroupTemplate = (args) =>
     type="${args.type}"
     value="${args.value}"
   >
+    ${args.action || ''}
     ${optgroupOptions.map(
       (group) => html`<optgroup label="${group.label}">${group.options.map((option) => html`<option value="${option.value}">${option.label}</option>`)}</optgroup>`,
     )}
@@ -153,3 +155,43 @@ WithOptgroup.args = {
   name: 'beatles',
   value: 'george',
 };
+
+export const withActionLink = (args) => html`<pds-select
+  autocomplete="${args.autocomplete}"
+  component-id="pds-select-action-link"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  hide-label="${args.hideLabel}"
+  invalid="${args.invalid}"
+  label="Timezone"
+  multiple="${args.multiple}"
+  name="timezone"
+  required="${args.required}"
+  type="${args.type}"
+  value="${args.value}">
+  <pds-link href="#" slot="action">
+    Auto-detect
+  </pds-link>
+  ${options.map((option) => html`<option value="${option.value}">${option.label}</option>`)}
+</pds-select>`;
+
+export const withActionButton = (args) => html`<pds-select
+  autocomplete="${args.autocomplete}"
+  component-id="pds-select-action-button"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  hide-label="${args.hideLabel}"
+  invalid="${args.invalid}"
+  label="Country"
+  multiple="${args.multiple}"
+  name="country"
+  required="${args.required}"
+  type="${args.type}"
+  value="${args.value}">
+  <pds-button slot="action" variant="unstyled">
+    <pds-icon name="question-circle"></pds-icon>
+  </pds-button>
+  ${options.map((option) => html`<option value="${option.value}">${option.label}</option>`)}
+</pds-select>`;

--- a/libs/core/src/components/pds-select/test/pds-select.e2e.ts
+++ b/libs/core/src/components/pds-select/test/pds-select.e2e.ts
@@ -1,7 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 
 describe('pds-select', () => {
-
   it('should handle option selection', async () => {
     const page = await newE2EPage();
 
@@ -43,7 +42,64 @@ describe('pds-select', () => {
 
     expect(changeEvent).toHaveReceivedEventTimes(1);
     expect(changeEvent).toHaveReceivedEventDetail({
-      isTrusted: false
+      isTrusted: false,
     });
+  });
+
+  it('renders action slot content when provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-select label="Country">
+          <span slot="action">Required</span>
+          <option value="us">United States</option>
+          <option value="ca">Canada</option>
+        </pds-select>
+      `);
+
+    const actionSlot = await page.find('pds-select >>> .pds-select__action');
+    expect(actionSlot).not.toBeNull();
+
+    const slotContent = await page.find('pds-select span[slot="action"]');
+    expect(await slotContent.innerText).toBe('Required');
+  });
+
+  it('does not render action wrapper when no action content is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-select label="Country">
+          <option value="us">United States</option>
+        </pds-select>
+      `);
+
+    const actionSlot = await page.find('pds-select >>> .pds-select__action');
+    expect(actionSlot).toBeNull();
+  });
+
+  it('sets has-action attribute when action slot has content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-select label="Language">
+          <button slot="action">Auto-detect</button>
+          <option value="en">English</option>
+          <option value="es">Spanish</option>
+        </pds-select>
+      `);
+
+    const component = await page.find('pds-select');
+    expect(component).toHaveAttribute('has-action');
+    expect(await component.getAttribute('has-action')).toBe('true');
+  });
+
+  it('hides action slot when hideLabel is true', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-select label="Country" hide-label="true">
+          <span slot="action">Required</span>
+          <option value="us">United States</option>
+        </pds-select>
+      `);
+
+    const actionSlot = await page.find('pds-select >>> .pds-select__action');
+    expect(actionSlot).toBeNull();
   });
 });

--- a/libs/core/src/components/pds-select/test/pds-select.spec.tsx
+++ b/libs/core/src/components/pds-select/test/pds-select.spec.tsx
@@ -12,9 +12,11 @@ describe('pds-select', () => {
       <pds-select component-id="field-1">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span></span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span></span>
+              </label>
+            </div>
             <select class="pds-select__field" id="field-1" part="select">
             </select>
             <div aria-hidden="true" class="hidden">
@@ -54,9 +56,11 @@ describe('pds-select', () => {
       <pds-select component-id="field-1" label="Name">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span>Name</span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span>Name</span>
+              </label>
+            </div>
             <select class="pds-select__field" id="field-1" part="select">
               <option value="1">Option 1</option>
               <option value="2">Option 2</option>
@@ -82,9 +86,11 @@ describe('pds-select', () => {
       <pds-select component-id="field-1" label="Name">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span>Name</span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span>Name</span>
+              </label>
+            </div>
             <select class="pds-select__field" id="field-1" part="select"></select>
             <div aria-hidden="true" class="hidden">
               <slot></slot>
@@ -130,9 +136,11 @@ describe('pds-select', () => {
       <pds-select aria-disabled="true" class="is-disabled" component-id="field-1" label="Disabled" disabled="">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span>Disabled</span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span>Disabled</span>
+              </label>
+            </div>
             <select class="pds-select__field" disabled="" id="field-1" part="select">
               <slot></slot>
             </select>
@@ -158,9 +166,11 @@ describe('pds-select', () => {
       <pds-select class="is-invalid" component-id="field-1" invalid="true">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span></span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span></span>
+              </label>
+            </div>
             <select class="pds-select__field" id="field-1" part="select">
               <slot></slot>
             </select>
@@ -184,9 +194,11 @@ describe('pds-select', () => {
       <pds-select autocomplete="off" component-id="field-1" label="Name">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span>Name</span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span>Name</span>
+              </label>
+            </div>
             <select autocomplete="off" class="pds-select__field" id="field-1" part="select"></select>
             <div aria-hidden="true" class="hidden">
               <slot></slot>
@@ -208,9 +220,11 @@ describe('pds-select', () => {
       <pds-select autocomplete="on" component-id="field-1" label="Name">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span>Name</span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span>Name</span>
+              </label>
+            </div>
             <select autocomplete="on" class="pds-select__field" id="field-1" part="select"></select>
             <div aria-hidden="true" class="hidden">
               <slot></slot>
@@ -232,9 +246,11 @@ describe('pds-select', () => {
       <pds-select component-id="field-1" multiple="">
         <mock:shadow-root>
           <div class="pds-select">
-            <label htmlfor="field-1">
-              <span></span>
-            </label>
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="field-1">
+                <span></span>
+              </label>
+            </div>
             <select class="pds-select__field" id="field-1" multiple="" part="select">
             </select>
             <div aria-hidden="true" class="hidden">
@@ -600,5 +616,160 @@ describe('onSelectUpdate', () => {
 
     expect(component.value).toEqual(['1', '2']);
     expect(pdsSelectChangeSpy).toHaveBeenCalled();
+  });
+});
+
+describe('action slot', () => {
+  it('renders action slot content when provided', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Country" name="country">
+          <span slot="action">Help</span>
+          <option value="us">United States</option>
+          <option value="ca">Canada</option>
+        </pds-select>
+      `,
+    });
+
+    expect(root).toEqualHtml(`
+      <pds-select component-id="select-1" has-action="true" label="Country" name="country">
+        <mock:shadow-root>
+          <div class="pds-select">
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="select-1">
+                <span>Country</span>
+              </label>
+              <div class="pds-select__action" part="action">
+                <slot name="action"></slot>
+              </div>
+            </div>
+            <select class="pds-select__field" id="select-1" name="country" part="select"></select>
+            <div aria-hidden="true" class="hidden">
+              <slot></slot>
+            </div>
+            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+          </div>
+        </mock:shadow-root>
+        <span slot="action">Help</span>
+        <option value="us">United States</option>
+        <option value="ca">Canada</option>
+      </pds-select>
+    `);
+  });
+
+  it('does not render action slot when no content is provided', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsSelect],
+      html: `<pds-select component-id="select-1" label="Country" name="country"></pds-select>`,
+    });
+
+    expect(root).toEqualHtml(`
+      <pds-select component-id="select-1" label="Country" name="country">
+        <mock:shadow-root>
+          <div class="pds-select">
+            <div class="pds-select__label-wrapper">
+              <label htmlfor="select-1">
+                <span>Country</span>
+              </label>
+            </div>
+            <select class="pds-select__field" id="select-1" name="country" part="select"></select>
+            <div aria-hidden="true" class="hidden">
+              <slot></slot>
+            </div>
+            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+          </div>
+        </mock:shadow-root>
+      </pds-select>
+    `);
+  });
+
+  it('sets has-action attribute when action slot content is present', async () => {
+    const page = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Language" name="language">
+          <button slot="action">Translate</button>
+          <option value="en">English</option>
+        </pds-select>
+      `,
+    });
+
+    const root = page.root;
+    expect(root?.getAttribute('has-action')).toBe('true');
+  });
+
+  it('renders action slot with complex content', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Timezone" name="timezone">
+          <a slot="action" href="#">
+            <span>Auto-detect</span>
+          </a>
+          <option value="est">EST</option>
+        </pds-select>
+      `,
+    });
+
+    const actionWrapper = root?.shadowRoot?.querySelector('.pds-select__action');
+    expect(actionWrapper).not.toBeNull();
+    expect(actionWrapper?.getAttribute('part')).toBe('action');
+  });
+
+  it('does not render label wrapper when hideLabel is true', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Country" name="country" hide-label>
+          <span slot="action">Help</span>
+          <option value="us">United States</option>
+        </pds-select>
+      `,
+    });
+
+    const labelWrapper = root?.shadowRoot?.querySelector('.pds-select__label-wrapper');
+    const actionSlot = root?.shadowRoot?.querySelector('.pds-select__action');
+    expect(labelWrapper).toBeNull();
+    expect(actionSlot).toBeNull();
+  });
+
+  it('renders action slot with error message', async () => {
+    const page = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Country" name="country" error-message="Please select a country">
+          <span slot="action">Required</span>
+          <option value="">Choose...</option>
+          <option value="us">United States</option>
+        </pds-select>
+      `,
+    });
+
+    const actionWrapper = page.root?.shadowRoot?.querySelector('.pds-select__action');
+    const errorMessage = page.root?.shadowRoot?.querySelector('.pds-select__error-message');
+
+    expect(actionWrapper).not.toBeNull();
+    expect(errorMessage?.textContent).toContain('Please select a country');
+  });
+
+  it('renders action slot with multiple select', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsSelect],
+      html: `
+        <pds-select component-id="select-1" label="Skills" name="skills" multiple>
+          <span slot="action">Select all that apply</span>
+          <option value="js">JavaScript</option>
+          <option value="ts">TypeScript</option>
+          <option value="py">Python</option>
+        </pds-select>
+      `,
+    });
+
+    const actionWrapper = root?.shadowRoot?.querySelector('.pds-select__action');
+    const selectIcon = root?.shadowRoot?.querySelector('.pds-select__select-icon');
+
+    expect(actionWrapper).not.toBeNull();
+    expect(selectIcon).toBeNull(); // Multiple selects don't have the dropdown icon
   });
 });

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -127,6 +127,82 @@ The `rows` property is used to pass a number of expected rows visible within the
   <pds-textarea name="Rows" label="Name" rows="4" component-id="textarea-rows"></pds-textarea>
 </DocCanvas>
 
+### Action Slot
+
+The action slot allows you to add helpful content next to the textarea label, such as links or help buttons. This is useful for providing additional context or quick actions related to the field.
+
+**Action Link**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsTextarea componentId="pds-textarea-action-link" label="Notes" rows="3" helperMessage="Add any additional notes here">
+  <PdsLink href="#" slot="action">View examples</PdsLink>
+</PdsTextarea>`,
+    webComponent: `<pds-textarea component-id="pds-textarea-action-link" label="Notes" rows="3" helper-message="Add any additional notes here">
+  <pds-link href="#" slot="action">View examples</pds-link>
+</pds-textarea>`
+}}>
+  <pds-textarea component-id="pds-textarea-action-link" label="Notes" rows="3" helper-message="Add any additional notes here">
+    <pds-link href="#" slot="action">View examples</pds-link>
+  </pds-textarea>
+</DocCanvas>
+
+**Action Button**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsTextarea componentId="pds-textarea-action-button" label="Description" rows="4" placeholder="Describe your issue...">
+  <PdsButton slot="action" variant="unstyled">Format</PdsButton>
+</PdsTextarea>`,
+    webComponent: `<pds-textarea component-id="pds-textarea-action-button" label="Description" rows="4" placeholder="Describe your issue...">
+  <pds-button slot="action" variant="unstyled">Format</pds-button>
+</pds-textarea>`
+}}>
+  <pds-textarea component-id="pds-textarea-action-button" label="Description" rows="4" placeholder="Describe your issue...">
+    <pds-button slot="action" variant="unstyled">Format</pds-button>
+  </pds-textarea>
+</DocCanvas>
+
+**Action with Tooltip**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsTextarea componentId="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
+  <PdsTooltip slot="action" align="bottom-start">
+    <PdsIcon name="question-circle"></PdsIcon>
+    <span slot="content">Tell us about yourself in 500 characters or less</span>
+  </PdsTooltip>
+</PdsTextarea>`,
+    webComponent: `<pds-textarea component-id="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
+  <pds-tooltip slot="action" align="bottom-start">
+    <pds-icon name="question-circle"></pds-icon>
+    <span slot="content">Tell us about yourself in 500 characters or less</span>
+  </pds-tooltip>
+</pds-textarea>`
+}}>
+  <pds-textarea component-id="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
+    <pds-tooltip slot="action" align="bottom-start">
+      <pds-icon name="question-circle"></pds-icon>
+      <span slot="content">Tell us about yourself in 500 characters or less</span>
+    </pds-tooltip>
+  </pds-textarea>
+</DocCanvas>
+
+**Action with Link**
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsTextarea componentId="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
+  <PdsLink slot="action" href="#" variant="inline" size="sm">View full terms</PdsLink>
+</PdsTextarea>`,
+    webComponent: `<pds-textarea component-id="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
+  <pds-link slot="action" href="#" variant="inline" size="sm">View full terms</pds-link>
+</pds-textarea>`
+}}>
+  <pds-textarea component-id="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
+    <pds-link slot="action" href="#" variant="inline" size="sm">View full terms</pds-link>
+  </pds-textarea>
+</DocCanvas>
+
 ## References
 
 [MDN: Autocomplete Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -168,20 +168,20 @@ The action slot allows you to add helpful content next to the textarea label, su
 <DocCanvas client:only
   mdxSource={{
     react: `<PdsTextarea componentId="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
-  <PdsTooltip slot="action" align="bottom-start">
+  <PdsTooltip slot="action">
     <PdsIcon name="question-circle"></PdsIcon>
     <span slot="content">Tell us about yourself in 500 characters or less</span>
   </PdsTooltip>
 </PdsTextarea>`,
     webComponent: `<pds-textarea component-id="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
-  <pds-tooltip slot="action" align="bottom-start">
+  <pds-tooltip slot="action">
     <pds-icon name="question-circle"></pds-icon>
     <span slot="content">Tell us about yourself in 500 characters or less</span>
   </pds-tooltip>
 </pds-textarea>`
 }}>
   <pds-textarea component-id="pds-textarea-action-tooltip" label="Bio" rows="4" maxlength="500">
-    <pds-tooltip slot="action" align="bottom-start">
+    <pds-tooltip slot="action">
       <pds-icon name="question-circle"></pds-icon>
       <span slot="content">Tell us about yourself in 500 characters or less</span>
     </pds-tooltip>

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -188,21 +188,6 @@ The action slot allows you to add helpful content next to the textarea label, su
   </pds-textarea>
 </DocCanvas>
 
-**Action with Link**
-<DocCanvas client:only
-  mdxSource={{
-    react: `<PdsTextarea componentId="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
-  <PdsLink slot="action" href="#" variant="inline" size="sm">View full terms</PdsLink>
-</PdsTextarea>`,
-    webComponent: `<pds-textarea component-id="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
-  <pds-link slot="action" href="#" variant="inline" size="sm">View full terms</pds-link>
-</pds-textarea>`
-}}>
-  <pds-textarea component-id="textarea-action-link" label="Terms & Conditions" readonly value="Please read and accept our terms..." rows="6">
-    <pds-link slot="action" href="#" variant="inline" size="sm">View full terms</pds-link>
-  </pds-textarea>
-</DocCanvas>
-
 ## References
 
 [MDN: Autocomplete Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -14,9 +14,28 @@
   flex-direction: column;
 }
 
+.pds-textarea__label-wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-block-end: var(--pine-dimension-xs);
+}
+
+.pds-textarea__action {
+  align-items: center;
+  display: flex;
+  gap: var(--pine-dimension-xs);
+  margin-inline-start: var(--pine-dimension-xs);
+}
+
 label {
   display: block;
   margin-block-end: var(--pine-dimension-xs);
+}
+
+// When label is inside wrapper, remove its margin
+.pds-textarea__label-wrapper label {
+  margin-block-end: 0;
 }
 
 .pds-textarea__field {

--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -6,6 +6,9 @@ import type { Attributes } from '@utils/attributes';
 import { inheritAttributes, inheritAriaAttributes } from '@utils/attributes';
 import { danger } from '@pine-ds/icons/icons';
 
+/**
+ * @slot action - Content to be displayed in the label area, typically for help icons or links
+ */
 @Component({
   tag: 'pds-textarea',
   styleUrls: [
@@ -137,6 +140,11 @@ export class PdsTextarea {
 
   @State() hasFocus = false;
 
+  /**
+   * If true, the textarea has action content in the label area
+   */
+  @State() hasAction = false;
+
   @Watch('debounce')
   protected debounceChanged() {
     const { pdsInput, debounce, originalPdsInput } = this;
@@ -232,10 +240,23 @@ export class PdsTextarea {
       ...inheritAriaAttributes(this.el),
       ...inheritAttributes(this.el),
     };
+    this.hasAction = this.el.querySelector('[slot="action"]') !== null;
   }
 
   componentDidLoad() {
     this.originalPdsInput = this.pdsInput;
+  }
+
+  private renderAction() {
+    const hasAction = this.el.querySelector('[slot="action"]') !== null;
+    if (hasAction) {
+      return (
+        <div class="pds-textarea__action" part="action">
+          <slot name="action"></slot>
+        </div>
+      );
+    }
+    return null;
   }
 
   render() {
@@ -245,10 +266,14 @@ export class PdsTextarea {
       <Host
         aria-disabled={this.disabled ? 'true' : null}
         aria-readonly={this.readonly ? 'true' : null}
+        has-action={this.hasAction ? 'true' : null}
       >
         <div class="pds-textarea">
           {this.label &&
-            <label htmlFor={this.componentId}>{this.label}</label>
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor={this.componentId}>{this.label}</label>
+              {this.renderAction()}
+            </div>
           }
           <textarea
             ref={(el) => this.nativeTextarea = el }

--- a/libs/core/src/components/pds-textarea/readme.md
+++ b/libs/core/src/components/pds-textarea/readme.md
@@ -49,6 +49,20 @@ Type: `Promise<void>`
 
 
 
+## Slots
+
+| Slot       | Description                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `"action"` | Content to be displayed in the label area, typically for help icons or links |
+
+
+## Shadow Parts
+
+| Part       | Description |
+| ---------- | ----------- |
+| `"action"` |             |
+
+
 ## Dependencies
 
 ### Depends on

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
@@ -45,7 +45,7 @@ const BaseTemplate = (args) => html`<pds-textarea
   invalid="${args.invalid}"
   label="${args.label}"
   name="${args.name}"
-  onChange=${args.onChange}"
+  onChange="${args.onChange}"
   placeholder="${args.placeholder}"
   readonly="${args.readonly}"
   required="${args.required}"
@@ -54,6 +54,7 @@ const BaseTemplate = (args) => html`<pds-textarea
   data-tooltip-id="foo"
   title="bar"
   >
+  ${args.action || ''}
 </pds-textarea>`;
 
 export const Default = BaseTemplate.bind({});
@@ -130,3 +131,49 @@ Autocomplete.args = {
   autocomplete: 'on',
   placeholder: 'Enter a message...',
 };
+
+export const withActionLink = (args) => html`<pds-textarea
+  autocomplete="${args.autocomplete}"
+  clear-on-edit="${args.clearOnEdit}"
+  component-id="pds-textarea-action-link"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Notes"
+  name="${args.name}"
+  onChange="${args.onChange}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  rows="3"
+  value="${args.value}"
+  data-tooltip-id="foo"
+  title="bar">
+  <pds-link href="#" slot="action">
+    View examples
+  </pds-link>
+</pds-textarea>`;
+
+export const withActionButton = (args) => html`<pds-textarea
+  autocomplete="${args.autocomplete}"
+  clear-on-edit="${args.clearOnEdit}"
+  component-id="pds-textarea-action-button"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Description"
+  name="${args.name}"
+  onChange="${args.onChange}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  rows="4"
+  value="${args.value}"
+  data-tooltip-id="foo"
+  title="bar">
+  <pds-button slot="action" variant="unstyled">
+    <pds-icon name="question-circle"></pds-icon>
+  </pds-button>
+</pds-textarea>`;

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.e2e.ts
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.e2e.ts
@@ -33,4 +33,40 @@ describe('pds-textarea', () => {
     expect(value).toBe('Hello');
     expect(event).toHaveReceivedEvent();
   });
+
+  it('renders action slot content when provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-textarea label="Description">
+          <span slot="action">0/500</span>
+        </pds-textarea>
+      `);
+
+    const actionSlot = await page.find('pds-textarea >>> .pds-textarea__action');
+    expect(actionSlot).not.toBeNull();
+
+    const slotContent = await page.find('pds-textarea span[slot="action"]');
+    expect(await slotContent.innerText).toBe('0/500');
+  });
+
+  it('does not render action wrapper when no action content is provided', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-textarea label="Description"></pds-textarea>');
+
+    const actionSlot = await page.find('pds-textarea >>> .pds-textarea__action');
+    expect(actionSlot).toBeNull();
+  });
+
+  it('sets has-action attribute when action slot has content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+        <pds-textarea label="Comments">
+          <a slot="action" href="#">View guidelines</a>
+        </pds-textarea>
+      `);
+
+    const component = await page.find('pds-textarea');
+    expect(component).toHaveAttribute('has-action');
+    expect(await component.getAttribute('has-action')).toBe('true');
+  });
 });

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -103,7 +103,9 @@ describe('pds-textarea', () => {
       <pds-textarea label="label">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label>label</label>
+            <div class="pds-textarea__label-wrapper">
+              <label>label</label>
+            </div>
             <textarea class="pds-textarea__field"></textarea>
           </div>
         </mock:shadow-root>
@@ -189,7 +191,9 @@ describe('pds-textarea', () => {
       <pds-textarea component-id="pds-textarea-id" label="label">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label htmlFor="pds-textarea-id">label</label>
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor="pds-textarea-id">label</label>
+            </div>
             <textarea class="pds-textarea__field" id="pds-textarea-id" name="pds-textarea-id"></textarea>
           </div>
         </mock:shadow-root>
@@ -249,7 +253,9 @@ describe('pds-textarea', () => {
       <pds-textarea component-id="textarea-with-description" label="Textarea with description" helper-message="This is a helper message" error-message="This is an error message" invalid="true">
         <mock:shadow-root>
           <div class="pds-textarea">
-            <label htmlFor="textarea-with-description">Textarea with description</label>
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor="textarea-with-description">Textarea with description</label>
+            </div>
             <textarea aria-describedby="textarea-with-description__error-message" aria-invalid="true"  class="is-invalid pds-textarea__field" id="textarea-with-description" name="textarea-with-description"></textarea>
             <p id="textarea-with-description__helper-message"  class="pds-textarea__helper-message">
               This is a helper message
@@ -404,5 +410,145 @@ it('should set focus on the input element when setFocus is called', async() => {
     await page.waitForChanges();
 
     expect(inputEventSpy).toHaveBeenCalled();
+  });
+
+  describe('action slot', () => {
+    it('renders action slot content when provided', async () => {
+      const {root} = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1" label="Description">
+            <span slot="action">0/500</span>
+          </pds-textarea>
+        `,
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-textarea component-id="textarea-1" has-action="true" label="Description">
+          <mock:shadow-root>
+            <div class="pds-textarea">
+              <div class="pds-textarea__label-wrapper">
+                <label htmlFor="textarea-1">Description</label>
+                <div class="pds-textarea__action" part="action">
+                  <slot name="action"></slot>
+                </div>
+              </div>
+              <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
+            </div>
+          </mock:shadow-root>
+          <span slot="action">0/500</span>
+        </pds-textarea>
+      `);
+    });
+
+    it('does not render action slot when no content is provided', async () => {
+      const {root} = await newSpecPage({
+        components: [PdsTextarea],
+        html: `<pds-textarea component-id="textarea-1" label="Description"></pds-textarea>`,
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-textarea component-id="textarea-1" label="Description">
+          <mock:shadow-root>
+            <div class="pds-textarea">
+              <div class="pds-textarea__label-wrapper">
+                <label htmlFor="textarea-1">Description</label>
+              </div>
+              <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
+            </div>
+          </mock:shadow-root>
+        </pds-textarea>
+      `);
+    });
+
+    it('sets has-action attribute when action slot content is present', async () => {
+      const page = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1" label="Comments">
+            <a slot="action" href="#">View guidelines</a>
+          </pds-textarea>
+        `,
+      });
+
+      const root = page.root;
+      expect(root?.getAttribute('has-action')).toBe('true');
+    });
+
+    it('properly detects action slot presence in componentWillLoad', async () => {
+      const page = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1" label="Bio">
+            <button slot="action">Help</button>
+          </pds-textarea>
+        `,
+      });
+
+      const component = page.rootInstance;
+      expect(component.hasAction).toBe(true);
+    });
+
+    it('renders action slot with complex content', async () => {
+      const {root} = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1" label="Message">
+            <button slot="action" type="button">
+              <span>Attach file</span>
+            </button>
+          </pds-textarea>
+        `,
+      });
+
+      const actionWrapper = root?.shadowRoot?.querySelector('.pds-textarea__action');
+      expect(actionWrapper).not.toBeNull();
+      expect(actionWrapper?.getAttribute('part')).toBe('action');
+    });
+
+    it('does not render label wrapper when no label is provided', async () => {
+      const {root} = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1">
+            <span slot="action">Help</span>
+          </pds-textarea>
+        `,
+      });
+
+      const labelWrapper = root?.shadowRoot?.querySelector('.pds-textarea__label-wrapper');
+      expect(labelWrapper).toBeNull();
+    });
+
+    it('renders action slot with value and helper message', async () => {
+      const {root} = await newSpecPage({
+        components: [PdsTextarea],
+        html: `
+          <pds-textarea component-id="textarea-1" label="Bio" value="Hello" helper-message="Max 500 characters">
+            <span slot="action">5/500</span>
+          </pds-textarea>
+        `,
+      });
+
+      expect(root).toEqualHtml(`
+        <pds-textarea component-id="textarea-1" has-action="true" helper-message="Max 500 characters" label="Bio" value="Hello">
+          <mock:shadow-root>
+            <div class="pds-textarea">
+              <div class="pds-textarea__label-wrapper">
+                <label htmlFor="textarea-1">Bio</label>
+                <div class="pds-textarea__action" part="action">
+                  <slot name="action"></slot>
+                </div>
+              </div>
+              <textarea aria-describedby="textarea-1__helper-message" class="pds-textarea__field" id="textarea-1" name="textarea-1">Hello</textarea>
+              <p class="pds-textarea__helper-message" id="textarea-1__helper-message">
+                Max 500 characters
+              </p>
+            </div>
+          </mock:shadow-root>
+          <span slot="action">5/500</span>
+        </pds-textarea>
+      `);
+    });
   });
 });

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -412,143 +412,141 @@ it('should set focus on the input element when setFocus is called', async() => {
     expect(inputEventSpy).toHaveBeenCalled();
   });
 
-  describe('action slot', () => {
-    it('renders action slot content when provided', async () => {
-      const {root} = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1" label="Description">
-            <span slot="action">0/500</span>
-          </pds-textarea>
-        `,
-      });
-
-      expect(root).toEqualHtml(`
-        <pds-textarea component-id="textarea-1" has-action="true" label="Description">
-          <mock:shadow-root>
-            <div class="pds-textarea">
-              <div class="pds-textarea__label-wrapper">
-                <label htmlFor="textarea-1">Description</label>
-                <div class="pds-textarea__action" part="action">
-                  <slot name="action"></slot>
-                </div>
-              </div>
-              <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
-            </div>
-          </mock:shadow-root>
+  it('renders action slot content when provided', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1" label="Description">
           <span slot="action">0/500</span>
         </pds-textarea>
-      `);
+      `,
     });
 
-    it('does not render action slot when no content is provided', async () => {
-      const {root} = await newSpecPage({
-        components: [PdsTextarea],
-        html: `<pds-textarea component-id="textarea-1" label="Description"></pds-textarea>`,
-      });
-
-      expect(root).toEqualHtml(`
-        <pds-textarea component-id="textarea-1" label="Description">
-          <mock:shadow-root>
-            <div class="pds-textarea">
-              <div class="pds-textarea__label-wrapper">
-                <label htmlFor="textarea-1">Description</label>
+    expect(root).toEqualHtml(`
+      <pds-textarea component-id="textarea-1" has-action="true" label="Description">
+        <mock:shadow-root>
+          <div class="pds-textarea">
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor="textarea-1">Description</label>
+              <div class="pds-textarea__action" part="action">
+                <slot name="action"></slot>
               </div>
-              <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
             </div>
-          </mock:shadow-root>
+            <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
+          </div>
+        </mock:shadow-root>
+        <span slot="action">0/500</span>
+      </pds-textarea>
+    `);
+  });
+
+  it('does not render action slot when no content is provided', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsTextarea],
+      html: `<pds-textarea component-id="textarea-1" label="Description"></pds-textarea>`,
+    });
+
+    expect(root).toEqualHtml(`
+      <pds-textarea component-id="textarea-1" label="Description">
+        <mock:shadow-root>
+          <div class="pds-textarea">
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor="textarea-1">Description</label>
+            </div>
+            <textarea class="pds-textarea__field" id="textarea-1" name="textarea-1"></textarea>
+          </div>
+        </mock:shadow-root>
+      </pds-textarea>
+    `);
+  });
+
+  it('sets has-action attribute when action slot content is present', async () => {
+    const page = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1" label="Comments">
+          <a slot="action" href="#">View guidelines</a>
         </pds-textarea>
-      `);
+      `,
     });
 
-    it('sets has-action attribute when action slot content is present', async () => {
-      const page = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1" label="Comments">
-            <a slot="action" href="#">View guidelines</a>
-          </pds-textarea>
-        `,
-      });
+    const root = page.root;
+    expect(root?.getAttribute('has-action')).toBe('true');
+  });
 
-      const root = page.root;
-      expect(root?.getAttribute('has-action')).toBe('true');
+  it('properly detects action slot presence in componentWillLoad', async () => {
+    const page = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1" label="Bio">
+          <button slot="action">Help</button>
+        </pds-textarea>
+      `,
     });
 
-    it('properly detects action slot presence in componentWillLoad', async () => {
-      const page = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1" label="Bio">
-            <button slot="action">Help</button>
-          </pds-textarea>
-        `,
-      });
+    const component = page.rootInstance;
+    expect(component.hasAction).toBe(true);
+  });
 
-      const component = page.rootInstance;
-      expect(component.hasAction).toBe(true);
+  it('renders action slot with complex content', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1" label="Message">
+          <button slot="action" type="button">
+            <span>Attach file</span>
+          </button>
+        </pds-textarea>
+      `,
     });
 
-    it('renders action slot with complex content', async () => {
-      const {root} = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1" label="Message">
-            <button slot="action" type="button">
-              <span>Attach file</span>
-            </button>
-          </pds-textarea>
-        `,
-      });
+    const actionWrapper = root?.shadowRoot?.querySelector('.pds-textarea__action');
+    expect(actionWrapper).not.toBeNull();
+    expect(actionWrapper?.getAttribute('part')).toBe('action');
+  });
 
-      const actionWrapper = root?.shadowRoot?.querySelector('.pds-textarea__action');
-      expect(actionWrapper).not.toBeNull();
-      expect(actionWrapper?.getAttribute('part')).toBe('action');
+  it('does not render label wrapper when no label is provided', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1">
+          <span slot="action">Help</span>
+        </pds-textarea>
+      `,
     });
 
-    it('does not render label wrapper when no label is provided', async () => {
-      const {root} = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1">
-            <span slot="action">Help</span>
-          </pds-textarea>
-        `,
-      });
+    const labelWrapper = root?.shadowRoot?.querySelector('.pds-textarea__label-wrapper');
+    expect(labelWrapper).toBeNull();
+  });
 
-      const labelWrapper = root?.shadowRoot?.querySelector('.pds-textarea__label-wrapper');
-      expect(labelWrapper).toBeNull();
-    });
-
-    it('renders action slot with value and helper message', async () => {
-      const {root} = await newSpecPage({
-        components: [PdsTextarea],
-        html: `
-          <pds-textarea component-id="textarea-1" label="Bio" value="Hello" helper-message="Max 500 characters">
-            <span slot="action">5/500</span>
-          </pds-textarea>
-        `,
-      });
-
-      expect(root).toEqualHtml(`
-        <pds-textarea component-id="textarea-1" has-action="true" helper-message="Max 500 characters" label="Bio" value="Hello">
-          <mock:shadow-root>
-            <div class="pds-textarea">
-              <div class="pds-textarea__label-wrapper">
-                <label htmlFor="textarea-1">Bio</label>
-                <div class="pds-textarea__action" part="action">
-                  <slot name="action"></slot>
-                </div>
-              </div>
-              <textarea aria-describedby="textarea-1__helper-message" class="pds-textarea__field" id="textarea-1" name="textarea-1">Hello</textarea>
-              <p class="pds-textarea__helper-message" id="textarea-1__helper-message">
-                Max 500 characters
-              </p>
-            </div>
-          </mock:shadow-root>
+  it('renders action slot with value and helper message', async () => {
+    const {root} = await newSpecPage({
+      components: [PdsTextarea],
+      html: `
+        <pds-textarea component-id="textarea-1" label="Bio" value="Hello" helper-message="Max 500 characters">
           <span slot="action">5/500</span>
         </pds-textarea>
-      `);
+      `,
     });
+
+    expect(root).toEqualHtml(`
+      <pds-textarea component-id="textarea-1" has-action="true" helper-message="Max 500 characters" label="Bio" value="Hello">
+        <mock:shadow-root>
+          <div class="pds-textarea">
+            <div class="pds-textarea__label-wrapper">
+              <label htmlFor="textarea-1">Bio</label>
+              <div class="pds-textarea__action" part="action">
+                <slot name="action"></slot>
+              </div>
+            </div>
+            <textarea aria-describedby="textarea-1__helper-message" class="pds-textarea__field" id="textarea-1" name="textarea-1">Hello</textarea>
+            <p class="pds-textarea__helper-message" id="textarea-1__helper-message">
+              Max 500 characters
+            </p>
+          </div>
+        </mock:shadow-root>
+        <span slot="action">5/500</span>
+      </pds-textarea>
+    `);
   });
 });


### PR DESCRIPTION
# Description

This PR adds a new "action" slot to three form components (pds-input, pds-textarea, and pds-select) that allows developers to insert interactive elements next to field labels. The slot appears to the right of the label text and can contain links, buttons, icons, or any other content that provides contextual help or actions related to the field.

Fixes [DSS-1146](https://kajabi.atlassian.net/browse/DSS-1164)

|  Component   | Screenshot |
|--------|--------|
| Input |<img width="1045" height="649" alt="Screenshot 2025-07-14 at 4 43 48 PM" src="https://github.com/user-attachments/assets/b0a8fef5-cf7f-4534-95bf-d822407ec90a" />|
| Select |<img width="1031" height="637" alt="Screenshot 2025-07-14 at 4 47 12 PM" src="https://github.com/user-attachments/assets/0678a94d-60fb-4804-a283-c4f774d61758" />|
| Textarea |<img width="1029" height="838" alt="Screenshot 2025-07-14 at 4 47 31 PM" src="https://github.com/user-attachments/assets/bda7f1d6-ed44-4193-922c-a2e0932a38df" />|

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

[DSS-1146]: https://kajabi.atlassian.net/browse/DSS-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ