### PR TITLE
docs(pds-input): fix story implementations errors

### DIFF
--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -136,79 +136,135 @@ Autocomplete.args = {
   autocomplete: 'given-name',
 };
 
-export const withPrefixIcon = BaseTemplate.bind({});
-withPrefixIcon.args = {
-  componentId: 'pds-input-prefix-icon',
-  label: 'Email',
-  type: 'email',
-  prefix: html`<pds-icon slot="prefix" name="mail" size="small"></pds-icon>`,
-};
+export const withPrefixIcon = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-prefix-icon"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Email"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="email"
+  value="${args.value}">
+  <pds-icon slot="prefix" name="mail" size="small"></pds-icon>
+</pds-input>`;
 
-export const withSuffixButton = BaseTemplate.bind({});
-withSuffixButton.args = {
-  componentId: 'pds-input-suffix-button',
-  label: 'Search',
-  type: 'text',
-  suffix: html`<pds-button slot="suffix" variant="unstyled" class="pds-input__suffix"><pds-icon name="search" size="small"></pds-icon></pds-button>`,
-};
+export const withSuffixButton = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-suffix-button"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Search"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="text"
+  value="${args.value}">
+  <pds-button slot="suffix" variant="unstyled" class="pds-input__suffix">
+    <pds-icon name="search" size="small"></pds-icon>
+  </pds-button>
+</pds-input>`;
 
-export const withPrependSelect = BaseTemplate.bind({});
-withPrependSelect.args = {
-  componentId: 'pds-input-prepend-select',
-  label: 'Amount',
-  type: 'text',
-  prepend: html`
-    <pds-select hide-label label="Currency" slot="prepend" class="pds-input__prepend">
-      <option value="USD">USD</option>
-      <option value="EUR">EUR</option>
-      <option value="GBP">GBP</option>
-    </pds-select>
-  `,
-};
+export const withPrependSelect = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-prepend-select"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Amount"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="text"
+  value="${args.value}">
+  <pds-select hide-label label="Currency" slot="prepend" class="pds-input__prepend" name="currency">
+    <option value="USD">USD</option>
+    <option value="EUR">EUR</option>
+    <option value="GBP">GBP</option>
+  </pds-select>
+</pds-input>`;
 
-export const withAppendSelect = BaseTemplate.bind({});
-withAppendSelect.args = {
-  componentId: 'pds-input-append-select',
-  label: 'Phone',
-  type: 'tel',
-  append: html`
-    <pds-select hide-label slot="append" class="pds-input__append">
-      <option value="mobile">Mobile</option>
-      <option value="home">Home</option>
-      <option value="work">Work</option>
-    </pds-select>
-  `,
-};
+export const withAppendSelect = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-append-select"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Phone"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="tel"
+  value="${args.value}">
+  <pds-select hide-label slot="append" class="pds-input__append" name="phone-type">
+    <option value="mobile">Mobile</option>
+    <option value="home">Home</option>
+    <option value="work">Work</option>
+  </pds-select>
+</pds-input>`;
 
-export const withPrefixAndAppend = BaseTemplate.bind({});
-withPrefixAndAppend.args = {
-  componentId: 'pds-input-prefix-append',
-  label: 'Amount',
-  type: 'text',
-  prefix: html`<pds-icon name="dollar" size="small"></pds-icon>`,
-  append: html`
-    <pds-select hide-label slot="append" class="pds-input__append">
-      <option value="USD">USD</option>
-      <option value="EUR">EUR</option>
-      <option value="GBP">GBP</option>
-    </pds-select>
-  `,
-};
+export const withPrefixAndAppend = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-prefix-append"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Amount"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="text"
+  value="${args.value}">
+  <pds-icon slot="prefix" name="dollar" size="small"></pds-icon>
+  <pds-select hide-label slot="append" class="pds-input__append" name="currency">
+    <option value="USD">USD</option>
+    <option value="EUR">EUR</option>
+    <option value="GBP">GBP</option>
+  </pds-select>
+</pds-input>`;
 
-export const withPrependAndSuffix = BaseTemplate.bind({});
-withPrependAndSuffix.args = {
-  componentId: 'pds-input-prepend-suffix',
-  label: 'Amount',
-  type: 'text',
-  prepend: html`
-    <pds-select hide-label slot="prepend" class="pds-input__prepend">
-      <option value="USD">USD</option>
-      <option value="EUR">EUR</option>
-      <option value="GBP">GBP</option>
-    </pds-select>
-  `,
-  suffix: html`<pds-button slot="suffix" variant="unstyled" class="pds-input__suffix"><pds-icon name="remove-circle" size="small"></pds-icon></pds-button>`,
-};
+export const withPrependAndSuffix = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-prepend-suffix"
+  debounce="${args.debounce}"
+  disabled="${args.disabled}"
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  invalid="${args.invalid}"
+  label="Amount"
+  name="${args.name}"
+  placeholder="${args.placeholder}"
+  readonly="${args.readonly}"
+  required="${args.required}"
+  type="text"
+  value="${args.value}">
+  <pds-select hide-label slot="prepend" class="pds-input__prepend" name="currency">
+    <option value="USD">USD</option>
+    <option value="EUR">EUR</option>
+    <option value="GBP">GBP</option>
+  </pds-select>
+  <pds-button slot="suffix" variant="unstyled" class="pds-input__suffix">
+    <pds-icon name="remove-circle" size="small"></pds-icon>
+  </pds-button>
+</pds-input>`;
 
 export const withActionLink = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"


### PR DESCRIPTION
# Description

The pds-input Storybook stories were experiencing rendering errors for stories that included slot content (prefix, suffix, prepend, append). These stories were attempting to pass HTML slot content through the args object to a bound BaseTemplate function, but Storybook cannot properly process slot content when passed as template arguments. This resulted in formatting errors and the stories failing to render correctly in Storybook.

Converted affected stories (withPrefixIcon, withSuffixButton, withPrependSelect, withAppendSelect, withPrefixAndAppend, and withPrependAndSuffix) to use custom template functions that embed slot content directly in the HTML template, following the same pattern as the working withActionLink and withActionButton stories. Also added missing required name attributes to all pds-select components used in the stories.

Fixes [DSS-1481](https://kajabi.atlassian.net/browse/DSS-1481)

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="1849" height="1208" alt="Screenshot 2025-07-15 at 11 00 20 AM" src="https://github.com/user-attachments/assets/1b83fcec-7d91-47a1-a778-50e351b9a50b" />|<img width="1854" height="1224" alt="Screenshot 2025-07-15 at 11 00 30 AM" src="https://github.com/user-attachments/assets/c06ebead-4c7f-4227-bab0-a3645ce7c6a7" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Navigate to Input in Sidebar
Verify prefix/suffix/prepend/append stories no longer error.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1481]: https://kajabi.atlassian.net/browse/DSS-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ