### PR TITLE
fix(form-elements): align height spacing and message color

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -6,7 +6,7 @@
   --pds-button-border-radius-start-start: var(--pine-border-radius-full);
   --pds-button-border-radius-end-end: var(--pine-border-radius-full);
   --pds-button-border-radius-end-start: var(--pine-border-radius-full);
-  --pds-button-min-height: 40px;
+  --pds-button-min-height: var(--pine-dimension-450);
   --color-border-default: transparent;
   --color-border-disabled: transparent;
   --color-border-focus: transparent;

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -59,7 +59,7 @@
   font: var(--pine-typography-body-brand-label);
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-button-min-height);
-  padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
+  padding: calc(var(--pine-dimension-xs) - var(--pine-border-width)) var(--pine-dimension-sm);
   position: relative;
   text-decoration: none;
 

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -7,7 +7,7 @@
   --pds-input-border-radius: var(--pine-dimension-125);
   --pds-input-border-width: var(--pine-border-width-thin);
   --pds-input-padding-x: var(--pine-dimension-150);
-  --pds-input-padding-y: calc(var(--pine-dimension-xs) - 1px);
+  --pds-input-padding-y: calc(var(--pine-dimension-xs) - var(--pine-border-width));
   --pds-input-font: var(--pine-typography-body);
   --pds-input-text-color: var(--pine-color-text-active);
   --pds-input-placeholder-color: var(--pine-color-text-placeholder);

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -7,7 +7,7 @@
   --pds-input-border-radius: var(--pine-dimension-125);
   --pds-input-border-width: var(--pine-border-width-thin);
   --pds-input-padding-x: var(--pine-dimension-150);
-  --pds-input-padding-y: var(--pine-dimension-xs);
+  --pds-input-padding-y: calc(var(--pine-dimension-xs) - 1px);
   --pds-input-font: var(--pine-typography-body);
   --pds-input-text-color: var(--pine-color-text-active);
   --pds-input-placeholder-color: var(--pine-color-text-placeholder);
@@ -20,7 +20,7 @@
   --pds-input-error-border-hover: var(--pine-color-border-danger-hover);
   --pds-input-addon-background: var(--pine-color-background-subtle);
   --pds-input-addon-color: var(--pine-color-text-secondary);
-  --pds-input-field-min-height: calc(var(--pine-dimension-450) + 2px);
+  --pds-input-field-min-height: var(--pine-dimension-450);
   --box-shadow-focus: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring);
   --box-shadow-focus-error: 0 0 0 1px #ffffff, 0 0 0 3px var(--pine-color-focus-ring-danger);
 
@@ -142,7 +142,6 @@
 .pds-input {
   display: flex;
   flex-direction: column;
-  gap: var(--pine-dimension-2xs);
 }
 
 .pds-input__label-wrapper {
@@ -257,7 +256,8 @@
 
 .pds-input__error-message,
 .pds-input__helper-message {
-  font: var(--pine-typography-body-sm-medium);
+  color: var(--pine-color-text-message);
+  font: var(--pine-typography-body-sm);
   margin-block-end: var(--pine-dimension-none);
   margin-block-start: var(--pine-dimension-2xs);
 }

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -66,7 +66,7 @@ select {
   grid-area: field;
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-select-min-height);
-  padding: var(--pine-dimension-xs) var(--pine-dimension-150);
+  padding: calc(var(--pine-dimension-xs) - 1px) var(--pine-dimension-150);
   padding-inline-end: var(--pine-dimension-450);
   position: relative;
 
@@ -111,6 +111,7 @@ select {
 
 .pds-select__error-message,
 .pds-select__helper-message {
+  color: var(--pine-color-text-message);
   font: var(--pine-typography-body-sm-medium);
   margin-block-end: 0;
   margin-block-start: var(--pine-dimension-2xs);

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -66,7 +66,7 @@ select {
   grid-area: field;
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-select-min-height);
-  padding: calc(var(--pine-dimension-xs) - 1px) var(--pine-dimension-150);
+  padding: calc(var(--pine-dimension-xs) - var(--pine-border-width)) var(--pine-dimension-150);
   padding-inline-end: var(--pine-dimension-450);
   position: relative;
 

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -18,7 +18,6 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
-  margin-block-end: var(--pine-dimension-xs);
 }
 
 .pds-textarea__action {
@@ -77,6 +76,7 @@ label {
 
 .pds-textarea__error-message,
 .pds-textarea__helper-message {
+  color: var(--pine-color-text-message);
   font: var(--pine-typography-body-sm-medium);
   margin-block-start: var(--pine-dimension-xs);
 }


### PR DESCRIPTION
# Description

- [x] ensure button, input, and select are `36px` tall
- [x] ensure all form element message text matches spec

Fixes #(issue)

| Before `40px`  | After `36px` |
|--------|--------|
|<img width="451" height="209" alt="Screenshot 2025-07-21 at 9 48 19 AM" src="https://github.com/user-attachments/assets/190bcde3-4a85-4d67-bcc3-be91d4fcfd79" />|<img width="416" height="214" alt="Screenshot 2025-07-21 at 9 50 03 AM" src="https://github.com/user-attachments/assets/7a380066-721a-4bf7-be37-279ebfeaf51f" />|

| Before `38px`  | After `36px` |
|--------|--------|
|<img width="406" height="282" alt="Screenshot 2025-07-21 at 9 52 38 AM" src="https://github.com/user-attachments/assets/4496565b-1bc8-4625-aac7-0ae7d038816d" />|<img width="703" height="291" alt="Screenshot 2025-07-21 at 9 53 00 AM" src="https://github.com/user-attachments/assets/5d89f46c-9bb9-46dc-8cf2-8402e81547c6" />|
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
