### PR TITLE
fix(input): add full width variant  tests and docs

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -649,6 +649,10 @@ export namespace Components {
          */
         "errorMessage"?: string;
         /**
+          * Determines whether or not the input field takes full width of its container.
+         */
+        "fullWidth"?: boolean;
+        /**
           * Displays a message or hint below the input field.
          */
         "helperMessage"?: string;
@@ -2698,6 +2702,10 @@ declare namespace LocalJSX {
           * Specifies the error message and provides an error-themed treatment to the field.
          */
         "errorMessage"?: string;
+        /**
+          * Determines whether or not the input field takes full width of its container.
+         */
+        "fullWidth"?: boolean;
         /**
           * Displays a message or hint below the input field.
          */

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -89,6 +89,18 @@ Removes the ability to interact with the text field. If a value is present, that
   <pds-input component-id="pds-input-readonly-example" label="Name" type="email" readonly="true" value="Frank Dux"></pds-input>
 </DocCanvas>
 
+### Full Width
+
+When `full-width` is set to `true`, the input component will occupy the full width of its parent container instead of using its natural inline width.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: '<PdsInput componentId="pds-input-full-width-example" label="Full Width Input" type="text" fullWidth="true" placeholder="This input takes full width of its container"></PdsInput>',
+    webComponent: '<pds-input component-id="pds-input-full-width-example" label="Full Width Input" type="text" full-width="true" placeholder="This input takes full width of its container"></pds-input>'
+}}>
+  <pds-input component-id="pds-input-full-width-example" label="Full Width Input" type="text" full-width="true" placeholder="This input takes full width of its container"></pds-input>
+</DocCanvas>
+
 ### Helper Message
 
 A `helper-message` is used to provide additional information about how to complete the text field.

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -131,6 +131,10 @@
   }
 }
 
+:host([full-width="true"]) {
+  width: 100%;
+}
+
 :host([invalid="true"]) {
   &::part(prepend),
   &::part(append) {

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -191,6 +191,11 @@ export class PdsInput {
   @Prop({mutable: true}) value?: string | number | null = '';
 
   /**
+   * Determines whether or not the input field takes full width of its container.
+   */
+  @Prop() fullWidth?: boolean;
+
+  /**
    * Determines if the input has focus.
    */
   @State() hasFocus = false;
@@ -413,6 +418,7 @@ export class PdsInput {
         has-prepend={this.hasPrepend ? 'true' : null}
         has-append={this.hasAppend ? 'true' : null}
         has-action={this.hasAction ? 'true' : null}
+        full-width={this.fullWidth ? 'true' : null}
       >
         <div class="pds-input">
           {label && (

--- a/libs/core/src/components/pds-input/readme.md
+++ b/libs/core/src/components/pds-input/readme.md
@@ -14,6 +14,7 @@
 | `debounce`                 | `debounce`       | Sets the number of milliseconds to wait before updating the value.                                                    | `number`           | `undefined` |
 | `disabled`                 | `disabled`       | Determines whether or not the input field is disabled.                                                                | `boolean`          | `undefined` |
 | `errorMessage`             | `error-message`  | Specifies the error message and provides an error-themed treatment to the field.                                      | `string`           | `undefined` |
+| `fullWidth`                | `full-width`     | Determines whether or not the input field takes full width of its container.                                          | `boolean`          | `undefined` |
 | `helperMessage`            | `helper-message` | Displays a message or hint below the input field.                                                                     | `string`           | `undefined` |
 | `invalid`                  | `invalid`        | Determines whether or not the input field is invalid or throws an error.                                              | `boolean`          | `undefined` |
 | `label`                    | `label`          | Text to be displayed as the input label.                                                                              | `string`           | `undefined` |

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -9,6 +9,7 @@ export default {
     debounce: null,
     disabled: false,
     errorMessage: null,
+    fullWidth: false,
     helperMessage: null,
     invalid: false,
     max: null,
@@ -43,6 +44,7 @@ const BaseTemplate = (args) => html`<pds-input
   debounce="${args.debounce}"
   disabled="${args.disabled}"
   error-message="${args.errorMessage}"
+  full-width="${args.fullWidth}"
   helper-message="${args.helperMessage}"
   invalid="${args.invalid}"
   label="${args.label}"
@@ -134,6 +136,15 @@ Autocomplete.args = {
   label: 'First name',
   type: 'text',
   autocomplete: 'given-name',
+};
+
+export const FullWidth = BaseTemplate.bind({});
+FullWidth.args = {
+  componentId: 'pds-input-full-width-example',
+  label: 'Full Width Input',
+  type: 'text',
+  fullWidth: true,
+  placeholder: 'This input takes full width of its container',
 };
 
 export const withPrefixIcon = (args) => html`<pds-input

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -118,6 +118,25 @@ describe('pds-input', () => {
     `);
   });
 
+  it('renders full width input', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsInput],
+      html: `<pds-input full-width="true" component-id="field-1" value="Frank Dux"></pds-input>`
+    });
+
+    expect(root).toEqualHtml(`
+    <pds-input component-id="field-1" full-width="true" value="Frank Dux">
+      <mock:shadow-root>
+        <div class="pds-input">
+          <div class="pds-input__field-wrapper">
+            <input id="field-1" class="pds-input__field" type="text" value="Frank Dux" />
+          </div>
+        </div>
+      </mock:shadow-root>
+    </pds-input>
+    `);
+  });
+
   it('renders in invalid state when invalid prop is set', async () => {
     const { root } = await newSpecPage({
       components: [PdsInput],


### PR DESCRIPTION
# Description

- [x] - add `fullWidth` prop

<img width="860" height="544" alt="Screenshot 2025-07-21 at 3 21 15 PM" src="https://github.com/user-attachments/assets/7887c4db-d77e-4020-b861-4da04a88435e" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [x] unit tests

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
