### PR TITLE
fix(pds-button): add white space nowrap to button text

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -174,6 +174,7 @@
 .pds-button__text {
   align-items: center;
   display: inline-flex;
+  white-space: nowrap;
 }
 
 .pds-button__icon--hidden,


### PR DESCRIPTION
# Description
- [x] add `white-space: nowrap` to button text required for this change.

| Before | After |
|--------|--------|
|<img width="865" height="174" alt="Screenshot 2025-07-21 at 3 26 05 PM" src="https://github.com/user-attachments/assets/b04a2a00-a5d2-4fdc-bc10-4b47bd16bbe4" />|<img width="846" height="155" alt="Screenshot 2025-07-21 at 3 27 06 PM" src="https://github.com/user-attachments/assets/43da8e4b-fcdd-4eb6-bda1-ecf3bffdea0c" />| 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
