### PR TITLE
style(pds-box): update md border radius to correct token

### DIFF
--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -160,7 +160,7 @@ $pine-spacing-tokens: (
 }
 
 .pds-border-radius-md {
-  border-radius: var(--pine-dimension-100);
+  border-radius: var(--pine-dimension-125);
 }
 
 .pds-border-radius-lg {


### PR DESCRIPTION
# Description

The border-radius prop for the box component has the same value for sm and md. 
This PR updates md to the correct token/10px value.

Fixes https://kajabi.atlassian.net/browse/DSS-1489

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
