### PR TITLE
fix(pds-modal): adjust max height ot remove double scrollbars

### DIFF
--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -43,7 +43,7 @@
   display: flex;
   flex-direction: column;
   margin: var(--pine-dimension-md);
-  max-height: calc(100vh - (calc(6vh + 96px)));
+  max-height: calc(100vh - (calc(5vh + 96px)));
   width: 100%;
 
   @media (min-width: 992px) {


### PR DESCRIPTION
# Description

- [x] adjust `max-height` to remove double scrollbars

Fixes [DSS-1490](https://kajabi.atlassian.net/browse/DSS-1490)

| Header | Header |
|--------|--------|
|![modal-scroll-before](https://github.com/user-attachments/assets/6900f9c6-6118-4527-95f8-30359d4c4b47)|![modal-scroll-after](https://github.com/user-attachments/assets/197367da-f1d4-40c3-92aa-4720a294c452)|

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1490]: https://kajabi.atlassian.net/browse/DSS-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ