### PR TITLE
docs: remove camel case from documentation

### DIFF
--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -45,8 +45,8 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 - `direction`: Controls item orientation (`row` = horizontal, `column` = vertical)
 - `size`: Sets column width (1-12 grid system, works best inside pds-row)
 - `gap`: Controls spacing between items
-- `justifyContent`: Horizontal alignment of items
-- `alignItems`: Vertical alignment of items
+- `justify-content`: Horizontal alignment of items
+- `align-items`: Vertical alignment of items
 
 ### Working with PDS-Row
 
@@ -67,7 +67,7 @@ When pds-box is used standalone:
 ## Variants
 
 ### `border`
-By default Box has no border. Use `border` to add a border to the box. Use `borderColor` to change the color of the border. Use `borderRadius` to change the rounding of the box's corners.
+By default Box has no border. Use `border` to add a border to the box. Use `border-color` to change the color of the border. Use `border-radius` to change the rounding of the box's corners.
 
 <DocCanvas client:only
   mdxSource={{
@@ -78,7 +78,7 @@ By default Box has no border. Use `border` to add a border to the box. Use `bord
 </DocCanvas>
 
 ### Border Color
-Please refer to the color brand guidelines for the appropriate color to use. Use `borderColor` to change the color of the border. Accepts any valid color token or CSS color value.
+Please refer to the color brand guidelines for the appropriate color to use. Use `border-color` to change the color of the border. Accepts any valid color token or CSS color value.
 
 <DocCanvas client:only
   mdxSource={{
@@ -98,7 +98,7 @@ Please refer to the color brand guidelines for the appropriate color to use. Use
 </DocCanvas>
 
 ### Border Radius
-By default Box has no border radius. Use `borderRadius` to change the rounding of the box's corners.
+By default Box has no border radius. Use `border-radius` to change the rounding of the box's corners.
 
 <DocCanvas client:only
   mdxSource={{
@@ -265,7 +265,7 @@ Grid system:
 - Uses a 12-column grid system
 - Values range from 1-12 (e.g., `6` = 50% width, `12` = 100% width)
 - Most effective when used inside `pds-row` containers
-- Responsive variants available: `sizeXs`, `sizeSm`, `sizeMd`, `sizeLg`, `sizeXl`
+- Responsive variants available: `size-xs`, `size-sm`, `size-md`, `size-lg`, `size-xl`
 
 ### Layout Properties
 `pds-box` not only allows for custom element properties, but it also allows for a flexible layout system. The layout system is based on the [CSS Flexbox specification](https://drafts.csswg.org/css-flexbox/) and can be view on the [Layouts](/docs/components-layout--docs) page
@@ -294,17 +294,17 @@ The `pds-box` component uses a mobile-first approach to responsive sizing. This 
 
 ```html
 <!-- Full width on mobile, half width on tablets and up -->
-<pds-box size="12" sizeMd="6"></pds-box>
+<pds-box size="12" size-md="6"></pds-box>
 
 <!-- Full width on mobile, one-third width on tablets and up -->
-<pds-box size="12" sizeMd="4"></pds-box>
+<pds-box size="12" size-md="4"></pds-box>
 ```
 
 #### Explicit full-width layout on small screens
 
 ```html
 <!-- Explicit full width on mobile, different widths at different breakpoints -->
-<pds-box size="12" sizeSm="6" sizeLg="4"></pds-box>
+<pds-box size="12" size-sm="6" size-lg="4"></pds-box>
 ```
 
 #### When to use/avoid the base `size` prop
@@ -320,7 +320,7 @@ If you need different sizes at different breakpoints:
 
 ```html
 <!-- Different widths at different breakpoints -->
-<pds-box sizeSm="12" sizeMd="6" sizeLg="4"></pds-box>
+<pds-box size-sm="12" size-md="6" size-lg="4"></pds-box>
 ```
 
 ### Default Behavior

--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -277,7 +277,7 @@ The `pds-box` component uses a mobile-first approach to responsive sizing. This 
 ### Understanding the Cascade
 
 - The base `size` prop sets the default width that applies to all breakpoints unless overridden
-- Breakpoint-specific props (`sizeXs`, `sizeSm`, etc.) override the base size at their respective breakpoints and larger
+- Breakpoint-specific props (`size-xs`, `size-sm`, etc.) override the base size at their respective breakpoints and larger
 - Each breakpoint-specific prop overrides any sizes set by smaller breakpoint props
 
 ### Breakpoint Ranges

--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -284,7 +284,7 @@ You can control the dropdown's placement, width, and height, as well as the trig
 - `dropdownPlacement`: 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end' (default: 'bottom-start')
 - `dropdownWidth`: Any valid CSS width value (default: '236px')
 - `triggerWidth`: Any valid CSS width value for both input and button triggers (default: 'fit-content')
-- `maxHeight`: Any valid CSS height value (e.g., '200px', '10rem') to limit dropdown height with scrolling
+- `max-height`: Any valid CSS height value (e.g., '200px', '10rem') to limit dropdown height with scrolling
 
 ### Custom Placement
 You can control where the dropdown appears relative to the trigger element. This example shows the dropdown aligned to the right edge (`bottom-end`).

--- a/libs/core/src/components/pds-popover/docs/pds-popover.mdx
+++ b/libs/core/src/components/pds-popover/docs/pds-popover.mdx
@@ -127,7 +127,7 @@ Toggles the popover visibility state when triggered. Clicking the popover trigge
 
 ### Width/Sizing
 
-The `maxWidth` prop allows adjusting the maximum width of the popover content. Default is 352px.
+The `max-width` prop allows adjusting the maximum width of the popover content. Default is 352px.
 
 <DocCanvas client:only
   mdxSource={{

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -121,7 +121,7 @@ Layout impact:
 - `baseline`: Items align to their text baseline
 - `stretch`: Items stretch to fill the row height (default)
 
-Best practice: Use with `minHeight` for consistent vertical alignment
+Best practice: Use with `min-height` for consistent vertical alignment
 
 ### Column Gap
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -150,12 +150,12 @@ Best practice: Use `space-between` for navigation or action buttons
 
 Layout impact:
 - Ensures consistent row height for vertical alignment
-- Required for `alignItems="center"` to work properly
+- Required for `align-items="center"` to work properly
 - Prevents row height from collapsing when content is short
 
-Best practice: Use with `alignItems="center"` for vertically centered content
+Best practice: Use with `align-items="center"` for vertically centered content
 
-Example: `minHeight="100px"` or `minHeight="10rem"`
+Example: `min-height="100px"` or `min-height="10rem"`
 
 ### No Wrap
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -24,10 +24,10 @@ The pds-row component creates a 12-column grid system for responsive layouts. It
 
 ### Key Props for Layout
 
-- `colGap`: Controls spacing between columns
-- `justifyContent`: Horizontal alignment of columns
-- `alignItems`: Vertical alignment of columns
-- `noWrap`: Prevents column wrapping
+- `col-gap`: Controls spacing between columns
+- `justify-content`: Horizontal alignment of columns
+- `align-items`: Vertical alignment of columns
+- `no-wrap`: Prevents column wrapping
 
 ### Working with PDS-Box
 

--- a/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
+++ b/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
@@ -113,7 +113,7 @@ By default the arrow is visible but it can be hidden by disabling it when `has-a
 
 
 ### Width/Sizing
-The `maxWidth` prop allows for adjust the maximum width for the tooltip content. The default max width is 352px, but it can be customized as needed by passing a new pixel value.
+The `max-width` prop allows for adjust the maximum width for the tooltip content. The default max width is 352px, but it can be customized as needed by passing a new pixel value.
 
 <DocCanvas client:only
   mdxSource={{


### PR DESCRIPTION
# Standardize property names to kebab-case in documentation text

## Changes
- Updated camelCase property references to kebab-case in component documentation text
- Affected components: pds-box, pds-row, pds-combobox, pds-tooltip, pds-popover

## Details
- sizeXs, sizeSm → size-xs, size-sm
- minHeight → min-height
- maxHeight → max-height
- maxWidth → max-width

## What's preserved
✅ React examples remain in camelCase (for documentation consistency)
✅ Web component examples already use kebab-case (no changes needed)
✅ Property values and non-property text unchanged
This ensures consistent kebab-case formatting for property names in documentation text while maintaining the appropriate casing for code examples.