### PR TITLE
fix: add form association and element internals to checkbox and switch

### DIFF
--- a/libs/core/src/stories/guides/forms.docs.mdx
+++ b/libs/core/src/stories/guides/forms.docs.mdx
@@ -374,6 +374,9 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('pds-input defined:', customElements.get('pds-input'));
       console.log('pds-select defined:', customElements.get('pds-select'));
       console.log('pds-textarea defined:', customElements.get('pds-textarea'));
+      console.log('pds-checkbox defined:', customElements.get('pds-checkbox'));
+      console.log('pds-radio defined:', customElements.get('pds-radio'));
+      console.log('pds-switch defined:', customElements.get('pds-switch'));
 
       console.log('📊 Testing form elements access:');
       console.log('Form elements:', form.elements);
@@ -381,6 +384,9 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('Named elements:', {
         name: form.elements.namedItem('name'),
         email: form.elements.namedItem('email'),
+        subscribe: form.elements.namedItem('subscribe'),
+        direction: form.elements.namedItem('direction'),
+        notifications: form.elements.namedItem('notifications'),
         message: form.elements.namedItem('message')
       });
 
@@ -388,25 +394,37 @@ document.addEventListener('DOMContentLoaded', () => {
       const pdsInput = document.querySelector('pds-input');
       const pdsSelect = document.querySelector('pds-select');
       const pdsTextarea = document.querySelector('pds-textarea');
+      const pdsCheckbox = document.querySelector('pds-checkbox');
+      const pdsRadio = document.querySelector('pds-radio');
+      const pdsSwitch = document.querySelector('pds-switch');
 
       console.log('🌲 Pine components in DOM:', {
         input: pdsInput,
         select: pdsSelect,
-        textarea: pdsTextarea
+        textarea: pdsTextarea,
+        checkbox: pdsCheckbox,
+        radio: pdsRadio,
+        switch: pdsSwitch
       });
 
       if (pdsInput || pdsSelect || pdsTextarea) {
         console.log('🔧 Component internals:', {
           inputInternals: pdsInput?.internals,
           selectInternals: pdsSelect?.internals,
-          textareaInternals: pdsTextarea?.internals
+          textareaInternals: pdsTextarea?.internals,
+          checkboxInternals: pdsCheckbox?.internals,
+          radioInternals: pdsRadio?.internals,
+          switchInternals: pdsSwitch?.internals
         });
 
         // Check if components are form-associated
         console.log('✅ Form association check:', {
           inputFormAssociated: pdsInput?.constructor?.formAssociated,
           selectFormAssociated: pdsSelect?.constructor?.formAssociated,
-          textareaFormAssociated: pdsTextarea?.constructor?.formAssociated
+          textareaFormAssociated: pdsTextarea?.constructor?.formAssociated,
+          checkboxFormAssociated: pdsCheckbox?.constructor?.formAssociated,
+          radioFormAssociated: pdsRadio?.constructor?.formAssociated,
+          switchFormAssociated: pdsSwitch?.constructor?.formAssociated
         });
       } else {
         console.error('❌ No Pine components found in DOM! Check if components are loading properly.');
@@ -430,7 +448,11 @@ document.addEventListener('DOMContentLoaded', () => {
       console.log('🎯 Component values:', {
         name: form.querySelector('[name="name"]')?.value,
         email: form.querySelector('[name="email"]')?.value,
-        message: form.querySelector('[name="message"]')?.value
+        subscribe: form.querySelector('[name="subscribe"]')?.checked,
+        direction: form.querySelector('input[name="direction"]:checked')?.value,
+        notifications: form.querySelector('[name="notifications"]')?.checked,
+        message: form.querySelector('[name="message"]')?.value,
+        timeOfDay: form.querySelector('[name="timeOfDay"]')?.value
       });
 
       // Log native form elements

--- a/libs/core/src/stories/guides/forms.docs.mdx
+++ b/libs/core/src/stories/guides/forms.docs.mdx
@@ -279,13 +279,19 @@ The web component example utilizes vanilla JavaScript to access values directly 
     console.log('📦 Custom element definitions:', {
       'pds-input': customElements.get('pds-input') ? '✅ Defined' : '❌ Not defined',
       'pds-select': customElements.get('pds-select') ? '✅ Defined' : '❌ Not defined',
-      'pds-textarea': customElements.get('pds-textarea') ? '✅ Defined' : '❌ Not defined'
+      'pds-textarea': customElements.get('pds-textarea') ? '✅ Defined' : '❌ Not defined',
+      'pds-checkbox': customElements.get('pds-checkbox') ? '✅ Defined' : '❌ Not defined',
+      'pds-radio': customElements.get('pds-radio') ? '✅ Defined' : '❌ Not defined',
+      'pds-switch': customElements.get('pds-switch') ? '✅ Defined' : '❌ Not defined'
     });
 
     // Check if Pine components have form association
     const formComponents = {
       input: form.querySelector('pds-input[component-id="name"]'),
       email: form.querySelector('pds-input[component-id="email"]'),
+      subscribe: form.querySelector('pds-checkbox[component-id="subscribe"]'),
+      direction: form.querySelector('pds-radio[component-id="direction-up"]'),
+      notifications: form.querySelector('pds-switch[component-id="notifications"]'),
       select: form.querySelector('pds-select[component-id="timeOfDay"]'),
       textarea: form.querySelector('pds-textarea[component-id="message"]')
     };


### PR DESCRIPTION
# Description

- [x] add formAssociation and elementInternals to checkbox and switch
- [x] radio is set to `shadow: false` so no update needed

| Before | After |
|--------|--------|
|<img width="973" height="667" alt="Screenshot 2025-08-12 at 6 44 40 AM" src="https://github.com/user-attachments/assets/d4003ae0-230f-498d-8dcb-43ac0cbe7e70" />|<img width="1018" height="604" alt="Screenshot 2025-08-12 at 6 42 51 AM" src="https://github.com/user-attachments/assets/dd748810-6c43-4480-abf1-6ed500f53e3a" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - PDS Checkbox and Switch now behave like native form controls: participate in form submissions, sync their checked/value state with forms, and restore state when navigating or reloading.
  - Form data reflects checked components (using their value or a default) and omits unchecked ones for accurate submissions.

- Documentation
  - Forms guide updated with examples for checkbox, radio, and switch, showing how to use them in forms alongside input, select, and textarea.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->