### PR TITLE
docs: update row examples and box docs

### DIFF
--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -50,14 +50,18 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 
 ### Working with PDS-Row
 
-When pds-box is used inside pds-row:
-- The default `direction="row"` works well for grid layouts
+> **⚠️ KEY LAYOUT RULE:** When `pds-box` is inside `pds-row`, it becomes a **grid column**. When `pds-box` is standalone, it becomes a **flexbox container**.
+
+**Inside pds-row (Grid Column Mode):**
 - Use `size` props (1-12) to control column widths
+- The default `direction="row"` works well for grid layouts
+- **DON'T use flex props** - they are ignored in grid mode
 - The box becomes a grid column within the row
 
-When pds-box is used standalone:
+**Standalone (Flexbox Container Mode):**
 - Default `direction="row"` creates horizontal flow
 - Set `direction="column"` for vertical stacking
+- **DO use flex props** - they work for child boxes
 - Size props have limited effect outside of pds-row
 
 ## Properties

--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -35,12 +35,11 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 
 ### Direction: When to Use Column vs Row
 
-> **🤖 LLM Direction Rules:** Choose based on how you want **direct children** to arrange:
+> **Direction Rules:** Choose based on how you want **direct children** to arrange:
 
 #### Use `direction="column"` (Vertical Stacking) When:
 - **Stacking content vertically** (headings, paragraphs, buttons)
 - **Creating page sections** (hero, content, footer)
-- **Building forms** (label, input, label, input)
 - **Making card layouts** (image, title, description, actions)
 - **Creating main containers** (usually with `fit="true"`)
 
@@ -60,7 +59,7 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 - **Making inline layouts** (icon + text, multiple form fields)
 - **This is the DEFAULT** - no need to specify
 
-```tsx
+```html
 // ✅ Correct: Horizontal items (default behavior)
 <pds-box>
   <pds-button>Save</pds-button>
@@ -68,8 +67,8 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 </pds-box>
 ```
 
-#### ❌ Common LLM Mistakes:
-```tsx
+#### ❌ Common Mistakes:
+```html
 // DON'T: Using row direction for stacked content
 <pds-box direction="row">  // ❌ Will place items side by side
   <h1>Title</h1>
@@ -155,7 +154,7 @@ Items flow horizontally by default, so you'll need to explicitly set `direction=
 
 ### Working with PDS-Row
 
-> **⚠️ KEY LAYOUT RULE:** When `pds-box` is inside `pds-row`, it becomes a **grid column**. When `pds-box` is standalone, it becomes a **flexbox container**.
+> **KEY LAYOUT RULE:** When `pds-box` is inside `pds-row`, it becomes a **grid column**. When `pds-box` is standalone, it becomes a **flexbox container**.
 
 **Inside pds-row (Grid Column Mode):**
 - Use `size` props (1-12) to control column widths
@@ -498,7 +497,7 @@ Common custom flex patterns:
 
 ### Quick Decision Tree for LLMs:
 
-> **🤖 Direction Decision Rules:**
+> ** Direction Decision Rules:**
 > 1. **Are you building a page/card/form?** → Use `direction="column"`
 > 2. **Are you placing buttons/badges/icons together?** → Use default (no direction needed)
 > 3. **Are children meant to stack vertically?** → Use `direction="column"`

--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -33,12 +33,117 @@ This approach ensures that your layouts will work correctly regardless of the te
 
 Items flow horizontally by default, so you'll need to explicitly set `direction="column"` for vertical stacking. This is the most common consideration when working with Box components.
 
+### Direction: When to Use Column vs Row
+
+> **🤖 LLM Direction Rules:** Choose based on how you want **direct children** to arrange:
+
+#### Use `direction="column"` (Vertical Stacking) When:
+- **Stacking content vertically** (headings, paragraphs, buttons)
+- **Creating page sections** (hero, content, footer)
+- **Building forms** (label, input, label, input)
+- **Making card layouts** (image, title, description, actions)
+- **Creating main containers** (usually with `fit="true"`)
+
+```tsx
+// ✅ Correct: Vertical content stacking
+<pds-box direction="column">
+  <h1>Page Title</h1>
+  <p>Description</p>
+  <pds-button>Action</pds-button>
+</pds-box>
+```
+
+#### Use `direction="row"` (Horizontal Flow) - DEFAULT When:
+- **Placing items side by side** (buttons, badges, icons)
+- **Creating navigation bars** (logo, menu items, user profile)
+- **Building toolbars** (action buttons in a row)
+- **Making inline layouts** (icon + text, multiple form fields)
+- **This is the DEFAULT** - no need to specify
+
+```tsx
+// ✅ Correct: Horizontal items (default behavior)
+<pds-box>
+  <pds-button>Save</pds-button>
+  <pds-button variant="secondary">Cancel</pds-button>
+</pds-box>
+```
+
+#### ❌ Common LLM Mistakes:
+```tsx
+// DON'T: Using row direction for stacked content
+<pds-box direction="row">  // ❌ Will place items side by side
+  <h1>Title</h1>
+  <p>This will be next to the title, not below it</p>
+</pds-box>
+
+// DON'T: Using column direction for side-by-side items
+<pds-box direction="column">  // ❌ Will stack items vertically
+  <pds-button>Save</pds-button>
+  <pds-button>Cancel</pds-button>  // Will be below Save, not next to it
+</pds-box>
+```
+
 ### Layout Patterns
 
-- Horizontal Flow (Default): Items are placed side by side
-- Vertical Stacking: Set `direction="column"` for items to stack vertically
-- Main Containers: Use `direction="column"` and `fit="true"` for page sections and main content areas
-- Grid Layout: Use inside `pds-row` with `size-*` props for responsive grid
+- **Horizontal Flow (Default)**: Items are placed side by side - good for buttons, navigation
+- **Vertical Stacking**: Set `direction="column"` for content that should stack - good for pages, cards, forms
+- **Main Containers**: Use `direction="column"` and `fit="true"` for page sections and main content areas
+- **Grid Layout**: Use inside `pds-row` with `size-*` props for responsive grid
+
+### Direction Examples
+
+**Column Direction (Vertical Stacking):**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsBox direction="column" border="true" padding="md">
+  <h3>Page Title</h3>
+  <p>This is a description that appears below the title.</p>
+  <PdsBox gap="sm">
+    <PdsButton>Primary Action</PdsButton>
+    <PdsButton variant="secondary">Secondary</PdsButton>
+  </PdsBox>
+</PdsBox>`,
+    webComponent: `<pds-box direction="column" border="true" padding="md">
+  <h3>Page Title</h3>
+  <p>This is a description that appears below the title.</p>
+  <pds-box gap="sm">
+    <pds-button>Primary Action</pds-button>
+    <pds-button variant="secondary">Secondary</pds-button>
+  </pds-box>
+</pds-box>`
+}}>
+  <pds-box direction="column" border="true" padding="md">
+    <h3>Page Title</h3>
+    <p>This is a description that appears below the title.</p>
+    <pds-box gap="sm">
+      <pds-button>Primary Action</pds-button>
+      <pds-button variant="secondary">Secondary</pds-button>
+    </pds-box>
+  </pds-box>
+</DocCanvas>
+
+**Row Direction (Horizontal Flow - Default):**
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `<PdsBox border="true" padding="md" align-items="center" gap="sm">
+  <PdsIcon name="info" />
+  <span>Status message</span>
+  <PdsButton size="sm">Action</PdsButton>
+</PdsBox>`,
+    webComponent: `<pds-box border="true" padding="md" align-items="center" gap="sm">
+  <pds-icon name="info"></pds-icon>
+  <span>Status message</span>
+  <pds-button size="sm">Action</pds-button>
+</pds-box>`
+}}>
+  <pds-box border="true" padding="md" align-items="center" gap="sm">
+    <pds-icon name="info"></pds-icon>
+    <span>Status message</span>
+    <pds-button size="sm">Action</pds-button>
+  </pds-box>
+</DocCanvas>
 
 ### Key Props for Layout
 
@@ -350,6 +455,54 @@ Common custom flex patterns:
 
 ### Layout Properties
 `pds-box` not only allows for custom element properties, but it also allows for a flexible layout system. The layout system is based on the [CSS Flexbox specification](https://drafts.csswg.org/css-flexbox/) and can be view on the [Layouts](/docs/components-layout--docs) page
+
+## Direction Troubleshooting
+
+### Problem: Items Not Arranging as Expected
+
+#### Issue: Content stacking when you want side-by-side
+```tsx
+// ❌ Problem: Buttons stack vertically instead of horizontally
+<PdsBox direction="column">
+  <PdsButton>Save</PdsButton>
+  <PdsButton>Cancel</PdsButton>
+</PdsBox>
+```
+
+**Solution:** Remove `direction="column"` or use `direction="row"` (default):
+```tsx
+// ✅ Solution: Buttons appear side by side
+<PdsBox>
+  <PdsButton>Save</PdsButton>
+  <PdsButton>Cancel</PdsButton>
+</PdsBox>
+```
+
+#### Issue: Content appearing side-by-side when you want stacking
+```tsx
+// ❌ Problem: Title and text appear next to each other
+<PdsBox>
+  <h1>Page Title</h1>
+  <p>Description text</p>
+</PdsBox>
+```
+
+**Solution:** Add `direction="column"`:
+```tsx
+// ✅ Solution: Title appears above description
+<PdsBox direction="column">
+  <h1>Page Title</h1>
+  <p>Description text</p>
+</PdsBox>
+```
+
+### Quick Decision Tree for LLMs:
+
+> **🤖 Direction Decision Rules:**
+> 1. **Are you building a page/card/form?** → Use `direction="column"`
+> 2. **Are you placing buttons/badges/icons together?** → Use default (no direction needed)
+> 3. **Are children meant to stack vertically?** → Use `direction="column"`
+> 4. **Are children meant to flow horizontally?** → Use default (no direction needed)
 
 ## Responsive Sizing Strategies & Examples
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -31,13 +31,16 @@ The pds-row component creates a 12-column grid system for responsive layouts. It
 
 ### Working with PDS-Box
 
-pds-row is designed to work with pds-box children:
-- Direct Children: Only pds-box components should be direct children
-- Size Props: pds-box children should use size props (1-12) for grid layout
-- Direction: pds-box children default to `direction="row"` which works well in grid
-- Column Sum: Total of all size props should not exceed 12 per row
+> **⚠️ CRITICAL:** `pds-row` transforms `pds-box` children into **grid columns**, not flexbox items. This changes how they behave.
 
-> **⚠️ IMPORTANT:** `pds-box` flex properties (`flex="grow"`, `flex="shrink"`, `flex="none"`, or custom flex strings like `flex="1"`) do **NOT** work when the box is a direct child of `pds-row`. The flex properties only work when the immediate parent is another `pds-box` component. Use the `size` props instead for controlling column width within rows.
+**Grid Column Behavior Inside pds-row:**
+- **REQUIRED:** Only `pds-box` components should be direct children
+- **USE:** `size` props (1-12) for column width control
+- **DEFAULT:** Children use `direction="row"` which works well in grid
+- **LIMIT:** Total of all size props should not exceed 12 per row
+- **FORBIDDEN:** Flex properties (`flex="grow"`, `flex="shrink"`, `flex="none"`, or custom values like `flex="1"`) are **ignored**
+
+> **🚨 COMMON MISTAKE:** Using `flex` props on boxes inside `pds-row` won't work. Use `size` props instead.
 
 ### Common Patterns
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -31,7 +31,7 @@ The pds-row component creates a 12-column grid system for responsive layouts. It
 
 ### Working with PDS-Box
 
-> **⚠️ CRITICAL:** `pds-row` transforms `pds-box` children into **grid columns**, not flexbox items. This changes how they behave.
+> **CRITICAL:** `pds-row` transforms `pds-box` children into **grid columns**, not flexbox items. This changes how they behave.
 
 **Grid Column Behavior Inside pds-row:**
 - **REQUIRED:** Only `pds-box` components should be direct children
@@ -40,7 +40,7 @@ The pds-row component creates a 12-column grid system for responsive layouts. It
 - **LIMIT:** Total of all size props should not exceed 12 per row
 - **FORBIDDEN:** Flex properties (`flex="grow"`, `flex="shrink"`, `flex="none"`, or custom values like `flex="1"`) are **ignored**
 
-> **🚨 COMMON MISTAKE:** Using `flex` props on boxes inside `pds-row` won't work. Use `size` props instead.
+> **COMMON MISTAKE:** Using `flex` props on boxes inside `pds-row` won't work. Use `size` props instead.
 
 ### Common Patterns
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -78,13 +78,19 @@ By default boxes with rows will be equal width if no size is specified.
       </pds-row>
     `
 }}>
-  <pds-row>
-    <pds-box>Item 1</pds-box>
-    <pds-box direction="column">
-      <p>Content 1</p>
-      <p>Content 2</p>
+  <pds-row col-gap="sm">
+    <pds-box>
+      <pds-box border>Item 1</pds-box>
     </pds-box>
-    <pds-box>Item 3</pds-box>
+    <pds-box>
+      <pds-box border direction="column">
+        <p>Content 1</p>
+        <p>Content 2</p>
+      </pds-box>
+    </pds-box>
+    <pds-box>
+      <pds-box border>Item 3</pds-box>
+    </pds-box>
   </pds-row>
 </DocCanvas>
 
@@ -94,21 +100,33 @@ If the size values equal more than 12, the boxes will wrap to the next line.
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsRow>
-        <PdsBox border size-xs="4">size-xs 4</PdsBox>
-        <PdsBox border size-xs="10">size-xs 10</PdsBox>
+      <PdsRow colGap="sm">
+        <PdsBox size-xs="4">
+          <pds-box border>size-xs 4</pds-box>
+        </pds-box>
+        <pds-box size-xs="10">
+          <pds-box border>size-xs 10</pds-box>
+        </pds-box>
       </PdsRow>
     `,
     webComponent: `
-      <pds-row>
-        <pds-box border size-xs="4">size-xs 4</pds-box>
-        <pds-box border size-xs="10">size-xs 10</pds-box>
+      <pds-row col-gap="sm">
+        <pds-box size-xs="4">
+          <pds-box border>size-xs 4</pds-box>
+        </pds-box>
+        <pds-box size-xs="10">
+          <pds-box border>size-xs 10</pds-box>
+        </pds-box>
       </pds-row>
     `
 }}>
-  <pds-row>
-    <pds-box border size-xs="4">size-xs 4</pds-box>
-    <pds-box border size-xs="10">size-xs 10</pds-box>
+  <pds-row col-gap="sm">
+    <pds-box size-xs="4">
+      <pds-box border>size-xs 4</pds-box>
+    </pds-box>
+    <pds-box size-xs="10">
+      <pds-box border>size-xs 10</pds-box>
+    </pds-box>
   </pds-row>
 </DocCanvas>
 

--- a/libs/core/src/components/pds-row/stories/pds-row.stories.js
+++ b/libs/core/src/components/pds-row/stories/pds-row.stories.js
@@ -9,18 +9,21 @@ export default {
 
 const BaseTemplate = (args) => html`
 <pds-row
-  align-items="${args.alignItems}"  
-  border="${args.border}"
-  component-id="${args.componentId}" 
+  align-items="${args.alignItems}"
+  component-id="${args.componentId}"
   col-gap="${args.colGap}"
   justify-content="${args.justifyContent}"
   min-height="${args.minHeight}"
   no-wrap="${args.noWrap}"
 >
-  <pds-box border>Item 1</pds-box>
-  <pds-box border direction="column">
-    <p>Content 1</p>
-    <p>Content 2</p>
+  <pds-box>
+    <pds-box border>Item 1</pds-box>
+  </pds-box>
+  <pds-box>
+    <pds-box border direction="column">
+      <p>Content 1</p>
+      <p>Content 2</p>
+    </pds-box>
   </pds-box>
 </pds-row>
 `;
@@ -34,9 +37,9 @@ Default.args = {
 
 const GapTemplate = (args) => html`
 <pds-row
-  align-items="${args.alignItems}"  
+  align-items="${args.alignItems}"
   border="${args.border}"
-  component-id="${args.componentId}" 
+  component-id="${args.componentId}"
   col-gap="${args.colGap}"
   justify-content="${args.justifyContent}"
   min-height="${args.minHeight}"

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -99,25 +99,37 @@ Use `pds-row` for Multi-Column Layouts:
   mdxSource={{
     react: `
       <PdsBox backgroundColor="#f5f5f5" fit="true">
-        <PdsRow>
-          <PdsBox size="8" padding="md" border="true">Column 1</PdsBox>
-          <PdsBox size="4" padding="md" border="true">Column 2</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox size="8">
+            <pds-box border padding="md">Column 1</pds-box>
+          </pds-box>
+          <PdsBox size="4">
+            <pds-box border padding="md">Column 2</pds-box>
+          </pds-box>
         </pds-row>
       </PdsBox>
     `,
     webComponent: `
       <pds-box background-color="#f5f5f5" fit="true">
-        <pds-row>
-          <pds-box size="8" padding="md" border="true">Column 1</pds-box>
-          <pds-box size="4" padding="md" border="true">Column 2</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size="8">
+            <pds-box border padding="md">Column 1</pds-box>
+          </pds-box>
+          <pds-box size="4">
+            <pds-box border padding="md">Column 2</pds-box>
+          </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box background-color="#f5f5f5" fit="true">
-    <pds-row>
-      <pds-box size="8" padding="md" border="true">Column 1</pds-box>
-      <pds-box size="4" padding="md" border="true">Column 2</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size="8">
+        <pds-box border padding="md">Column 1</pds-box>
+      </pds-box>
+      <pds-box size="4">
+        <pds-box border padding="md">Column 2</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -130,25 +142,37 @@ Add size modifiers to your child `pds-box` for responsive design
   mdxSource={{
     react: `
       <PdsBox backgroundColor="#f5f5f5" fit="true">
-        <PdsRow>
-          <PdsBox sizeMd="8" padding="md" border="true">Column 1</PdsBox>
-          <PdsBox sizeMd="4" padding="md" border="true">Column 2</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox sizeMd="8">
+            <pds-box border padding="md">Column 1</pds-box>
+          </pds-box>
+          <PdsBox sizeMd="4">
+            <pds-box border padding="md">Column 2</pds-box>
+          </pds-box>
         </pds-row>
       </PdsBox>
     `,
     webComponent: `
       <pds-box background-color="#f5f5f5" fit="true">
-        <pds-row>
-          <pds-box size-md="8" padding="sm" border="true">Column 1</pds-box>
-          <pds-box size-md="4" padding="sm" border="true">Column 2</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size-md="8">
+            <pds-box border padding="sm">Column 1</pds-box>
+          </pds-box>
+          <pds-box size-md="4">
+            <pds-box border padding="sm">Column 2</pds-box>
+          </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box background-color="#f5f5f5" fit="true">
-    <pds-row>
-      <pds-box size-md="8" padding="sm" border="true">Column 1</pds-box>
-      <pds-box size-md="4" padding="sm" border="true">Column 2</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size-md="8">
+        <pds-box border padding="sm">Column 1</pds-box>
+      </pds-box>
+      <pds-box size-md="4">
+        <pds-box border padding="sm">Column 2</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -607,23 +631,30 @@ By combining the `pds-box` and `pds-row` components, you can easily create a 12-
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <pdsRow>
-          <PdsBox border>
-            Content for column 1
+        <PdsRow>
+          <PdsBox>
+            <PdsBox border>
+              Content for column 1
+            </PdsBox>
           </PdsBox>
-          <PdsBox border>
-            Content for column 2
+          <PdsBox>
+            <PdsBox border>
+              Content for column 2
+            </PdsBox>
           </PdsBox>
-        </pdsRow>
+        </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box border>
-            Content for column 1
+        <pds-row col-gap="sm">
+          <pds-box>
+            <pds-box border>
+              Content for column 1
+            </pds-box>
           </pds-box>
-          <pds-box border>
+          <pds-box>
+            <pds-box border>
             Content for column 2
           </pds-box>
         </pds-row>
@@ -631,9 +662,13 @@ By combining the `pds-box` and `pds-row` components, you can easily create a 12-
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box border>Content for column 1</pds-box>
-      <pds-box border>Content for column 2</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box>
+        <pds-box border>Content for column 1</pds-box>
+      </pds-box>
+      <pds-box>
+        <pds-box border>Content for column 2</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -645,33 +680,44 @@ This creates a two-column layout, and you can customize the `size` and arrangeme
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <PdsRow>
-          <PdsBox border size="4">
-            Content for column 1
+        <PdsRow col-gap="sm">
+          <PdsBox size="4">
+            <PdsBox border>
+              Content for column 1
+            </PdsBox>
           </PdsBox>
-          <PdsBox border size="8">
+          <PdsBox size="8">
             Content for column 2
+            </PdsBox>
           </PdsBox>
         </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box border size="4">
-            Content for column 1
+        <pds-row col-gap="sm">
+          <pds-box size="4">
+            <pds-box border>
+              Content for column 1
+            </pds-box>
           </pds-box>
-          <pds-box border size="8">
-            Content for column 2
+          <pds-box size="8">
+            <pds-box border>
+              Content for column 2
+            </pds-box>
           </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box border size="4">Content for column 1</pds-box>
-      <pds-box border size="8">Content for column 2</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size="4">
+        <pds-box border>Content for column 1</pds-box>
+      </pds-box>
+      <pds-box size="8">
+        <pds-box border>Content for column 2</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -685,27 +731,45 @@ Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior f
     react: `
       <PdsBox display="block">
         <PdsRow>
-          <PdsBox border sizeMd="6" sizeLg="4" sizeXl="3">Item 1</PdsBox>
-          <PdsBox border sizeMd="6" sizeLg="4" sizeXl="3">Item 2</PdsBox>
-          <PdsBox border sizeMd="6" sizeLg="4" sizeXl="3">Item 3</PdsBox>
+          <PdsBox sizeMd="6" sizeLg="4" sizeXl="3">
+            <PdsBox border>Item 1</PdsBox>
+          </PdsBox>
+          <PdsBox sizeMd="6" sizeLg="4" sizeXl="3">
+            <PdsBox border>Item 2</PdsBox>
+          </PdsBox>
+          <PdsBox sizeMd="6" sizeLg="4" sizeXl="3">
+            <PdsBox border>Item 3</PdsBox>
+          </PdsBox>
         </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box border size-md="6" size-lg="4" size-xl="3">Item 1</pds-box>
-          <pds-box border size-md="6" size-lg="4" size-xl="3">Item 2</pds-box>
-          <pds-box border size-md="6" size-lg="4" size-xl="3">Item 3</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size-md="6" size-lg="4" size-xl="3">
+            <pds-box border>Item 1</pds-box>
+          </pds-box>
+          <pds-box size-md="6" size-lg="4" size-xl="3">
+            <pds-box border>Item 2</pds-box>
+          </pds-box>
+          <pds-box size-md="6" size-lg="4" size-xl="3">
+            <pds-box border>Item 3</pds-box>
+          </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box border size-md="6" size-lg="4" size-xl="3">Item 1</pds-box>
-      <pds-box border size-md="6" size-lg="4" size-xl="3">Item 2</pds-box>
-      <pds-box border size-md="6" size-lg="4" size-xl="3">Item 3</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size-md="6" size-lg="4" size-xl="3">
+        <pds-box border>Item 1</pds-box>
+      </pds-box>
+      <pds-box size-md="6" size-lg="4" size-xl="3">
+        <pds-box border>Item 2</pds-box>
+      </pds-box>
+      <pds-box size-md="6" size-lg="4" size-xl="3">
+        <pds-box border>Item 3</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -719,25 +783,37 @@ Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior f
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <PdsRow>
-          <PdsBox border sizeXs="0" sizeSm="0" sizeLg="12">Larger screen content</PdsBox>
-          <PdsBox border sizeMd="12" sizeLg="0">Small screen content</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox sizeXs="0" sizeSm="0" sizeLg="12">
+            <PdsBox border>Larger screen content</PdsBox>
+          </PdsBox>
+          <PdsBox sizeMd="12" sizeLg="0">
+            <PdsBox border>Small screen content</PdsBox>
+          </PdsBox>
         </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box border size-xs="0" size-sm="0" size-lg="12">Larger screen content</pds-box>
-          <pds-box border size-md="12" size-lg="0">Small screen content</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size-xs="0" size-sm="0" size-lg="12">
+            <pds-box border>Larger screen content</pds-box>
+          </pds-box>
+          <pds-box size-md="12" size-lg="0">
+            <pds-box border>Small screen content</pds-box>
+          </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box border size-xs="0" size-sm="0" size-lg="12">Larger screen content</pds-box>
-      <pds-box border size-md="12" size-lg="0">Small screen content</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size-xs="0" size-sm="0" size-lg="12">
+        <pds-box border>Larger screen content</pds-box>
+      </pds-box>
+      <pds-box size-md="12" size-lg="0">
+        <pds-box border>Small screen content</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -750,43 +826,71 @@ Use the `offset` property to offset columns to the right. The `offset` property 
   mdxSource={{
     react: `
       <PdsBox direction="column" fit>
-        <PdsRow>
-          <PdsBox border size="4">Item 1</PdsBox>
-          <PdsBox border offset="4" size="4">Item 2</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox size="4">
+            <PdsBox border>Item 1</PdsBox>
+          </PdsBox>
+          <PdsBox offset="4" size="4">
+            <PdsBox border>Item 2</PdsBox>
+          </PdsBox>
         </PdsRow>
-        <PdsRow>
-          <PdsBox border sizeMd="4">Item 1</PdsBox>
-          <PdsBox border offsetMd="4" sizeMd="4">Item 2</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox sizeMd="4">
+            <PdsBox border>Item 1</PdsBox>
+          </PdsBox>
+          <PdsBox offsetMd="4" sizeMd="4">
+            <PdsBox border>Item 2</PdsBox>
+          </PdsBox>
         </PdsRow>
-        <PdsRow>
-          <PdsBox border offset="3" offsetXs="2" size="6" sizeXs="8">Item 1</PdsBox>
+        <PdsRow col-gap="sm">
+          <PdsBox offset="3" offsetXs="2" size="6" sizeXs="8">
+            <PdsBox border>Item 1</PdsBox>
+          </PdsBox>
         </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box direction="column" fit>
-        <pds-row>
-          <pds-box border size="4">Item 1</pds-box>
-          <pds-box border offset="4" size="4">Item 2</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size="4">
+            <pds-box border>Item 1</pds-box>
+          </pds-box>
+          <pds-box offset="4" size="4">
+            <pds-box border>Item 2</pds-box>
+          </pds-box>
         </pds-row>
-        <pds-row>
-          <pds-box border size-md="4">Item 1</pds-box>
-          <pds-box border offset-md="4" size-md="4">Item 2</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box size-md="4">
+            <pds-box border>Item 1</pds-box>
+          </pds-box>
+          <pds-box offset-md="4" size-md="4">
+            <pds-box border>Item 2</pds-box>
+          </pds-box>
         </pds-row>
-        <pds-row>
-          <pds-box border offset="3" offset-xs="2" size="6" size-xs="8">Item 1</pds-box>
+        <pds-row col-gap="sm">
+          <pds-box offset="3" offset-xs="2" size="6" size-xs="8">
+            <pds-box border>Item 1</pds-box>
+          </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box direction="column" fit>
     <pds-row>
-      <pds-box border size="4">Item 1</pds-box>
-      <pds-box border offset="4" size="4">Item 2</pds-box>
+      <pds-box size="4">
+        <pds-box border>Item 1</pds-box>
+      </pds-box>
+      <pds-box offset="4" size="4">
+        <pds-box border>Item 2</pds-box>
+      </pds-box>
     </pds-row>
     <pds-row>
-      <pds-box border size-md="4">Item 1</pds-box>
-      <pds-box border offset-md="4" size-md="4">Item 2</pds-box>
+      <pds-box size-md="4">
+        <pds-box border>Item 1</pds-box>
+      </pds-box>
+      <pds-box offset-md="4" size-md="4">
+        <pds-box border>Item 2</pds-box>
+      </pds-box>
     </pds-row>
     <pds-row>
       <pds-box border offset="3" offset-xs="2" size="6" size-xs="8">Item 1</pds-box>
@@ -802,33 +906,38 @@ Adding either `flex` **`display`** property to the box will initiate alignment v
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <PdsRow minHeight="100px">
-          <PdsBox
-            alignItems="start"
-            border="true"
-            display="flex"
-            justifyContent="center"
-            minHeight="200px"
-            padding="sm"
-          >
+        <PdsRow minHeight="100px" colGap="sm">
+          <PdsBox size="2">
+            <PdsBox
+              align-items="start"
+              border="true"
+              display="flex"
+              justify-content="center"
+              min-height="200px"
+              padding="sm"
+            >
             Content 1
+            </PdsBox>
           </PdsBox>
-          <PdsBox
-            alignItems="center"
-            border="true"
-            display="flex"
-            justifyContent="center"
-            padding="sm"
-          >
+          <PdsBox>
+            <PdsBox
+              alignItems="center"
+              border="true"
+              display="flex"
+              justifyContent="center"
+              padding="sm"
+            >
             Content2
+            </PdsBox>
           </PdsBox>
-          <PdsBox
-            alignItems="end"
-            border="true"
-            display="flex"
-            justifyContent="end"
-            padding="sm"
-          >
+          <PdsBox>
+            <PdsBox
+              alignItems="end"
+              border="true"
+              display="flex"
+              justifyContent="end"
+              padding="sm"
+            >
             Content 3
           </PdsBox>
         </PdsRow>
@@ -836,63 +945,69 @@ Adding either `flex` **`display`** property to the box will initiate alignment v
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row min-height="100px">
-          <pds-box
-            align-items="start"
-            border="true"
-            display="flex"
-            justify-content="center"
-            min-height="200px"
-            padding="sm"
-          >
-            Content 1
+        <pds-row min-height="100px" col-gap="sm">
+          <pds-box size="2">
+            <pds-box
+              align-items="start"
+              border="true"
+              display="flex"
+              justify-content="center"
+              min-height="200px"
+              padding="sm"
+            >Content 1</pds-box>
           </pds-box>
-          <pds-box
-            align-items="center"
-            border="true"
-            display="flex"
-            justify-content="center"
-            padding="sm"
-          >
-            Content2
+          <pds-box>
+            <pds-box
+              align-items="center"
+              border="true"
+              display="flex"
+              justify-content="center"
+              padding="sm"
+            >Content2</pds-box>
           </pds-box>
-          <pds-box
-            align-items="end"
-            border="true"
-            display="flex"
-            justify-content="end"
-            padding="sm"
-          >
-            Content 3
+          <pds-box>
+            <pds-box
+              align-items="end"
+              border="true"
+              display="flex"
+              justify-content="end"
+              padding="sm"
+            >Content 3</pds-box>
           </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box display="block">
-    <pds-row min-height="100px">
-      <pds-box
-        align-items="start"
-        border="true"
-        display="flex"
-        justify-content="center"
-        min-height="200px"
-        padding="sm"
-      >Content 1</pds-box>
-      <pds-box
-        align-items="center"
-        border="true"
-        display="flex"
-        justify-content="center"
-        padding="sm"
-      >Content2</pds-box>
-      <pds-box
-        align-items="end"
-        border="true"
-        display="flex"
-        justify-content="end"
-        padding="sm"
-      >Content 3</pds-box>
+    <pds-row min-height="100px" col-gap="sm">
+      <pds-box size="2">
+        <pds-box
+          align-items="start"
+          border="true"
+          display="flex"
+          justify-content="center"
+          min-height="200px"
+          padding="sm"
+        >Content 1</pds-box>
+      </pds-box>
+      <pds-box>
+        <pds-box
+          align-items="center"
+          border="true"
+          display="flex"
+          justify-content="center"
+          padding="sm"
+        >Content2</pds-box>
+      </pds-box>
+      <pds-box>
+        <pds-box
+          align-items="end"
+          border="true"
+          display="flex"
+          justify-content="end"
+          padding="sm"
+        >Content 3</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -903,32 +1018,35 @@ Note - using **`min-height`** on the `Box` or the parent `Row` is recommended to
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <PdsRow>
-          <PdsBox
-            alignItems="start"
-            border="true"
-            display="flex"
-            justifyContent="center"
-            padding="sm"
-          >
+        <PdsRow col-gap="sm">
+          <PdsBox size="2">
+            <PdsBox
+              alignItems="start"
+              border="true"
+              display="flex"
+              justifyContent="start"
+              padding="sm"
+            >
             Content 1
           </PdsBox>
-          <PdsBox
-            alignItems="center"
-            border="true"
-            display="flex"
-            justifyContent="center"
-            padding="sm"
-          >
+          <PdsBox>
+            <PdsBox
+              alignItems="center"
+              border="true"
+              display="flex"
+              justifyContent="center"
+              padding="sm"
+            >
             Content2
           </PdsBox>
-          <PdsBox
-            alignItems="end"
-            border="true"
-            display="flex"
-            justifyContent="end"
-            padding="sm"
-          >
+          <PdsBox size="2">
+            <PdsBox
+              alignItems="end"
+              border="true"
+              display="flex"
+              justifyContent="end"
+              padding="sm"
+            >
             Content 3
           </PdsBox>
         </PdsRow>
@@ -936,61 +1054,67 @@ Note - using **`min-height`** on the `Box` or the parent `Row` is recommended to
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box
-            align-items="start"
-            border="true"
-            display="flex"
-            justify-content="center"
-            padding="sm"
-          >
-            Content 1
+        <pds-row col-gap="sm">
+          <pds-box size="2">
+            <pds-box
+              align-items="start"
+              border="true"
+              display="flex"
+              justify-content="start"
+              padding="sm"
+            >Content 1</pds-box>
           </pds-box>
-          <pds-box
-            align-items="center"
-            border="true"
-            display="flex"
-            justify-content="center"
-            padding="sm"
-          >
-            Content2
+          <pds-box>
+            <pds-box
+              align-items="center"
+              border="true"
+              display="flex"
+              justify-content="center"
+              padding="sm"
+            >Content2</pds-box>
           </pds-box>
-          <pds-box
-            align-items="end"
-            border="true"
-            display="flex"
-            justify-content="end"
-            padding="sm"
-          >
-            Content 3
+          <pds-box size="2">
+            <pds-box
+              align-items="end"
+              border="true"
+              display="flex"
+              justify-content="end"
+              padding="sm"
+            >Content 3</pds-box>
           </pds-box>
         </pds-row>
       </pds-box>
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box
-        align-items="start"
-        border="true"
-        display="flex"
-        justify-content="center"
-        padding="sm"
-      >Content 1</pds-box>
-      <pds-box
-        align-items="center"
-        border="true"
-        display="flex"
-        justify-content="center"
-        padding="sm"
-      >Content2</pds-box>
-      <pds-box
-        align-items="end"
-        border="true"
-        display="flex"
-        justify-content="end"
-        padding="sm"
-      >Content 3</pds-box>
+    <pds-row col-gap="sm">
+      <pds-box size="2">
+        <pds-box
+          align-items="start"
+          border="true"
+          display="flex"
+          justify-content="start"
+          padding="sm"
+        >Content 1</pds-box>
+      </pds-box>
+      <pds-box>
+        <pds-box
+          align-items="center"
+          border="true"
+          display="flex"
+          justify-content="center"
+          padding="sm"
+        >Content2</pds-box>
+      </pds-box>
+      <pds-box size="2">
+        <pds-box
+          align-items="end"
+          border="true"
+          display="flex"
+          justify-content="end"
+          padding="sm"
+        >Content 3</pds-box>
+      </pds-box>
     </pds-row>
   </pds-box>
 </DocCanvas>
@@ -1003,48 +1127,43 @@ You can nest `pds-row` and `pds-box` components to create more complex layouts.
   mdxSource={{
     react: `
       <PdsBox display="block">
-        <PdsRow>
-          <PdsBox border display="block" sizeMd="8">
-            <PdsRow>
-              <PdsBox sizeXl="6">Column 1 Item 1</PdsBox>
-              <PdsBox sizeXl="6">Column 1 Item 2</PdsBox>
-            <PpdsRow>
+        <PdsRow colGap="sm">
+          <PdsBox sizeMd="8">
+            <PdsBox border>
+              <PdsRow>
+                <PdsBox sizeXl="6">Column 1 Item 1</PdsBox>
+                <PdsBox sizeXl="6">Column 1 Item 2</PdsBox>
+              </PdsRow>
+            </PdsBox>
           </PdsBox>
           <PdsBox
-            border
-            display="flex"
             sizeMd="4"
           >
             <PdsBox
-              display="flex"
               alignItems="center"
+              border="true"
+              display="flex"
               justifyContent="center"
             >
               Column 2
             </PdsBox>
           </PdsBox>
-        <PpdsRow>
+        </PdsRow>
       </PdsBox>
     `,
     webComponent: `
       <pds-box display="block">
-        <pds-row>
-          <pds-box border display="block" size-md="8">
-            <pds-row>
-              <pds-box size-xl="6">Column 1 Item 1</pds-box>
-              <pds-box size-xl="6">Column 1 Item 2</pds-box>
-            </pds-row>
+        <pds-row col-gap="sm">
+          <pds-box size-md="8">
+            <pds-box border>
+              <pds-row>
+                <pds-box size-xl="6">Column 1 Item 1</pds-box>
+                <pds-box size-xl="6">Column 1 Item 2</pds-box>
+              </pds-row>
+            </pds-box>
           </pds-box>
-          <pds-box
-            border
-            display="flex"
-            size-md="4"
-          >
-            <pds-box
-              display="flex"
-              align-items="center"
-              justify-content="center"
-            >
+          <pds-box size-md="4">
+            <pds-box border display="flex" align-items="center" justify-content="center">
               Column 2
             </pds-box>
           </pds-box>
@@ -1053,19 +1172,19 @@ You can nest `pds-row` and `pds-box` components to create more complex layouts.
     `
 }}>
   <pds-box display="block">
-    <pds-row>
-      <pds-box border display="block" size-md="8">
-        <pds-row>
-          <pds-box size-xl="6">Column 1 Item 1</pds-box>
-          <pds-box size-xl="6">Column 1 Item 2</pds-box>
-        </pds-row>
+    <pds-row col-gap="sm">
+      <pds-box size-md="8">
+        <pds-box border>
+          <pds-row>
+            <pds-box size-xl="6">Column 1 Item 1</pds-box>
+            <pds-box size-xl="6">Column 1 Item 2</pds-box>
+          </pds-row>
+        </pds-box>
       </pds-box>
-      <pds-box
-        border
-        display="flex"
-        size-md="4"
-      >
-        <pds-box display="flex" align-items="center" justify-content="center">Column 2</pds-box>
+      <pds-box size-md="4">
+        <pds-box border display="flex" align-items="center" justify-content="center">
+          Column 2
+        </pds-box>
       </pds-box>
     </pds-row>
   </pds-box>

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -38,6 +38,15 @@ The `pds-row` component defines a horizontal container for multiple columns (`pd
 - It ensures that the total column size per row does not exceed 12, maintaining the integrity of the grid system.
 
 
+## Quick Reference for LLMs
+
+> **🤖 AI/LLM Quick Rules:**
+> 1. **Flex props ONLY work inside `pds-box` parent** - NOT inside `pds-row`
+> 2. **Inside `pds-row`**: Use `size` props (1-12) for column width
+> 3. **Inside `pds-box`**: Use `flex` props for flexible sizing
+> 4. **For spacing**: Use `col-gap` on `pds-row`, `gap` on `pds-box`
+> 5. **Common mistake**: `<pds-row><pds-box flex="grow">` ❌ | `<pds-box><pds-box flex="grow">` ✅
+
 ## Best Practices for Layouts
 
 Use `pds-box` for Single-Column Layouts:

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -37,16 +37,6 @@ The `pds-row` component defines a horizontal container for multiple columns (`pd
 - `pds-row` supports responsive design with properties like `size-xs` or `offset-md`. The size modifier is the trigger for responsive behavior.
 - It ensures that the total column size per row does not exceed 12, maintaining the integrity of the grid system.
 
-
-## Quick Reference for LLMs
-
-> **🤖 AI/LLM Quick Rules:**
-> 1. **Flex props ONLY work inside `pds-box` parent** - NOT inside `pds-row`
-> 2. **Inside `pds-row`**: Use `size` props (1-12) for column width
-> 3. **Inside `pds-box`**: Use `flex` props for flexible sizing
-> 4. **For spacing**: Use `col-gap` on `pds-row`, `gap` on `pds-box`
-> 5. **Common mistake**: `<pds-row><pds-box flex="grow">` ❌ | `<pds-box><pds-box flex="grow">` ✅
-
 ## Best Practices for Layouts
 
 Use `pds-box` for Single-Column Layouts:


### PR DESCRIPTION
# Description
This is a docs only change aimed at reducing confusion around around when a box should be horizontal or vertical in nested layouts

- [x] updated row examples include col-gap for consistent layout generation
- [x] update box mdx to contain box only layout details

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- Visit the box, row, and layout docs pages

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
