### PR TITLE
fix(pds-button): add button link to full width rule

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -21,6 +21,7 @@
   display: flex;
   width: 100%;
 
+  a,
   button {
     justify-content: center;
     width: 100%;


### PR DESCRIPTION
# Description

`full-width` not working when `pds-button` has a `href`

- [x] add `a` to `full-width` rule

| Before | After |
|--------|--------|
|<img width="342" height="169" alt="Screenshot 2025-08-13 at 1 08 09 PM" src="https://github.com/user-attachments/assets/ddd24147-a25f-472a-bdf3-86071a794ab3" />|<img width="902" height="153" alt="Screenshot 2025-08-13 at 1 07 39 PM" src="https://github.com/user-attachments/assets/d0441bf7-f048-4508-9feb-da46d479d872" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
