### PR TITLE
docs: update boolean attribute handling across components

### DIFF
--- a/libs/core/src/components/pds-accordion/stories/pds-accordion.stories.js
+++ b/libs/core/src/components/pds-accordion/stories/pds-accordion.stories.js
@@ -12,7 +12,7 @@ export default {
 }
 
 const BaseTemplate = (args) => html`
-	<pds-accordion component-id="${args.componentId}" open="${args.isOpen}">
+	<pds-accordion component-id="${args.componentId}" ?open=${args.isOpen}>
     <pds-box align-items="center" slot="label">
       <pds-icon name="product"></pds-icon>
       <span style="display: inline-block; margin-left: 8px;">Products</span>

--- a/libs/core/src/components/pds-alert/stories/pds-alert.stories.js
+++ b/libs/core/src/components/pds-alert/stories/pds-alert.stories.js
@@ -18,16 +18,16 @@ const BaseTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  small="${args.small}"
-  dismissible="${args.dismissible}"
+  ?small=${args.small}
+  ?dismissible=${args.dismissible}
 >${args.description}</pds-alert>`;
 
 const ActionsTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  small="${args.small}"
-  dismissible="${args.dismissible}"
+  ?small=${args.small}
+  ?dismissible=${args.dismissible}
 >
   ${args.description}
   <pds-button slot="actions" variant="primary">Button</pds-button>
@@ -38,8 +38,8 @@ const SmallActionsTemplate = (args) => html` <pds-alert
   component-id="${args.componentId}"
   variant="${args.variant}"
   heading="${args.heading}"
-  small="${args.small}"
-  dismissible="${args.dismissible}"
+  ?small=${args.small}
+  ?dismissible=${args.dismissible}
 >
   ${args.description}
   <pds-link slot="actions" variant="plain" href="#">Link</pds-link>

--- a/libs/core/src/components/pds-box/stories/pds-box.stories.js
+++ b/libs/core/src/components/pds-box/stories/pds-box.stories.js
@@ -16,7 +16,7 @@ const BaseTemplate = (args) => html`
   align-self="${args.alignSelf}"
   auto="${args.auto}"
   background-color="${args.backgroundColor}"
-	border="${args.border}"
+	?border=${args.border}
   border-color="${args.borderColor}"
 	border-radius="${args.borderRadius}"
   direction="${args.direction}"

--- a/libs/core/src/components/pds-button/stories/pds-button.stories.js
+++ b/libs/core/src/components/pds-button/stories/pds-button.stories.js
@@ -18,12 +18,12 @@ export default {
 const BaseTemplate = (args) => html`
   <pds-button
     component-id=${args.componentId}
-    disabled=${args.disabled}
-    full-width=${args.fullWidth}
+    ?disabled=${args.disabled}
+    ?full-width=${args.fullWidth}
     href=${args.href}
-    icon-only=${args.iconOnly}
+    ?icon-only=${args.iconOnly}
     icon=${args.icon}
-    loading=${args.loading}
+    ?loading=${args.loading}
     name=${args.name}
     target=${args.target}
     type=${args.type}

--- a/libs/core/src/components/pds-checkbox/stories/pds-checkbox.stories.js
+++ b/libs/core/src/components/pds-checkbox/stories/pds-checkbox.stories.js
@@ -25,16 +25,16 @@ export default {
 const BaseTemplate = (args) =>
   html` <pds-checkbox
     component-id=${args.componentId}
-    checked=${args.checked}
-    disabled=${args.disabled}
+    ?checked=${args.checked}
+    ?disabled=${args.disabled}
     error-message=${args.errorMessage}
     helper-message=${args.helperMessage}
-    hide-label=${args.hideLabel}
-    indeterminate=${args.indeterminate}
-    invalid=${args.invalid}
+    ?hide-label=${args.hideLabel}
+    ?indeterminate=${args.indeterminate}
+    ?invalid=${args.invalid}
     label=${args.label}
     name=${args.name}
-    required=${args.required}
+    ?required=${args.required}
     value=${args.value}
   />`;
 

--- a/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
+++ b/libs/core/src/components/pds-chip/stories/pds-chip.stories.js
@@ -17,9 +17,9 @@ export default {
 const BaseTemplate = (args) => html`
 <pds-chip
   component-id="${args.componentId}"
-  dot="${args.dot}"
+  ?dot=${args.dot}
   icon="${args.icon}"
-  large="${args.large}"
+  ?large=${args.large}
   sentiment="${args.sentiment}"
   variant="${args.variant}"
 >

--- a/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
+++ b/libs/core/src/components/pds-copytext/stories/pds-copytext.stories.js
@@ -16,11 +16,11 @@ export default {
 
 const BaseTemplate = (args) => html`
   <pds-copytext
-    border="${args.border}"
-    full-width="${args.fullWidth}"
+    ?border=${args.border}
+    ?full-width=${args.fullWidth}
     component-id=${args.componentId}
     onClick=${args.onClick}
-    truncate="${args.truncate}"
+    ?truncate=${args.truncate}
     value="${args.value}">
   </pds-copytext>`;
 

--- a/libs/core/src/components/pds-image/stories/pds-image.stories.js
+++ b/libs/core/src/components/pds-image/stories/pds-image.stories.js
@@ -11,7 +11,7 @@ const BaseTemplate = (args) => html` <pds-image
   alt="${args.alt}"
   height="${args.height}"
   component-id="${args.componentId}"
-  loading="${args.loading}"
+  ?loading=${args.loading}
   sizes="${args.sizes}"
   src="${args.src}"
   srcset="${args.srcset}"

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -42,16 +42,16 @@ const BaseTemplate = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="${args.componentId}"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
-  full-width="${args.fullWidth}"
+  ?full-width=${args.fullWidth}
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="${args.label}"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="${args.type}"
   value="${args.value}">
   ${args.prefix || ''}
@@ -151,15 +151,15 @@ export const withPrefixIcon = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-prefix-icon"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Email"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="email"
   value="${args.value}">
   <pds-icon slot="prefix" name="mail" size="small"></pds-icon>
@@ -169,15 +169,15 @@ export const withSuffixButton = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-suffix-button"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Search"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="text"
   value="${args.value}">
   <pds-button slot="suffix" variant="unstyled" class="pds-input__suffix">
@@ -189,15 +189,15 @@ export const withPrependSelect = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-prepend-select"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Amount"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="text"
   value="${args.value}">
   <pds-select hide-label label="Currency" slot="prepend" class="pds-input__prepend" name="currency">
@@ -211,15 +211,15 @@ export const withAppendSelect = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-append-select"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Phone"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="tel"
   value="${args.value}">
   <pds-select hide-label slot="append" class="pds-input__append" name="phone-type">
@@ -233,15 +233,15 @@ export const withPrefixAndAppend = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-prefix-append"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Amount"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="text"
   value="${args.value}">
   <pds-icon slot="prefix" name="dollar" size="small"></pds-icon>
@@ -256,15 +256,15 @@ export const withPrependAndSuffix = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-prepend-suffix"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Amount"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="text"
   value="${args.value}">
   <pds-select hide-label slot="prepend" class="pds-input__prepend" name="currency">
@@ -281,15 +281,15 @@ export const withActionLink = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-action-link"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Password"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="true"
+  ?readonly=${args.readonly}
+  required
   type="password"
   value="${args.value}">
   <pds-link href="#" slot="action">
@@ -301,15 +301,15 @@ export const withActionButton = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-action-button"
   debounce="${args.debounce}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="Choose a unique username"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Username"
   name="${args.name}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   type="text"
   value="${args.value}">
   <pds-button slot="action" variant="unstyled">

--- a/libs/core/src/components/pds-link/stories/pds-link.stories.js
+++ b/libs/core/src/components/pds-link/stories/pds-link.stories.js
@@ -14,8 +14,8 @@ export default {
   title: 'components/Link'
 }
 
-const BaseTemplate = (args) => html`<pds-link color=${args.color} external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}></pds-link>`;
-const BaseTemplateWithSlot = (args) => html` <pds-link color=${args.color} external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}>${args.slot}</pds-link>`;
+const BaseTemplate = (args) => html`<pds-link color=${args.color} ?external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}></pds-link>`;
+const BaseTemplateWithSlot = (args) => html` <pds-link color=${args.color} ?external=${args.external} font-size=${args.fontSize} href=${args.href} component-id=${args.componentId} variant=${args.variant}>${args.slot}</pds-link>`;
 
 export const Colors = BaseTemplate.bind();
 Colors.args = {

--- a/libs/core/src/components/pds-loader/stories/pds-loader.stories.js
+++ b/libs/core/src/components/pds-loader/stories/pds-loader.stories.js
@@ -13,8 +13,8 @@ export default {
 
 const BaseTemplate = (args) => html`
   <pds-loader
-    is-loading="${args.isLoading}"
-    show-label="${args.showLabel}"
+    ?is-loading=${args.isLoading}
+    ?show-label=${args.showLabel}
     size="${args.size}"
     variant="${args.variant}"
   >

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -30,8 +30,8 @@ const BaseTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?backdrop-dismiss="${args.backdropDismiss}"
-      ?open="${args.open}"
+      ?backdrop-dismiss=${args.backdropDismiss}
+      ?open=${args.open}
     >
       <pds-modal-header>
         <pds-box direction="column" fit padding="md">
@@ -100,8 +100,8 @@ const DestructiveTemplate = (args) => html`
       id="${args.componentId}"
       component-id="${args.componentId}"
       size="${args.size}"
-      ?backdrop-dismiss="${args.backdropDismiss}"
-      ?open="${args.open}"
+      ?backdrop-dismiss=${args.backdropDismiss}
+      ?open=${args.open}
     >
       <pds-modal-header>
         <pds-box direction="column" fit padding="md">
@@ -166,8 +166,8 @@ const CustomContentTemplate = (args) => html`
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?backdrop-dismiss="${args.backdropDismiss}"
-        ?open="${args.open}"
+        ?backdrop-dismiss=${args.backdropDismiss}
+        ?open=${args.open}
       >
 
         <pds-modal-header>
@@ -254,8 +254,8 @@ const ScrollableTemplate = (args) => {
       <pds-modal
         id="${args.componentId}"
         size="${args.size}"
-        ?backdrop-dismiss="${args.backdropDismiss}"
-        ?open="${args.open}"
+        ?backdrop-dismiss=${args.backdropDismiss}
+        ?open=${args.open}
       >
         <pds-modal-header>
           <pds-box direction="column" fit padding="md">
@@ -338,7 +338,7 @@ const FullscreenTemplate = (args) => html`
       id="${args.componentId}"
       size=${args.size}
       ?backdrop-dismiss=${args.backdropDismiss}
-      ?open="${args.open}"
+      ?open=${args.open}
     >
       <pds-modal-header>
         <pds-box

--- a/libs/core/src/components/pds-progress/stories/pds-progress.stories.js
+++ b/libs/core/src/components/pds-progress/stories/pds-progress.stories.js
@@ -9,12 +9,12 @@ export default {
 
 const BaseTemplate = (args) =>
   html`<pds-progress
-    animated=${args.animated}
+    ?animated=${args.animated}
     component-id=${args.componentId}
     fill-color=${args.fillColor}
     label=${args.label}
     percent=${args.percent}
-    show-percent=${args.showPercent}
+    ?show-percent=${args.showPercent}
   ></pds-progress>`;
 
 

--- a/libs/core/src/components/pds-radio/stories/pds-radio.stories.js
+++ b/libs/core/src/components/pds-radio/stories/pds-radio.stories.js
@@ -25,16 +25,16 @@ const BaseTemplate = (args) =>
   html` <pds-radio
     component-id=${args.componentId}
     label=${args.label}
-    checked=${args.checked}
-    disabled=${args.disabled}
+    ?checked=${args.checked}
+    ?disabled=${args.disabled}
     error-message=${args.errorMessage}
     helper-message=${args.helperMessage}
-    hide-label=${args.hideLabel}
+    ?hide-label=${args.hideLabel}
     name=${args.name}
-    indeterminate=${args.indeterminate}
-    required=${args.required}
+    ?indeterminate=${args.indeterminate}
+    ?required=${args.required}
     value=${args.value}
-    invalid=${args.invalid}
+    ?invalid=${args.invalid}
   />`;
 
 export const Default = BaseTemplate.bind();

--- a/libs/core/src/components/pds-row/stories/pds-row.stories.js
+++ b/libs/core/src/components/pds-row/stories/pds-row.stories.js
@@ -10,6 +10,7 @@ export default {
 const BaseTemplate = (args) => html`
 <pds-row
   align-items="${args.alignItems}"
+  ?border=${args.border}
   component-id="${args.componentId}"
   col-gap="${args.colGap}"
   justify-content="${args.justifyContent}"
@@ -30,7 +31,7 @@ const BaseTemplate = (args) => html`
 
 export const Default = BaseTemplate.bind();
 Default.args = {
-  border: "true",
+  border: true,
   componentId: 'opt0',
   colGap: '8px',
 };
@@ -38,7 +39,7 @@ Default.args = {
 const GapTemplate = (args) => html`
 <pds-row
   align-items="${args.alignItems}"
-  border="${args.border}"
+  ?border=${args.border}
   component-id="${args.componentId}"
   col-gap="${args.colGap}"
   justify-content="${args.justifyContent}"
@@ -70,7 +71,7 @@ const GapTemplate = (args) => html`
 
 export const Gap = GapTemplate.bind();
 Gap.args = {
-  border: "false",
+  border: false,
   componentId: 'opt0',
   colGap: 'sm',
 };

--- a/libs/core/src/components/pds-select/stories/pds-select.stories.js
+++ b/libs/core/src/components/pds-select/stories/pds-select.stories.js
@@ -50,15 +50,15 @@ const BaseTemplate = (args) =>
   html`<pds-select
     autocomplete="${args.autocomplete}"
     component-id="${args.componentId}"
-    disabled="${args.disabled}"
+    ?disabled=${args.disabled}
     error-message="${args.errorMessage}"
     helper-message="${args.helperMessage}"
-    hide-label="${args.hideLabel}"
-    invalid="${args.invalid}"
+    ?hide-label=${args.hideLabel}
+    ?invalid=${args.invalid}
     label="${args.label}"
-    multiple="${args.multiple}"
+    ?multiple=${args.multiple}
     name="${args.name}"
-    required="${args.required}"
+    ?required=${args.required}
     type="${args.type}"
     value="${args.value}"
   >
@@ -70,14 +70,14 @@ const OptgroupTemplate = (args) =>
   html`<pds-select
     autocomplete="${args.autocomplete}"
     component-id="${args.componentId}"
-    disabled="${args.disabled}"
+    ?disabled=${args.disabled}
     error-message="${args.errorMessage}"
     helper-message="${args.helperMessage}"
-    invalid="${args.invalid}"
+    ?invalid=${args.invalid}
     label="${args.label}"
-    multiple="${args.multiple}"
+    ?multiple=${args.multiple}
     name="${args.name}"
-    required="${args.required}"
+    ?required=${args.required}
     type="${args.type}"
     value="${args.value}"
   >
@@ -159,15 +159,15 @@ WithOptgroup.args = {
 export const withActionLink = (args) => html`<pds-select
   autocomplete="${args.autocomplete}"
   component-id="pds-select-action-link"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  hide-label="${args.hideLabel}"
-  invalid="${args.invalid}"
+  ?hide-label=${args.hideLabel}
+  ?invalid=${args.invalid}
   label="Timezone"
-  multiple="${args.multiple}"
+  ?multiple=${args.multiple}
   name="timezone"
-  required="${args.required}"
+  ?required=${args.required}
   type="${args.type}"
   value="${args.value}">
   <pds-link href="#" slot="action">
@@ -179,15 +179,15 @@ export const withActionLink = (args) => html`<pds-select
 export const withActionButton = (args) => html`<pds-select
   autocomplete="${args.autocomplete}"
   component-id="pds-select-action-button"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  hide-label="${args.hideLabel}"
-  invalid="${args.invalid}"
+  ?hide-label=${args.hideLabel}
+  ?invalid=${args.invalid}
   label="Country"
-  multiple="${args.multiple}"
+  ?multiple=${args.multiple}
   name="country"
-  required="${args.required}"
+  ?required=${args.required}
   type="${args.type}"
   value="${args.value}">
   <pds-button slot="action" variant="unstyled">

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
@@ -15,21 +15,21 @@ export default {
 };
 
 const BaseTemplate = (args) => html`
-<pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item>Item 1</pds-sortable-item>
   <pds-sortable-item>Item 2</pds-sortable-item>
   <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>`;
 
 const HandleTemplate = (args) => html`
-<pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item>Item 1</pds-sortable-item>
   <pds-sortable-item>Item 2</pds-sortable-item>
   <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>`;
 
 const ActionsTemplate = (args) => html`
-<pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item enable-actions>
     <div>Item 1</div>
     <div slot="sortable-item-actions">
@@ -51,7 +51,7 @@ const ActionsTemplate = (args) => html`
 </pds-sortable>`;
 
 const FullDemoTemplate = (args) => html`
-<pds-sortable border="${args.border}" component-id="${args.componentId}" dividers="${args.dividers}" handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 1</strong></div>

--- a/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
+++ b/libs/core/src/components/pds-switch/stories/pds-switch.stories.js
@@ -21,17 +21,17 @@ export default {
 
 const BaseTemplate = (args) => html`
   <pds-switch
-    checked=${args.checked}
+    ?checked=${args.checked}
     component-id=${args.componentId}
-    disabled=${args.disabled}
+    ?disabled=${args.disabled}
     error-message=${args.errorMessage}
     helper-message=${args.helperMessage}
-    invalid=${args.invalid}
+    ?invalid=${args.invalid}
     label=${args.label}
-    hide-label=${args.hideLabel}
+    ?hide-label=${args.hideLabel}
     name=${args.name}
     onChange=${args.onChange}
-    required=${args.required}
+    ?required=${args.required}
     type=${args.type}
   />
 `;

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -16,11 +16,11 @@ export default {
 
 const BaseTemplate = (args) => html`
 <pds-table
-  compact="${args.compact}"
+  ?compact=${args.compact}
   component-id="${args.componentId}"
-  fixed-column="${args.fixedColumn}"
-  responsive="${args.responsive}"
-  selectable="${args.selectable}"
+  ?fixed-column=${args.fixedColumn}
+  ?responsive=${args.responsive}
+  ?selectable=${args.selectable}
 >
   <pds-table-head>
     <pds-table-head-cell>Column Title</pds-table-head-cell>
@@ -48,11 +48,11 @@ const BaseTemplate = (args) => html`
 
 const ResponsiveTemplate = (args) => html`
 <pds-table
-  compact="${args.compact}"
+  ?compact=${args.compact}
   component-id="${args.componentId}"
-  fixed-column="${args.fixedColumn}"
-  responsive="${args.responsive}"
-  selectable="${args.selectable}"
+  ?fixed-column=${args.fixedColumn}
+  ?responsive=${args.responsive}
+  ?selectable=${args.selectable}
 >
   <pds-table-head>
     <pds-table-head-cell>Column Title</pds-table-head-cell>
@@ -116,11 +116,11 @@ const ResponsiveTemplate = (args) => html`
 
 const SortableTemplate = (args) => html`
 <pds-table
-  compact="${args.compact}"
+  ?compact=${args.compact}
   component-id="${args.componentId}"
-  fixed-column="${args.fixedColumn}"
-  responsive="${args.responsive}"
-  selectable="${args.selectable}"
+  ?fixed-column=${args.fixedColumn}
+  ?responsive=${args.responsive}
+  ?selectable=${args.selectable}
 >
   <pds-table-head>
     <pds-table-head-cell sortable=${args.sortable}>Name</pds-table-head-cell>

--- a/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
+++ b/libs/core/src/components/pds-textarea/stories/pds-textarea.stories.js
@@ -37,18 +37,18 @@ export default {
 
 const BaseTemplate = (args) => html`<pds-textarea
   autocomplete="${args.autocomplete}"
-  clear-on-edit="${args.clearOnEdit}"
+  ?clear-on-edit=${args.clearOnEdit}
   component-id="${args.componentId}"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="${args.label}"
   name="${args.name}"
   onChange="${args.onChange}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   rows="${args.rows}"
   value="${args.value}"
   data-tooltip-id="foo"
@@ -134,18 +134,18 @@ Autocomplete.args = {
 
 export const withActionLink = (args) => html`<pds-textarea
   autocomplete="${args.autocomplete}"
-  clear-on-edit="${args.clearOnEdit}"
+  ?clear-on-edit=${args.clearOnEdit}
   component-id="pds-textarea-action-link"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Notes"
   name="${args.name}"
   onChange="${args.onChange}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   rows="3"
   value="${args.value}"
   data-tooltip-id="foo"
@@ -157,18 +157,18 @@ export const withActionLink = (args) => html`<pds-textarea
 
 export const withActionButton = (args) => html`<pds-textarea
   autocomplete="${args.autocomplete}"
-  clear-on-edit="${args.clearOnEdit}"
+  ?clear-on-edit=${args.clearOnEdit}
   component-id="pds-textarea-action-button"
-  disabled="${args.disabled}"
+  ?disabled=${args.disabled}
   error-message="${args.errorMessage}"
   helper-message="${args.helperMessage}"
-  invalid="${args.invalid}"
+  ?invalid=${args.invalid}
   label="Description"
   name="${args.name}"
   onChange="${args.onChange}"
   placeholder="${args.placeholder}"
-  readonly="${args.readonly}"
-  required="${args.required}"
+  ?readonly=${args.readonly}
+  ?required=${args.required}
   rows="4"
   value="${args.value}"
   data-tooltip-id="foo"

--- a/libs/core/src/components/pds-toast/stories/pds-toast.stories.js
+++ b/libs/core/src/components/pds-toast/stories/pds-toast.stories.js
@@ -18,7 +18,7 @@ export default {
 
 const BaseTemplate = (args) => html`
 <pds-toast
-  .dismissible="${args.dismissible}"
+  ?dismissible=${args.dismissible}
   component-id="${args.componentId}"
   duration="${args.duration}"
   icon="${args.icon || ''}"
@@ -29,7 +29,7 @@ const BaseTemplate = (args) => html`
 
 const WithLinkTemplate = (args) => html`
 <pds-toast
-  .dismissible="${args.dismissible}"
+  ?dismissible=${args.dismissible}
   component-id="${args.componentId}"
   duration="${args.duration}"
   icon="${args.icon || ''}"

--- a/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
+++ b/libs/core/src/components/pds-tooltip/stories/pds-tooltip.stories.js
@@ -15,10 +15,10 @@ export default {
 }
 
 const BaseTemplate = (args) => html`
-  <pds-tooltip content=${args.content} max-width=${args.maxWidth} has-arrow=${args.hasArrow} placement=${args.placement} opened=${args.opened}>${args.slot}</pds-tooltip>`;
+  <pds-tooltip content=${args.content} max-width=${args.maxWidth} ?has-arrow=${args.hasArrow} placement=${args.placement} ?opened=${args.opened}>${args.slot}</pds-tooltip>`;
 
 const HTMLContentTemplate = (args) => html`
-  <pds-tooltip has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement=${args.placement} html-content=${args.htmlContent} opened=${args.opened}>
+  <pds-tooltip ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement=${args.placement} ?html-content=${args.htmlContent} ?opened=${args.opened}>
     <div slot="content">
       <p><strong>This is a tooltip</strong></p>
       <p>Tooltips are used to describe or identify an element. In most scenarios, tooltips help the user understand the meaning, function or alt-text of an element.</p>
@@ -30,46 +30,46 @@ const PositionTemplate = (args) => html`
   <div class="demo-container" style="min-height: 50vh; width: 100%; display: flex; align-items: center; justify-content: center;">
     <div class="position-demo-grid">
       <div class="position-demo-grid-item">
-        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-start" opened=${args.opened}>
+        <pds-tooltip content="content 2" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-start" ?opened=${args.opened}>
           <pds-button variant="accent">t</pds-button>
         </pds-tooltip>
-        <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top" opened=${args.opened}>
+        <pds-tooltip content="content 2" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top" ?opened=${args.opened}>
           <pds-button variant="accent">t</pds-button>
         </pds-tooltip>
-        <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-end" opened=${args.opened}>
+        <pds-tooltip content="content 3" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="top-end" ?opened=${args.opened}>
           <pds-button variant="accent">te</pds-button>
         </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-start" ?opened=${args.opened}>
             <pds-button variant="accent">ls</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left" opened=${args.opened}>
+          <pds-tooltip content="content 2" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left" ?opened=${args.opened}>
             <pds-button variant="accent">l</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="left-end" ?opened=${args.opened}>
             <pds-button variant="accent">le</pds-button>
           </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-start" ?opened=${args.opened}>
             <pds-button variant="accent">bs</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom" opened=${args.opened}>
+          <pds-tooltip content="content 2" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom" ?opened=${args.opened}>
             <pds-button variant="accent">b</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="bottom-end" ?opened=${args.opened}>
             <pds-button variant="accent">be</pds-button>
           </pds-tooltip>
         </div>
         <div class="position-demo-grid-item">
-          <pds-tooltip content="content 1" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-start" opened=${args.opened}>
+          <pds-tooltip content="content 1" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-start" ?opened=${args.opened}>
             <pds-button variant="accent">rs</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 2" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right" opened=${args.opened}>
+          <pds-tooltip content="content 2" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right" ?opened=${args.opened}>
             <pds-button variant="accent">r</pds-button>
           </pds-tooltip>
-          <pds-tooltip content="content 3" has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-end" opened=${args.opened}>
+          <pds-tooltip content="content 3" ?has-arrow=${args.hasArrow} max-width=${args.maxWidth} placement="right-end" ?opened=${args.opened}>
             <pds-button variant="accent">re</pds-button>
           </pds-tooltip>
       </div>


### PR DESCRIPTION
# Description

Fixed incorrect boolean attribute binding in Storybook stories across all components. Boolean props were being rendered as strings (e.g., `disabled="false"`), causing attributes to always be truthy in HTML.

## Changes

- Updated all boolean attribute bindings from `attribute="${args.prop}"` to `?attribute=${args.prop}` using Lit's boolean attribute syntax
- Fixed mixed syntax issues (e.g., `?open="${args.open}"` → `?open=${args.open}`)
- Corrected string-based boolean args to proper boolean values in pds-row component

## Components Updated

**Critical fixes:** pds-input, pds-textarea, pds-select, pds-copytext, pds-image, pds-loader, pds-table, pds-alert, pds-chip, pds-accordion, pds-sortable, pds-toast, pds-modal

**Consistency improvements:** pds-button, pds-checkbox, pds-switch, pds-radio, pds-link, pds-tooltip, pds-progress, pds-box, pds-row

## Impact

- Boolean props now work correctly in Storybook (e.g., `disabled` prop actually disables components)
- Consistent boolean attribute handling across entire design system
- No breaking changes to component APIs

Fixes https://kajabi.atlassian.net/browse/DSS-1491

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
