### PR TITLE
feat(pds-table): add alignment for cell and head cells in component

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1131,6 +1131,10 @@ export namespace Components {
     }
     interface PdsTableCell {
         /**
+          * Sets the text alignment within the cell.
+         */
+        "cellAlign"?: 'start' | 'center' | 'end' | 'justify';
+        /**
           * Truncates content to a max width of 100px and adds an ellipsis.
          */
         "truncate": boolean;
@@ -1147,6 +1151,10 @@ export namespace Components {
         "isSelected": boolean;
     }
     interface PdsTableHeadCell {
+        /**
+          * Sets the text alignment within the head cell.
+         */
+        "cellAlign"?: 'start' | 'center' | 'end' | 'justify';
         /**
           * Determines whether the table column is sortable when set to `true`.
          */
@@ -3222,6 +3230,10 @@ declare namespace LocalJSX {
     }
     interface PdsTableCell {
         /**
+          * Sets the text alignment within the cell.
+         */
+        "cellAlign"?: 'start' | 'center' | 'end' | 'justify';
+        /**
           * Truncates content to a max width of 100px and adds an ellipsis.
          */
         "truncate"?: boolean;
@@ -3242,6 +3254,10 @@ declare namespace LocalJSX {
         "onPdsTableSelectAll"?: (event: PdsTableHeadCustomEvent<{ isSelected: boolean }>) => void;
     }
     interface PdsTableHeadCell {
+        /**
+          * Sets the text alignment within the head cell.
+         */
+        "cellAlign"?: 'start' | 'center' | 'end' | 'justify';
         /**
           * Event emitted to signal that a table column header has been sorted, providing information about the sorted column's name and sorting direction.
          */

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -932,6 +932,98 @@ When the `truncate` prop is set to `true` on a `pds-table-cell` element, the cel
   </pds-table>
 </DocCanvas>
 
+## Cell Alignment
+
+Text alignment can be controlled using the `cell-align` prop on both `pds-table-head-cell` and `pds-table-cell` elements. The available alignment options are `start`, `center`, `end`, and `justify`.
+
+<DocCanvas mdxSource={{
+  react: `<PdsTable componentId="alignment">
+  <PdsTableHead>
+    <PdsTableHeadCell cellAlign="start">Name</PdsTableHeadCell>
+    <PdsTableHeadCell cellAlign="center">Amount</PdsTableHeadCell>
+    <PdsTableHeadCell cellAlign="end">Status</PdsTableHeadCell>
+    <PdsTableHeadCell cellAlign="justify">Description</PdsTableHeadCell>
+  </PdsTableHead>
+  <PdsTableBody>
+    <PdsTableRow>
+      <PdsTableCell cellAlign="start">John Doe</PdsTableCell>
+      <PdsTableCell cellAlign="center">$1,234.56</PdsTableCell>
+      <PdsTableCell cellAlign="end">Active</PdsTableCell>
+      <PdsTableCell cellAlign="justify">This is a longer description that demonstrates justified text alignment in table cells. It shows how text wraps and aligns within the cell boundaries.</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell cellAlign="start">Jane Smith</PdsTableCell>
+      <PdsTableCell cellAlign="center">$987.65</PdsTableCell>
+      <PdsTableCell cellAlign="end">Inactive</PdsTableCell>
+      <PdsTableCell cellAlign="justify">Another example of justified text that spans multiple lines to show the alignment behavior in table cells with varying content lengths.</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell cellAlign="start">Michael Johnson</PdsTableCell>
+      <PdsTableCell cellAlign="center">$2,468.13</PdsTableCell>
+      <PdsTableCell cellAlign="end">Pending</PdsTableCell>
+      <PdsTableCell cellAlign="justify">Short justified text example.</PdsTableCell>
+    </PdsTableRow>
+  </PdsTableBody>
+</PdsTable>`,
+  webComponent: `<pds-table component-id="alignment">
+  <pds-table-head>
+    <pds-table-head-cell cell-align="start">Name</pds-table-head-cell>
+    <pds-table-head-cell cell-align="center">Amount</pds-table-head-cell>
+    <pds-table-head-cell cell-align="end">Status</pds-table-head-cell>
+    <pds-table-head-cell cell-align="justify">Description</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">John Doe</pds-table-cell>
+      <pds-table-cell cell-align="center">$1,234.56</pds-table-cell>
+      <pds-table-cell cell-align="end">Active</pds-table-cell>
+      <pds-table-cell cell-align="justify">This is a longer description that demonstrates justified text alignment in table cells. It shows how text wraps and aligns within the cell boundaries.</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">Jane Smith</pds-table-cell>
+      <pds-table-cell cell-align="center">$987.65</pds-table-cell>
+      <pds-table-cell cell-align="end">Inactive</pds-table-cell>
+      <pds-table-cell cell-align="justify">Another example of justified text that spans multiple lines to show the alignment behavior in table cells with varying content lengths.</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">Michael Johnson</pds-table-cell>
+      <pds-table-cell cell-align="center">$2,468.13</pds-table-cell>
+      <pds-table-cell cell-align="end">Pending</pds-table-cell>
+      <pds-table-cell cell-align="justify">Short justified text example.</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>
+`}}>
+  <pds-table component-id="alignment">
+    <pds-table-head>
+      <pds-table-head-cell cell-align="start">Name</pds-table-head-cell>
+      <pds-table-head-cell cell-align="center">Amount</pds-table-head-cell>
+      <pds-table-head-cell cell-align="end">Status</pds-table-head-cell>
+      <pds-table-head-cell cell-align="justify">Description</pds-table-head-cell>
+    </pds-table-head>
+    <pds-table-body>
+      <pds-table-row>
+        <pds-table-cell cell-align="start">John Doe</pds-table-cell>
+        <pds-table-cell cell-align="center">$1,234.56</pds-table-cell>
+        <pds-table-cell cell-align="end">Active</pds-table-cell>
+        <pds-table-cell cell-align="justify">This is a longer description that demonstrates justified text alignment in table cells. It shows how text wraps and aligns within the cell boundaries.</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell cell-align="start">Jane Smith</pds-table-cell>
+        <pds-table-cell cell-align="center">$987.65</pds-table-cell>
+        <pds-table-cell cell-align="end">Inactive</pds-table-cell>
+        <pds-table-cell cell-align="justify">Another example of justified text that spans multiple lines to show the alignment behavior in table cells with varying content lengths.</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell cell-align="start">Michael Johnson</pds-table-cell>
+        <pds-table-cell cell-align="center">$2,468.13</pds-table-cell>
+        <pds-table-cell cell-align="end">Pending</pds-table-cell>
+        <pds-table-cell cell-align="justify">Short justified text example.</pds-table-cell>
+      </pds-table-row>
+    </pds-table-body>
+  </pds-table>
+</DocCanvas>
+
 ## Sorting
 
 Basic sorting can be enabled by adding the `sortable` attribute to a `pds-table-head-cell` element. The table will automatically sort in ascending or descending order when the cell is clicked.

--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
@@ -40,3 +40,20 @@
   vertical-align: middle;
   width: 16px;
 }
+
+// Text Alignment
+:host(.pds-table-cell--align-start) {
+  text-align: start;
+}
+
+:host(.pds-table-cell--align-center) {
+  text-align: center;
+}
+
+:host(.pds-table-cell--align-end) {
+  text-align: end;
+}
+
+:host(.pds-table-cell--align-justify) {
+  text-align: justify;
+}

--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.tsx
@@ -20,6 +20,11 @@ export class PdsTableCell {
   }
 
   /**
+   * Sets the text alignment within the cell.
+   */
+  @Prop() cellAlign?: 'start' | 'center' | 'end' | 'justify';
+
+  /**
    * Truncates content to a max width of 100px and adds an ellipsis.
    */
   @Prop() truncate: boolean;
@@ -35,6 +40,10 @@ export class PdsTableCell {
 
     if (this.tableRef && this.tableRef.compact) {
       classNames.push('is-compact');
+    }
+
+    if (this.cellAlign) {
+      classNames.push(`pds-table-cell--align-${this.cellAlign}`);
     }
 
     if (this.truncate) {

--- a/libs/core/src/components/pds-table/pds-table-cell/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-cell/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                     | Type      | Default     |
-| ---------- | ---------- | --------------------------------------------------------------- | --------- | ----------- |
-| `truncate` | `truncate` | Truncates content to a max width of 100px and adds an ellipsis. | `boolean` | `undefined` |
+| Property    | Attribute    | Description                                                     | Type                                        | Default     |
+| ----------- | ------------ | --------------------------------------------------------------- | ------------------------------------------- | ----------- |
+| `cellAlign` | `cell-align` | Sets the text alignment within the cell.                        | `"center" \| "end" \| "justify" \| "start"` | `undefined` |
+| `truncate`  | `truncate`   | Truncates content to a max width of 100px and adds an ellipsis. | `boolean`                                   | `undefined` |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-table/pds-table-cell/stories/pds-table-cell.stories.js
+++ b/libs/core/src/components/pds-table/pds-table-cell/stories/pds-table-cell.stories.js
@@ -3,7 +3,15 @@ import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
-  argTypes: extractArgTypes('pds-table-cell'),
+  argTypes: {
+    ...extractArgTypes('pds-table-cell'),
+    cellAlign: {
+      control: {
+        type: 'select',
+      },
+      options: ['start', 'center', 'end', 'justify'],
+    },
+  },
   component: 'pds-table-cell',
   decorators: [withActions],
   title: 'components/Table/Cells',
@@ -11,11 +19,21 @@ export default {
 
 const BaseTemplate = (args) => html`
 <pds-table>
+  <pds-table-head>
+    <pds-table-head-cell>Name</pds-table-head-cell>
+    <pds-table-head-cell>Amount</pds-table-head-cell>
+    <pds-table-head-cell>Description</pds-table-head-cell>
+  </pds-table-head>
   <pds-table-body>
     <pds-table-row>
-      <pds-table-cell truncated=${args.truncate}>Row Item Alpha</pds-table-cell>
-      <pds-table-cell truncated=${args.truncate}>Row Item Beta</pds-table-cell>
-      <pds-table-cell truncated=${args.truncate}>Row Item Charlie</pds-table-cell>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>John Doe</pds-table-cell>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>$1,234.56</pds-table-cell>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>This is a longer description that demonstrates text alignment in table cells.</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>Jane Smith</pds-table-cell>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>$987.65</pds-table-cell>
+      <pds-table-cell truncate=${args.truncate} cell-align=${args.cellAlign}>Another example of text alignment behavior with different content lengths.</pds-table-cell>
     </pds-table-row>
   </pds-table-body>
 </pds-table>`;
@@ -23,4 +41,5 @@ const BaseTemplate = (args) => html`
 export const Default = BaseTemplate.bind();
 Default.args = {
   truncate: false,
+  cellAlign: 'start',
 };

--- a/libs/core/src/components/pds-table/pds-table-cell/test/pds-table-cell.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-cell/test/pds-table-cell.spec.tsx
@@ -76,4 +76,65 @@ describe('pds-table-cell', () => {
 
     expect(tableCell).not.toHaveClass('has-scrolled');
   });
+
+  it('renders without alignment class when cellAlign is not set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell.classList.toString()).not.toContain('pds-table-cell--align-');
+  });
+
+  it('renders with alignment class when cellAlign is set to start', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell cell-align="start"></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell).toHaveClass('pds-table-cell--align-start');
+  });
+
+  it('renders with alignment class when cellAlign is set to center', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell cell-align="center"></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell).toHaveClass('pds-table-cell--align-center');
+  });
+
+  it('renders with alignment class when cellAlign is set to end', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell cell-align="end"></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell).toHaveClass('pds-table-cell--align-end');
+  });
+
+  it('renders with alignment class when cellAlign is set to justify', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell cell-align="justify"></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell).toHaveClass('pds-table-cell--align-justify');
+  });
+
+  it('renders with both alignment and truncate classes when both props are set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableCell],
+      html: `<pds-table-cell cell-align="center" truncate="true"></pds-table-cell>`,
+    });
+
+    const tableCell = page.body.querySelector('pds-table-cell') as HTMLElement;
+    expect(tableCell).toHaveClass('pds-table-cell--align-center');
+    expect(tableCell).toHaveClass('is-truncated');
+  });
 });

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.scss
@@ -45,3 +45,20 @@
 :host(.is-active) {
   color: var(--pine-color-text-active);
 }
+
+// Text Alignment
+:host(.pds-table-head-cell--align-start) {
+  text-align: start;
+}
+
+:host(.pds-table-head-cell--align-center) {
+  text-align: center;
+}
+
+:host(.pds-table-head-cell--align-end) {
+  text-align: end;
+}
+
+:host(.pds-table-head-cell--align-justify) {
+  text-align: justify;
+}

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
@@ -12,6 +12,11 @@ export class PdsTableHeadCell {
   private tableRef: HTMLPdsTableElement;
 
   /**
+   * Sets the text alignment within the head cell.
+   */
+  @Prop() cellAlign?: 'start' | 'center' | 'end' | 'justify';
+
+  /**
    * Determines whether the table column is sortable when set to `true`.
    */
   @Prop() sortable: boolean;
@@ -75,6 +80,10 @@ export class PdsTableHeadCell {
 
     if (this.tableRef && this.tableRef.compact) {
       classNames.push('is-compact');
+    }
+
+    if (this.cellAlign) {
+      classNames.push(`pds-table-head-cell--align-${this.cellAlign}`);
     }
 
     if (this.sortable) {

--- a/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                         | Type      | Default     |
-| ---------- | ---------- | ------------------------------------------------------------------- | --------- | ----------- |
-| `sortable` | `sortable` | Determines whether the table column is sortable when set to `true`. | `boolean` | `undefined` |
+| Property    | Attribute    | Description                                                         | Type                                        | Default     |
+| ----------- | ------------ | ------------------------------------------------------------------- | ------------------------------------------- | ----------- |
+| `cellAlign` | `cell-align` | Sets the text alignment within the head cell.                       | `"center" \| "end" \| "justify" \| "start"` | `undefined` |
+| `sortable`  | `sortable`   | Determines whether the table column is sortable when set to `true`. | `boolean`                                   | `undefined` |
 
 
 ## Events

--- a/libs/core/src/components/pds-table/pds-table-head-cell/stories/pds-table-head-cell.stories.js
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/stories/pds-table-head-cell.stories.js
@@ -3,7 +3,15 @@ import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
-  argTypes: extractArgTypes('pds-table-head-cell'),
+  argTypes: {
+    ...extractArgTypes('pds-table-head-cell'),
+    cellAlign: {
+      control: {
+        type: 'select',
+      },
+      options: ['start', 'center', 'end', 'justify'],
+    },
+  },
   component: 'pds-table-head-cell',
   decorators: [withActions],
   title: 'components/Table/Head',
@@ -12,13 +20,14 @@ export default {
 const BaseTemplate = (args) => html`
 <pds-table>
   <pds-table-head>
-    <pds-table-head-cell sortable=${args.sortable}>Column Heading Alpha</pds-table-head-cell>
-    <pds-table-head-cell sortable=${args.sortable}>Column Heading Beta</pds-table-head-cell>
-    <pds-table-head-cell sortable=${args.sortable}>Column Heading Charlie</pds-table-head-cell>
+    <pds-table-head-cell sortable=${args.sortable} cell-align=${args.cellAlign}>Column Heading Alpha</pds-table-head-cell>
+    <pds-table-head-cell sortable=${args.sortable} cell-align=${args.cellAlign}>Column Heading Beta</pds-table-head-cell>
+    <pds-table-head-cell sortable=${args.sortable} cell-align=${args.cellAlign}>Column Heading Charlie</pds-table-head-cell>
   </pds-table-head>
 </pds-table>`;
 
 export const Default = BaseTemplate.bind();
 Default.args = {
   sortable: false,
+  cellAlign: 'start',
 };

--- a/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
@@ -93,4 +93,65 @@ describe('pds-table-head-cell', () => {
 
     expect(tableHeadCell.classList.contains('is-active')).toBe(true);
   });
+
+  it('renders without alignment class when cellAlign is not set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell.classList.toString()).not.toContain('pds-table-head-cell--align-');
+  });
+
+  it('renders with alignment class when cellAlign is set to start', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell cell-align="start"></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell).toHaveClass('pds-table-head-cell--align-start');
+  });
+
+  it('renders with alignment class when cellAlign is set to center', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell cell-align="center"></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell).toHaveClass('pds-table-head-cell--align-center');
+  });
+
+  it('renders with alignment class when cellAlign is set to end', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell cell-align="end"></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell).toHaveClass('pds-table-head-cell--align-end');
+  });
+
+  it('renders with alignment class when cellAlign is set to justify', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell cell-align="justify"></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell).toHaveClass('pds-table-head-cell--align-justify');
+  });
+
+  it('renders with both alignment and sortable classes when both props are set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell],
+      html: `<pds-table-head-cell cell-align="center" sortable="true"></pds-table-head-cell>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as HTMLElement;
+    expect(tableHeadCell).toHaveClass('pds-table-head-cell--align-center');
+    expect(tableHeadCell).toHaveClass('is-sortable');
+  });
 });

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -46,6 +46,42 @@ const BaseTemplate = (args) => html`
   </pds-table-body>
 </pds-table>`;
 
+const AlignmentTemplate = (args) => html`
+<pds-table
+  ?compact=${args.compact}
+  component-id="${args.componentId}"
+  ?fixed-column=${args.fixedColumn}
+  ?responsive=${args.responsive}
+  ?selectable=${args.selectable}
+>
+  <pds-table-head>
+    <pds-table-head-cell cell-align="start">Name</pds-table-head-cell>
+    <pds-table-head-cell cell-align="center">Amount</pds-table-head-cell>
+    <pds-table-head-cell cell-align="end">Status</pds-table-head-cell>
+    <pds-table-head-cell cell-align="justify">Description</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">John Doe</pds-table-cell>
+      <pds-table-cell cell-align="center">$1,234.56</pds-table-cell>
+      <pds-table-cell cell-align="end">Active</pds-table-cell>
+      <pds-table-cell cell-align="justify">This is a longer description that demonstrates justified text alignment in table cells. It shows how text wraps and aligns within the cell boundaries.</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">Jane Smith</pds-table-cell>
+      <pds-table-cell cell-align="center">$987.65</pds-table-cell>
+      <pds-table-cell cell-align="end">Inactive</pds-table-cell>
+      <pds-table-cell cell-align="justify">Another example of justified text that spans multiple lines to show the alignment behavior in table cells with varying content lengths.</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell cell-align="start">Michael Johnson</pds-table-cell>
+      <pds-table-cell cell-align="center">$2,468.13</pds-table-cell>
+      <pds-table-cell cell-align="end">Pending</pds-table-cell>
+      <pds-table-cell cell-align="justify">Short justified text example.</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>`;
+
 const ResponsiveTemplate = (args) => html`
 <pds-table
   ?compact=${args.compact}
@@ -175,6 +211,15 @@ export const Default = BaseTemplate.bind();
 Default.args = {
   compact: false,
   componentId: 'default',
+  fixedColumn: false,
+  responsive: false,
+  selectable: false,
+};
+
+export const Alignment = AlignmentTemplate.bind();
+Alignment.args = {
+  compact: false,
+  componentId: 'alignment',
   fixedColumn: false,
   responsive: false,
   selectable: false,


### PR DESCRIPTION
# Description

This PR adds text alignment functionality to table cell components (`pds-table-cell` and `pds-table-head-cell`) by introducing a new optional `cellAlign` property.

Fixes: https://kajabi.atlassian.net/browse/DSS-1507

## Summary of Changes

- **New Property**: Added `cellAlign` prop to both `pds-table-cell` and `pds-table-head-cell` components
- **Alignment Options**: Supports `'start' | 'center' | 'end' | 'justify'` values
- **CSS Implementation**: Added direct CSS classes for each alignment option using `:host()` selectors
- **Comprehensive Testing**: Added unit tests covering all alignment values and integration with existing features
- **Storybook Integration**: Updated stories with interactive dropdown controls for testing alignment
- **Documentation**: Added usage examples and guidance in main table documentation

## Motivation and Context

Developers requested the ability to control text alignment in table cells to improve data presentation, particularly for:
- Right-aligning numeric data for better readability
- Center-aligning headers when appropriate
- Justifying longer text content in description columns

The implementation follows Pine DS patterns and maintains full backward compatibility.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] **Unit tests**: Added comprehensive test coverage for both components
- [x] **Tested manually**: 



**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
