### PR TITLE
fix:() expose loader part to allow custom colors in loading button

### DIFF
--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -212,14 +212,14 @@ The loader color can be customized using CSS parts.
     <PdsButton className="custom-loader-danger" variant="secondary" loading="true">Danger Loader</PdsButton>
     `,
     webComponent: `
-    <style>{\`
+    <style>
       .custom-loader-accent::part(loader-svg) {
         color: var(--pine-color-accent);
       }
       .custom-loader-danger::part(loader-svg) {
         color: var(--pine-color-danger);
       }
-    \`}</style>
+    </style>
 
     <pds-button class="custom-loader-accent" variant="primary" loading="true">Accent Loader</pds-button>
     <pds-button class="custom-loader-danger" variant="secondary" loading="true">Danger Loader</pds-button>

--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -192,6 +192,52 @@ The loading prop allows a `pds-button` to display a loading state.
   <pds-button variant="primary" loading="true">Loading</pds-button>
 </DocCanvas>
 
+#### Customizing Loader Color
+
+The loader color can be customized using CSS parts.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <style>{\`
+      .custom-loader-accent::part(loader-svg) {
+        color: var(--pine-color-accent);
+      }
+      .custom-loader-danger::part(loader-svg) {
+        color: var(--pine-color-danger);
+      }
+    \`}</style>
+
+    <PdsButton className="custom-loader-accent" variant="primary" loading="true">Accent Loader</PdsButton>
+    <PdsButton className="custom-loader-danger" variant="secondary" loading="true">Danger Loader</PdsButton>
+    `,
+    webComponent: `
+    <style>{\`
+      .custom-loader-accent::part(loader-svg) {
+        color: var(--pine-color-accent);
+      }
+      .custom-loader-danger::part(loader-svg) {
+        color: var(--pine-color-danger);
+      }
+    \`}</style>
+
+    <pds-button class="custom-loader-accent" variant="primary" loading="true">Accent Loader</pds-button>
+    <pds-button class="custom-loader-danger" variant="secondary" loading="true">Danger Loader</pds-button>
+    `
+}}>
+  <style>{`
+    .custom-loader-accent::part(loader-svg) {
+      color: var(--pine-color-accent);
+    }
+    .custom-loader-danger::part(loader-svg) {
+      color: var(--pine-color-danger);
+    }
+  `}</style>
+
+  <pds-button class="custom-loader-accent" variant="primary" loading="true">Accent Loader</pds-button>
+  <pds-button class="custom-loader-danger" variant="secondary" loading="true">Danger Loader</pds-button>
+</DocCanvas>
+
 ### Icon Only
 
 The icon-only prop allows a `pds-button` to display an icon only.

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -9,6 +9,7 @@ import { caretDown } from '@pine-ds/icons/icons';
  * @part button-text - Exposes the button text for styling.
  * @part caret - Exposes the caret icon component for styling. Appears only on the disclosure variant.
  * @part icon - Exposes the icon component for styling.
+ * @part loader-svg - Exposes the loader SVG element for color customization. Appears only when loading.
  * @slot (default) - Button text.
  * @slot start - Content to display before the button text.
  * @slot end - Content to display after the button text.
@@ -217,7 +218,7 @@ export class PdsButton {
 
         {this.loading && (
           <span class="pds-button__loader">
-            <pds-loader is-loading={true} size="var(--pine-font-size-body-2xl)" variant="spinner">
+            <pds-loader is-loading={true} size="var(--pine-font-size-body-2xl)" variant="spinner" exportparts="loader-svg">
               Loading...
             </pds-loader>
           </span>

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -48,6 +48,7 @@
 | `"button-text"`    | Exposes the button text for styling.                                                  |
 | `"caret"`          | Exposes the caret icon component for styling. Appears only on the disclosure variant. |
 | `"icon"`           | Exposes the icon component for styling.                                               |
+| `"loader-svg"`     | Exposes the loader SVG element for color customization. Appears only when loading.    |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -40,7 +40,7 @@ describe('pds-button', () => {
 
     const elementForm = await page.find('form');
     const elementFormEvent = await elementForm.spyOnEvent('reset');
-    page.evaluate(() => (document.querySelector('input') as HTMLInputElement).value = 'test');
+    await page.evaluate(() => (document.querySelector('input') as HTMLInputElement).value = 'test');
     await page.evaluate(() => document.querySelector('pds-button')!.click());
     await page.waitForChanges();
 

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -185,7 +185,7 @@ describe('pds-button', () => {
                 <slot></slot>
               </span>
               <span class="pds-button__loader">
-                <pds-loader is-loading size="var(--pine-font-size-body-2xl)" variant="spinner">Loading...</pds-loader>
+                <pds-loader is-loading size="var(--pine-font-size-body-2xl)" variant="spinner" exportparts="loader-svg">Loading...</pds-loader>
               </span>
             </div>
           </button>
@@ -194,6 +194,30 @@ describe('pds-button', () => {
     `);
 
     const loader = root?.shadowRoot?.querySelector('pds-loader');
+    expect(loader).not.toBeNull();
+  });
+
+  it('exports loader-svg part when loading', async () => {
+    const { root } = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button loading="true"></pds-button>`,
+    });
+
+    const loader = root?.shadowRoot?.querySelector('pds-loader');
+    expect(loader?.getAttribute('exportparts')).toBe('loader-svg');
+  });
+
+  it('includes loader-svg part in JSDoc comments', async () => {
+    // This test verifies that the component properly documents the exported parts
+    const { root } = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button loading="true"></pds-button>`,
+    });
+
+    expect(root).toBeTruthy();
+    // The actual JSDoc validation is done at build time,
+    // but we can verify the loader element has the exportparts attribute
+    const loader = root?.shadowRoot?.querySelector('pds-loader[exportparts]');
     expect(loader).not.toBeNull();
   });
 

--- a/libs/core/src/components/pds-loader/pds-loader.tsx
+++ b/libs/core/src/components/pds-loader/pds-loader.tsx
@@ -1,6 +1,7 @@
 import { Component, Host, h, Prop } from '@stencil/core';
 
 /**
+ * @part loader-svg - Exposes the spinner SVG element for color customization.
  * @slot label - Default slot for Loader label text.
  */
 
@@ -66,7 +67,7 @@ export class PdsLoader {
       <Host class={`pds-loader ${this.isLoading ? '' : 'pds-loader--hidden'}`} aria-hidden={!this.isLoading} aria-busy={this.isLoading} aria-live="polite">
         {this.variant === 'spinner' && (
           <div class="pds-loader--spinner">
-            <svg style={this.style()} viewBox="0 0 200 200" fill="none">
+            <svg style={this.style()} viewBox="0 0 200 200" fill="none" part="loader-svg">
               <defs>
                 <linearGradient id="spinner-secondHalf">
                   <stop offset="0%" stop-opacity="0" stop-color="currentColor" />

--- a/libs/core/src/components/pds-loader/readme.md
+++ b/libs/core/src/components/pds-loader/readme.md
@@ -22,6 +22,13 @@
 | `"label"` | Default slot for Loader label text. |
 
 
+## Shadow Parts
+
+| Part           | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `"loader-svg"` | Exposes the spinner SVG element for color customization. |
+
+
 ## Dependencies
 
 ### Used by

--- a/libs/core/src/components/pds-loader/test/pds-loader.e2e.ts
+++ b/libs/core/src/components/pds-loader/test/pds-loader.e2e.ts
@@ -8,4 +8,93 @@ describe('pds-loader', () => {
     const element = await page.find('pds-loader');
     expect(element).toHaveClass('pds-loader--hidden');
   });
+
+  it('exposes loader-svg part for color customization', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <style>
+        .custom-color::part(loader-svg) {
+          color: rgb(0, 255, 255) !important;
+        }
+      </style>
+      <pds-loader class="custom-color" variant="spinner" is-loading="true"></pds-loader>
+    `);
+
+    const loader = await page.find('pds-loader');
+    expect(loader).toHaveClass('hydrated');
+
+    await page.waitForChanges();
+
+    // Test that the SVG part is accessible and can be styled
+    const svgColor = await page.evaluate(() => {
+      const loader = document.querySelector('pds-loader');
+      const svg = loader?.shadowRoot?.querySelector('svg[part="loader-svg"]');
+      return svg ? window.getComputedStyle(svg).color : null;
+    });
+
+    expect(svgColor).toBe('rgb(0, 255, 255)');
+  });
+
+  it('only exposes loader-svg part for spinner variant', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-loader variant="spinner" is-loading="true"></pds-loader>
+      <pds-loader variant="typing" is-loading="true"></pds-loader>
+    `);
+
+    await page.waitForChanges();
+
+    const hasSpinnerPart = await page.evaluate(() => {
+      const spinnerLoader = document.querySelectorAll('pds-loader')[0];
+      const svg = spinnerLoader?.shadowRoot?.querySelector('svg[part="loader-svg"]');
+      return !!svg;
+    });
+
+    const hasTypingPart = await page.evaluate(() => {
+      const typingLoader = document.querySelectorAll('pds-loader')[1];
+      const svg = typingLoader?.shadowRoot?.querySelector('svg[part="loader-svg"]');
+      return !!svg;
+    });
+
+    expect(hasSpinnerPart).toBe(true);
+    expect(hasTypingPart).toBe(false);
+  });
+
+  it('loader-svg part can be styled with different colors', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <style>
+        .red-loader::part(loader-svg) {
+          color: rgb(255, 0, 0) !important;
+        }
+        .blue-loader::part(loader-svg) {
+          color: rgb(0, 0, 255) !important;
+        }
+        .green-loader::part(loader-svg) {
+          color: rgb(0, 128, 0) !important;
+        }
+      </style>
+      <pds-loader class="red-loader" variant="spinner" is-loading="true"></pds-loader>
+      <pds-loader class="blue-loader" variant="spinner" is-loading="true"></pds-loader>
+      <pds-loader class="green-loader" variant="spinner" is-loading="true"></pds-loader>
+    `);
+
+    await page.waitForChanges();
+
+    const colors = await page.evaluate(() => {
+      const loaders = document.querySelectorAll('pds-loader');
+      const colors: (string | null)[] = [];
+
+      loaders.forEach(loader => {
+        const svg = loader.shadowRoot?.querySelector('svg[part="loader-svg"]');
+        colors.push(svg ? window.getComputedStyle(svg).color : null);
+      });
+
+      return colors;
+    });
+
+    expect(colors[0]).toBe('rgb(255, 0, 0)'); // red
+    expect(colors[1]).toBe('rgb(0, 0, 255)'); // blue
+    expect(colors[2]).toBe('rgb(0, 128, 0)'); // green
+  });
 });

--- a/libs/core/src/components/pds-loader/test/pds-loader.spec.tsx
+++ b/libs/core/src/components/pds-loader/test/pds-loader.spec.tsx
@@ -47,4 +47,66 @@ describe('pds-loader', () => {
 
     expect(label).not.toHaveClass('pds-loader--hidden');
   });
+
+  it('exposes loader-svg part for color customization', async () => {
+    const page = await newSpecPage({
+      components: [PdsLoader],
+      html: `<pds-loader variant="spinner"></pds-loader>`,
+    });
+
+    const svg = page.root?.shadowRoot?.querySelector('svg[part="loader-svg"]');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('part')).toBe('loader-svg');
+  });
+
+  it('does not expose loader-svg part for typing variant', async () => {
+    const page = await newSpecPage({
+      components: [PdsLoader],
+      html: `<pds-loader variant="typing"></pds-loader>`,
+    });
+
+    const svg = page.root?.shadowRoot?.querySelector('svg[part="loader-svg"]');
+    expect(svg).toBeNull();
+
+    const typingContainer = page.root?.shadowRoot?.querySelector('.pds-loader--typing');
+    expect(typingContainer).toBeTruthy();
+  });
+
+  it('renders spinner variant with correct HTML structure including parts', async () => {
+    const page = await newSpecPage({
+      components: [PdsLoader],
+      html: `<pds-loader variant="spinner" is-loading="true"></pds-loader>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <pds-loader aria-busy="" aria-live="polite" class="pds-loader" is-loading="true" size="md" variant="spinner">
+        <mock:shadow-root>
+          <div class="pds-loader--spinner">
+            <svg fill="none" part="loader-svg" viewBox="0 0 200 200" style="height: 48px; width: 48px;">
+              <defs>
+                <linearGradient id="spinner-secondHalf">
+                  <stop offset="0%" stop-color="currentColor" stop-opacity="0"></stop>
+                  <stop offset="100%" stop-color="currentColor" stop-opacity="0.5"></stop>
+                </linearGradient>
+                <linearGradient id="spinner-firstHalf">
+                  <stop offset="0%" stop-color="currentColor" stop-opacity="1"></stop>
+                  <stop offset="100%" stop-color="currentColor" stop-opacity="0.5"></stop>
+                </linearGradient>
+              </defs>
+              <g class="pds-loader__spinner-path">
+                <path d="M 4 100 A 96 96 0 0 1 196 100" stroke="url(#spinner-secondHalf)"></path>
+                <path d="M 196 100 A 96 96 0 0 1 4 100" stroke="url(#spinner-firstHalf)"></path>
+                <path d="M 4 100 A 96 96 0 0 1 4 98" stroke="currentColor" stroke-linecap="round"></path>
+              </g>
+            </svg>
+          </div>
+          <div class="pds-loader--hidden pds-loader__label">
+            <slot name="label">
+              Loading...
+            </slot>
+          </div>
+        </mock:shadow-root>
+      </pds-loader>
+    `);
+  });
 });


### PR DESCRIPTION
# Description

This PR adds CSS Shadow Parts support to enable developers to customize the loader color in `pds-button` components. Previously, developers had no way to customize the loader appearance when buttons were in a loading state, limiting design flexibility.

## Changes Made

- **Added CSS Parts to `pds-loader`**: Exposed the spinner SVG element with `part="loader-svg"`
- **Added `exportparts` to `pds-button`**: Made the loader parts accessible through the button's shadow boundary using `exportparts="loader-svg"`
- **Updated JSDoc documentation**: Added comprehensive documentation for the new parts
- **Added usage examples**: Included practical examples in button documentation
- **Added comprehensive tests**: Both unit and e2e tests to ensure functionality works correctly

Fixes https://kajabi.atlassian.net/browse/DSS-1524

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
