### PR TITLE
pds-row: resolve size bug and add directional col gap props

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -953,6 +953,14 @@ export namespace Components {
          */
         "colGap"?: BoxTShirtSizeType | null;
         /**
+          * Defines the spacing between the row items vertically.
+         */
+        "colGapBlock"?: BoxTShirtSizeType | null;
+        /**
+          * Defines the spacing between the row items horizontally.
+         */
+        "colGapInline"?: BoxTShirtSizeType | null;
+        /**
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
@@ -3032,6 +3040,14 @@ declare namespace LocalJSX {
           * Defines the spacing between the row items.
          */
         "colGap"?: BoxTShirtSizeType | null;
+        /**
+          * Defines the spacing between the row items vertically.
+         */
+        "colGapBlock"?: BoxTShirtSizeType | null;
+        /**
+          * Defines the spacing between the row items horizontally.
+         */
+        "colGapInline"?: BoxTShirtSizeType | null;
         /**
           * A unique identifier used for the underlying component `id` attribute.
          */

--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -96,10 +96,10 @@ $pine-spacing-tokens: (
 .pds-box {
   flex-basis: 0;
   flex-grow: 1;
+}
 
-  &[class*='pds-box-'] {
-    flex-basis: auto;
-  }
+.pds-row > .pds-box[class*='pds-box-'] {
+  flex-basis: auto;
 }
 
 .pds-box--auto {

--- a/libs/core/src/components/pds-box/pds-box.scss
+++ b/libs/core/src/components/pds-box/pds-box.scss
@@ -96,6 +96,10 @@ $pine-spacing-tokens: (
 .pds-box {
   flex-basis: 0;
   flex-grow: 1;
+
+  &[class*='pds-box-'] {
+    flex-basis: auto;
+  }
 }
 
 .pds-box--auto {

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -148,15 +148,210 @@ Best practice: Use with `min-height` for consistent vertical alignment
 
 ### Column Gap
 
-Defines the spacing between the row items.
+The `pds-row` component provides flexible gap control with three different props for precise spacing management.
 
-Layout impact:
+#### Gap Props Overview
+
+- **`col-gap`**: Sets both horizontal and vertical spacing between items
+- **`col-gap-inline`**: Sets only horizontal spacing between items (overrides `col-gap` for horizontal)
+- **`col-gap-block`**: Sets only vertical spacing between items (overrides `col-gap` for vertical)
+
+Available sizes: `none`, `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, `xxl`
+
+#### Basic Gap Usage
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsRow colGap="md">
+        <PdsBox size="4">
+          <pds-box border>Column 1</pds-box>
+        </PdsBox>
+        <PdsBox size="4">
+          <pds-box border>Column 2</pds-box>
+        </PdsBox>
+        <PdsBox size="4">
+          <pds-box border>Column 3</pds-box>
+        </PdsBox>
+      </PdsRow>
+    `,
+    webComponent: `
+      <pds-row col-gap="md">
+        <pds-box size="4">
+          <pds-box border>Column 1</pds-box>
+        </pds-box>
+        <pds-box size="4">
+          <pds-box border>Column 2</pds-box>
+        </pds-box>
+        <pds-box size="4">
+          <pds-box border>Column 3</pds-box>
+        </pds-box>
+      </pds-row>
+    `
+}}>
+  <pds-row col-gap="md">
+    <pds-box size="4">
+      <pds-box border>Column 1</pds-box>
+    </pds-box>
+    <pds-box size="4">
+      <pds-box border>Column 2</pds-box>
+    </pds-box>
+    <pds-box size="4">
+      <pds-box border>Column 3</pds-box>
+    </pds-box>
+  </pds-row>
+</DocCanvas>
+
+#### Directional Gap Control
+
+For more precise control, use `col-gap-inline` for horizontal spacing and `col-gap-block` for vertical spacing:
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsRow colGapInline="lg" colGapBlock="xs">
+        <PdsBox size="6">
+          <pds-box border>Wide horizontal gap</pds-box>
+        </PdsBox>
+        <PdsBox size="6">
+          <pds-box border>Between columns</pds-box>
+        </PdsBox>
+        <PdsBox size="4">
+          <pds-box border>Small vertical gap</pds-box>
+        </PdsBox>
+        <PdsBox size="4">
+          <pds-box border>When wrapping</pds-box>
+        </PdsBox>
+        <PdsBox size="4">
+          <pds-box border>To next line</pds-box>
+        </PdsBox>
+      </PdsRow>
+    `,
+    webComponent: `
+      <pds-row col-gap-inline="lg" col-gap-block="xs">
+        <pds-box size="6">
+          <pds-box border>Wide horizontal gap</pds-box>
+        </pds-box>
+        <pds-box size="6">
+          <pds-box border>Between columns</pds-box>
+        </pds-box>
+        <pds-box size="4">
+          <pds-box border>Small vertical gap</pds-box>
+        </pds-box>
+        <pds-box size="4">
+          <pds-box border>When wrapping</pds-box>
+        </pds-box>
+        <pds-box size="4">
+          <pds-box border>To next line</pds-box>
+        </pds-box>
+      </pds-row>
+    `
+}}>
+  <pds-row col-gap-inline="lg" col-gap-block="xs">
+    <pds-box size="6">
+      <pds-box border>Wide horizontal gap</pds-box>
+    </pds-box>
+    <pds-box size="6">
+      <pds-box border>Between columns</pds-box>
+    </pds-box>
+    <pds-box size="4">
+      <pds-box border>Small vertical gap</pds-box>
+    </pds-box>
+    <pds-box size="4">
+      <pds-box border>When wrapping</pds-box>
+    </pds-box>
+    <pds-box size="4">
+      <pds-box border>To next line</pds-box>
+    </pds-box>
+  </pds-row>
+</DocCanvas>
+
+#### Gap Size Comparison
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <div>
+        <h4>Small Gap (xs)</h4>
+        <PdsRow colGap="xs">
+          <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
+          <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
+        </PdsRow>
+
+        <h4>Medium Gap (md)</h4>
+        <PdsRow colGap="md">
+          <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
+          <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
+        </PdsRow>
+
+        <h4>Large Gap (xl)</h4>
+        <PdsRow colGap="xl">
+          <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
+          <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
+        </PdsRow>
+      </div>
+    `,
+    webComponent: `
+      <div>
+        <h4>Small Gap (xs)</h4>
+        <pds-row col-gap="xs">
+          <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+          <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+        </pds-row>
+
+        <h4>Medium Gap (md)</h4>
+        <pds-row col-gap="md">
+          <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+          <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+        </pds-row>
+
+        <h4>Large Gap (xl)</h4>
+        <pds-row col-gap="xl">
+          <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+          <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+        </pds-row>
+      </div>
+    `
+}}>
+  <div>
+    <h4>Small Gap (xs)</h4>
+    <pds-row col-gap="xs">
+      <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+      <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+    </pds-row>
+
+    <h4>Medium Gap (md)</h4>
+    <pds-row col-gap="md">
+      <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+      <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+    </pds-row>
+
+    <h4>Large Gap (xl)</h4>
+    <pds-row col-gap="xl">
+      <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
+      <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
+    </pds-row>
+  </div>
+</DocCanvas>
+
+**Layout impact:**
 - Controls the gap between columns in the grid
-- Available sizes: `none`, `xxs`, `xs`, `sm`, `md`, `lg`, `xl`, `xxl`
 - Creates consistent spacing between all columns
 - Works with both fixed-size and auto-width columns
 
-Best practice: Use `md` or `lg` for comfortable spacing between content columns
+**Best practice:** Use `md` or `lg` for comfortable spacing between content columns
+
+#### When to Use Each Gap Prop
+
+- **`col-gap`**: Use when you want uniform spacing in both directions (most common)
+- **`col-gap-inline`**: Use when you need different horizontal spacing than vertical (e.g., wide columns, tight rows)
+- **`col-gap-block`**: Use when you need different vertical spacing than horizontal (e.g., tight columns, spaced rows)
+
+**Common Patterns:**
+- **Cards Layout**: `col-gap="lg"` for even spacing
+- **Form Layout**: `col-gap-inline="md" col-gap-block="sm"` for tighter vertical spacing
+- **Navigation**: `col-gap-inline="lg"` with no vertical gap
+- **Dense Grid**: `col-gap="xs"` for minimal spacing
 
 ### Justify Content
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -271,67 +271,67 @@ For more precise control, use `col-gap-inline` for horizontal spacing and `col-g
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <div>
-        <h4>Small Gap (xs)</h4>
+      <PdsBox direction="column" fit="true">
+        <PdsText tag="h4">Small Gap (xs)</PdsText>
         <PdsRow colGap="xs">
           <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
           <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
         </PdsRow>
 
-        <h4>Medium Gap (md)</h4>
+        <PdsText tag="h4">Medium Gap (md)</PdsText>
         <PdsRow colGap="md">
           <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
           <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
         </PdsRow>
 
-        <h4>Large Gap (xl)</h4>
+        <PdsText tag="h4">Large Gap (xl)</PdsText>
         <PdsRow colGap="xl">
           <PdsBox size="6"><pds-box border>Column A</pds-box></PdsBox>
           <PdsBox size="6"><pds-box border>Column B</pds-box></PdsBox>
         </PdsRow>
-      </div>
+      </PdsBox>
     `,
     webComponent: `
-      <div>
-        <h4>Small Gap (xs)</h4>
+      <pds-box direction="column" fit="true">
+        <pds-text tag="h4">Small Gap (xs)</pds-text>
         <pds-row col-gap="xs">
           <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
           <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
         </pds-row>
 
-        <h4>Medium Gap (md)</h4>
+        <pds-text tag="h4">Medium Gap (md)</pds-text>
         <pds-row col-gap="md">
           <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
           <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
         </pds-row>
 
-        <h4>Large Gap (xl)</h4>
+        <pds-text tag="h4">Large Gap (xl)</pds-text>
         <pds-row col-gap="xl">
           <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
           <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
         </pds-row>
-      </div>
+      </pds-box>
     `
 }}>
-  <div>
-    <h4>Small Gap (xs)</h4>
+  <pds-box direction="column" fit="true">
+    <pds-text tag="h4">Small Gap (xs)</pds-text>
     <pds-row col-gap="xs">
       <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
       <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
     </pds-row>
 
-    <h4>Medium Gap (md)</h4>
+    <pds-text tag="h4">Medium Gap (md)</pds-text>
     <pds-row col-gap="md">
       <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
       <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
     </pds-row>
 
-    <h4>Large Gap (xl)</h4>
+    <pds-text tag="h4">Large Gap (xl)</pds-text>
     <pds-row col-gap="xl">
       <pds-box size="6"><pds-box border>Column A</pds-box></pds-box>
       <pds-box size="6"><pds-box border>Column B</pds-box></pds-box>
     </pds-row>
-  </div>
+  </pds-box>
 </DocCanvas>
 
 **Layout impact:**

--- a/libs/core/src/components/pds-row/pds-row.tsx
+++ b/libs/core/src/components/pds-row/pds-row.tsx
@@ -24,6 +24,16 @@ export class PdsRow {
   @Prop() colGap?: BoxTShirtSizeType | null;
 
   /**
+   * Defines the spacing between the row items vertically.
+   */
+  @Prop() colGapBlock?: BoxTShirtSizeType | null;
+
+  /**
+   * Defines the spacing between the row items horizontally.
+   */
+  @Prop() colGapInline?: BoxTShirtSizeType | null;
+
+  /**
    * A unique identifier used for the underlying component `id` attribute.
    */
   @Prop() componentId: string;
@@ -67,6 +77,12 @@ export class PdsRow {
       ...(this.colGap && {
         '--row-gap-x': this.colGap !== undefined && this.colGap.trim() !== '' ? this.colGapMap[this.colGap] : '',
         '--row-gap-y': this.colGap !== undefined && this.colGap.trim() !== '' ? this.colGapMap[this.colGap] : '',
+      }),
+      ...(this.colGapBlock && {
+        '--row-gap-y': this.colGapBlock !== undefined && this.colGapBlock.trim() !== '' ? this.colGapMap[this.colGapBlock] : '',
+      }),
+      ...(this.colGapInline && {
+        '--row-gap-x': this.colGapInline !== undefined && this.colGapInline.trim() !== '' ? this.colGapMap[this.colGapInline] : '',
       }),
       ...(this.minHeight && {
         'min-height': this.minHeight,

--- a/libs/core/src/components/pds-row/readme.md
+++ b/libs/core/src/components/pds-row/readme.md
@@ -12,6 +12,8 @@
 | `alignItems`     | `align-items`     | Defines the vertical alignment of the row items.                                              | `"baseline" \| "center" \| "end" \| "start" \| "stretch"`           | `undefined` |
 | `border`         | `border`          | If `true`, the row will have a border.                                                        | `boolean`                                                           | `false`     |
 | `colGap`         | `col-gap`         | Defines the spacing between the row items.                                                    | `"lg" \| "md" \| "none" \| "sm" \| "xl" \| "xs" \| "xxl" \| "xxs"`  | `undefined` |
+| `colGapBlock`    | `col-gap-block`   | Defines the spacing between the row items vertically.                                         | `"lg" \| "md" \| "none" \| "sm" \| "xl" \| "xs" \| "xxl" \| "xxs"`  | `undefined` |
+| `colGapInline`   | `col-gap-inline`  | Defines the spacing between the row items horizontally.                                       | `"lg" \| "md" \| "none" \| "sm" \| "xl" \| "xs" \| "xxl" \| "xxs"`  | `undefined` |
 | `componentId`    | `component-id`    | A unique identifier used for the underlying component `id` attribute.                         | `string`                                                            | `undefined` |
 | `justifyContent` | `justify-content` | Defines the horizontal alignment of the row items.                                            | `"center" \| "end" \| "space-around" \| "space-between" \| "start"` | `undefined` |
 | `minHeight`      | `min-height`      | The minimum height of the row. Used in conjunction with alignment props                       | `string`                                                            | `undefined` |

--- a/libs/core/src/components/pds-row/test/pds-row.spec.tsx
+++ b/libs/core/src/components/pds-row/test/pds-row.spec.tsx
@@ -32,6 +32,28 @@ describe('pds-row', () => {
     expect(element).toEqualAttribute('style', '--row-gap-x: 1rem; --row-gap-y: 1rem;');
   });
 
+  it('renders a vertical gap when prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsRow],
+      html: `<pds-row col-gap-block="sm"></pds-row>`,
+    });
+
+    const element = page.root;
+
+    expect(element).toEqualAttribute('style', '--row-gap-y: 1rem;');
+  });
+
+  it('renders a horizontal gap when prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsRow],
+      html: `<pds-row col-gap-inline="sm"></pds-row>`,
+    });
+
+    const element = page.root;
+
+    expect(element).toEqualAttribute('style', '--row-gap-x: 1rem;');
+  });
+
   it('renders the align-items when prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsRow],

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -101,13 +101,13 @@ Use `pds-row` for Multi-Column Layouts:
         <PdsRow col-gap="sm">
           <PdsBox size="8">
             <PdsBox border padding="md">Column 1</PdsBox>
-          </pds-box>
+          </PdsBox>
           <PdsBox size="4">
             <PdsBox border padding="md">Column 2</PdsBox>
-          </pds-box>
+          </PdsBox>
           <PdsBox size="4">
             <PdsBox border padding="md">Column 2</PdsBox>
-          </pds-box>
+          </PdsBox>
         </pds-row>
       </PdsBox>
     `,

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -97,22 +97,28 @@ Use `pds-row` for Multi-Column Layouts:
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsBox backgroundColor="#f5f5f5" fit="true">
+      <PdsBox fit="true">
         <PdsRow col-gap="sm">
           <PdsBox size="8">
-            <pds-box border padding="md">Column 1</pds-box>
+            <PdsBox border padding="md">Column 1</PdsBox>
           </pds-box>
           <PdsBox size="4">
-            <pds-box border padding="md">Column 2</pds-box>
+            <PdsBox border padding="md">Column 2</PdsBox>
+          </pds-box>
+          <PdsBox size="4">
+            <PdsBox border padding="md">Column 2</PdsBox>
           </pds-box>
         </pds-row>
       </PdsBox>
     `,
     webComponent: `
-      <pds-box background-color="#f5f5f5" fit="true">
+      <pds-box fit="true">
         <pds-row col-gap="sm">
           <pds-box size="8">
             <pds-box border padding="md">Column 1</pds-box>
+          </pds-box>
+          <pds-box size="4">
+            <pds-box border padding="md">Column 2</pds-box>
           </pds-box>
           <pds-box size="4">
             <pds-box border padding="md">Column 2</pds-box>
@@ -121,10 +127,13 @@ Use `pds-row` for Multi-Column Layouts:
       </pds-box>
     `
 }}>
-  <pds-box background-color="#f5f5f5" fit="true">
+  <pds-box fit="true">
     <pds-row col-gap="sm">
       <pds-box size="8">
         <pds-box border padding="md">Column 1</pds-box>
+      </pds-box>
+      <pds-box size="4">
+        <pds-box border padding="md">Column 2</pds-box>
       </pds-box>
       <pds-box size="4">
         <pds-box border padding="md">Column 2</pds-box>
@@ -140,7 +149,7 @@ Add size modifiers to your child `pds-box` for responsive design
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsBox backgroundColor="#f5f5f5" fit="true">
+      <PdsBox fit="true">
         <PdsRow col-gap="sm">
           <PdsBox sizeMd="8">
             <pds-box border padding="md">Column 1</pds-box>
@@ -152,7 +161,7 @@ Add size modifiers to your child `pds-box` for responsive design
       </PdsBox>
     `,
     webComponent: `
-      <pds-box background-color="#f5f5f5" fit="true">
+      <pds-box fit="true">
         <pds-row col-gap="sm">
           <pds-box size-md="8">
             <pds-box border padding="sm">Column 1</pds-box>
@@ -164,10 +173,13 @@ Add size modifiers to your child `pds-box` for responsive design
       </pds-box>
     `
 }}>
-  <pds-box background-color="#f5f5f5" fit="true">
+  <pds-box fit="true">
     <pds-row col-gap="sm">
       <pds-box size-md="8">
         <pds-box border padding="sm">Column 1</pds-box>
+      </pds-box>
+      <pds-box size-md="4">
+        <pds-box border padding="sm">Column 2</pds-box>
       </pds-box>
       <pds-box size-md="4">
         <pds-box border padding="sm">Column 2</pds-box>


### PR DESCRIPTION
# Description

- [x] resolve bug where `size` was not wrapping when values were greater than 12
- [x] add `colGapBlock` and `colGapInline` for directional gap control

Fixes [DSS-1527](https://kajabi.atlassian.net/browse/DSS-1527)

#### `size` not wrapping bug
| Before | After |
|--------|--------|
|<img width="1028" height="461" alt="Screenshot 2025-09-10 at 5 41 54 PM" src="https://github.com/user-attachments/assets/70d7d788-22fc-4da0-b2e5-429902c8fdc5" />|<img width="1013" height="510" alt="Screenshot 2025-09-10 at 5 42 31 PM" src="https://github.com/user-attachments/assets/524df40a-a385-4106-a008-8cd36f754bf8" />|


#### `colGapBlock` and `colGapInline`
<img width="1127" height="280" alt="Screenshot 2025-09-10 at 5 52 53 PM" src="https://github.com/user-attachments/assets/af415ced-54c1-4fb3-ba40-9cf9ca9dc7a5" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

#### colGap
 - Visit the Row docs and verify the mobile version of the **Directional Gap Control** section

#### `size`
- Visit the Row docs -> **Wrapping** section

- [x] unit tests

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:



[DSS-1527]: https://kajabi.atlassian.net/browse/DSS-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ