### PR TITLE
fix(pds-modal): add scrollable boolean and resolve dynamic border positioning

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -890,7 +890,7 @@ export namespace Components {
     }
     interface PdsModalContent {
         /**
-          * The border style for the content area. Automatically set based on available space of the modal content.
+          * The border style for the content area. When not explicitly set, automatically determined based on scroll state.
           * @default 'none'
          */
         "border": 'none' | 'both' | 'top' | 'bottom';
@@ -3054,7 +3054,7 @@ declare namespace LocalJSX {
     }
     interface PdsModalContent {
         /**
-          * The border style for the content area. Automatically set based on available space of the modal content.
+          * The border style for the content area. When not explicitly set, automatically determined based on scroll state.
           * @default 'none'
          */
         "border"?: 'none' | 'both' | 'top' | 'bottom';

--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -38,6 +38,11 @@ export namespace Components {
          */
         "open": boolean;
         /**
+          * Whether the modal content should be scrollable
+          * @default true
+         */
+        "scrollable": boolean;
+        /**
           * Shows the modal
          */
         "showModal": () => Promise<void>;
@@ -868,6 +873,11 @@ export namespace Components {
           * @default false
          */
         "open": boolean;
+        /**
+          * Whether the modal content should be scrollable
+          * @default true
+         */
+        "scrollable": boolean;
         /**
           * Opens the modal
          */
@@ -2170,6 +2180,11 @@ declare namespace LocalJSX {
          */
         "open"?: boolean;
         /**
+          * Whether the modal content should be scrollable
+          * @default true
+         */
+        "scrollable"?: boolean;
+        /**
           * The size of the modal
          */
         "size"?: 'sm' | 'md' | 'lg' | 'fullscreen';
@@ -3026,6 +3041,11 @@ declare namespace LocalJSX {
           * @default false
          */
         "open"?: boolean;
+        /**
+          * Whether the modal content should be scrollable
+          * @default true
+         */
+        "scrollable"?: boolean;
         /**
           * The size of the modal
           * @default 'md'

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -1079,6 +1079,161 @@ When `scrollable={false}`, the modal content will overflow naturally without cre
   </div>
 </DocCanvas>
 
+#### User-Defined Borders
+
+You can override the automatic border detection by explicitly setting the `border` prop on `pds-modal-content`. This is useful when you want specific border behavior regardless of scroll state.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <div>
+      <PdsButton onClick={() => {
+        const modal = document.querySelector('#border-demo-modal');
+        if (modal) modal.open = true;
+      }}>Custom Borders Demo</PdsButton>
+
+      <PdsModal id="border-demo-modal" componentId="border-demo-modal">
+        <PdsModalHeader>
+          <PdsBox direction="column" fit padding="md">
+            <PdsBox alignItems="center" fit justifyContent="space-between">
+              <PdsText tag="h2" size="h3">Custom Border Examples</PdsText>
+              <PdsButton
+                class="pds-modal__close"
+                variant="unstyled"
+                iconOnly="true"
+                onclick="document.querySelector('#border-demo-modal').open = false"
+                aria-label="Close modal"
+              >
+                <PdsIcon slot="start" name="remove" aria-hidden="true"></PdsIcon>
+              </PdsButton>
+            </PdsBox>
+          </PdsBox>
+        </PdsModalHeader>
+        <PdsModalContent border="both">
+          <PdsBox fit direction="column" paddingInlineStart="md" paddingInlineEnd="md">
+            <p><strong>This content has border="both"</strong></p>
+            <p>Notice the borders at top and bottom are always visible, regardless of scroll position.</p>
+            <p>Available border values:</p>
+            <ul>
+              <li><code>border="none"</code> - No borders</li>
+              <li><code>border="top"</code> - Top border only</li>
+              <li><code>border="bottom"</code> - Bottom border only</li>
+              <li><code>border="both"</code> - Top and bottom borders</li>
+            </ul>
+            <p>When you set a border value explicitly, the automatic scroll-based detection is disabled.</p>
+          </PdsBox>
+        </PdsModalContent>
+        <PdsModalFooter>
+          <PdsBox fit justifyContent="end" padding="md" gap="sm">
+            <PdsButton onClick={() => {
+              const modal = document.querySelector('#border-demo-modal');
+              if (modal) modal.open = false;
+            }}>Close</PdsButton>
+          </PdsBox>
+        </PdsModalFooter>
+      </PdsModal>
+    </div>
+    `,
+    webComponent: `
+    <div>
+      <pds-button onClick={() => {
+        const modal = document.querySelector('#border-demo-modal');
+        if (modal) modal.open = true;
+      }}>Custom Borders Demo</pds-button>
+
+      <pds-modal id="border-demo-modal" component-id="border-demo-modal">
+        <pds-modal-header>
+          <pds-box direction="column" fit padding="md">
+            <pds-box align-items="center" fit justify-content="space-between">
+              <pds-text tag="h2" size="h3">Custom Border Examples</pds-text>
+              <pds-button
+                class="pds-modal__close"
+                variant="unstyled"
+                icon-only="true"
+                onclick="document.querySelector('#border-demo-modal').open = false"
+                aria-label="Close modal"
+              >
+                <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+              </pds-button>
+            </pds-box>
+          </pds-box>
+        </pds-modal-header>
+        <pds-modal-content border="both">
+          <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+            <p><strong>This content has border="both"</strong></p>
+            <p>Notice the borders at top and bottom are always visible, regardless of scroll position.</p>
+            <p>Available border values:</p>
+            <ul>
+              <li><code>border="none"</code> - No borders</li>
+              <li><code>border="top"</code> - Top border only</li>
+              <li><code>border="bottom"</code> - Bottom border only</li>
+              <li><code>border="both"</code> - Top and bottom borders</li>
+            </ul>
+            <p>When you set a border value explicitly, the automatic scroll-based detection is disabled.</p>
+          </pds-box>
+        </pds-modal-content>
+        <pds-modal-footer>
+          <pds-box fit justify-content="end" padding="md" gap="sm">
+            <pds-button onClick={() => {
+              const modal = document.querySelector('#border-demo-modal');
+              if (modal) modal.open = false;
+            }}>Close</pds-button>
+          </pds-box>
+        </pds-modal-footer>
+      </pds-modal>
+    </div>
+    `
+  }}
+>
+  <div>
+    <pds-button onClick={() => {
+      const modal = document.querySelector('#border-demo-modal');
+      if (modal) modal.open = true;
+    }}>Custom Borders Demo</pds-button>
+
+    <pds-modal id="border-demo-modal" component-id="border-demo-modal">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Custom Border Examples</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#border-demo-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content border="both">
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p><strong>This content has border="both"</strong></p>
+          <p>Notice the borders at top and bottom are always visible, regardless of scroll position.</p>
+          <p>Available border values:</p>
+          <ul>
+            <li><code>border="none"</code> - No borders</li>
+            <li><code>border="top"</code> - Top border only</li>
+            <li><code>border="bottom"</code> - Bottom border only</li>
+            <li><code>border="both"</code> - Top and bottom borders</li>
+          </ul>
+          <p>When you set a border value explicitly, the automatic scroll-based detection is disabled.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onClick={() => {
+            const modal = document.querySelector('#border-demo-modal');
+            if (modal) modal.open = false;
+          }}>Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+  </div>
+</DocCanvas>
+
 ### Nested Modals
 
 Modals can be nested, with only the topmost modal responding to escape key and backdrop clicks.

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -28,7 +28,7 @@ The Modal component is composed of several subcomponents that work together to c
 
 #### Modal Content
 
-The `pds-modal-content` component provides a scrollable container for the main content of the modal. This component is always scrollable by default and automatically handles border visibility based on scroll state.
+The `pds-modal-content` component provides a container for the main content of the modal. By default, modals are scrollable when content exceeds the available space. You can control this behavior using the `scrollable` prop on the main modal component. The content component automatically handles border visibility based on scroll state.
 
 <DocArgsTable componentName="pds-modal-content" docSource={components} />
 
@@ -801,7 +801,11 @@ Use the destructive variant for actions that can't be undone.
 
 ### Scrollable Content
 
-Modals are scrollable by default when content exceeds the viewport height.
+Modals can be configured to handle content overflow in different ways using the `scrollable` prop.
+
+#### Scrollable (Default)
+
+By default, modals are scrollable when content exceeds the viewport height. The content area becomes scrollable while the header and footer remain fixed.
 
 <DocCanvas client:only
   mdxSource={{
@@ -924,6 +928,149 @@ Modals are scrollable by default when content exceeds the viewport height.
         <pds-box fit justify-content="end" padding="md" gap="sm">
           <pds-button onClick={() => {
             const modal = document.querySelector('#scroll-modal');
+            if (modal) modal.open = false;
+          }}>Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+  </div>
+</DocCanvas>
+
+#### Non-Scrollable
+
+When `scrollable={false}`, the modal content will overflow naturally without creating a scrollable area. This can be useful for modals with fixed-height content or when you want to handle overflow differently.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    <div>
+      <PdsButton onClick={() => {
+        const modal = document.querySelector('#non-scroll-modal');
+        if (modal) modal.open = true;
+      }}>Non-Scrollable Modal</PdsButton>
+
+      <PdsModal id="non-scroll-modal" componentId="non-scroll-modal" scrollable={false}>
+        <PdsModalHeader>
+          <PdsBox direction="column" fit padding="md">
+            <PdsBox alignItems="center" fit justifyContent="space-between">
+              <PdsText tag="h2" size="h3">Non-Scrollable Content</PdsText>
+              <PdsButton
+                class="pds-modal__close"
+                variant="unstyled"
+                iconOnly="true"
+                onclick="document.querySelector('#non-scroll-modal').open = false"
+                aria-label="Close modal"
+              >
+                <PdsIcon slot="start" name="remove" aria-hidden="true"></PdsIcon>
+              </PdsButton>
+            </PdsBox>
+          </PdsBox>
+        </PdsModalHeader>
+        <PdsModalContent>
+          <PdsBox fit direction="column" paddingInlineStart="md" paddingInlineEnd="md">
+            <p>This modal has scrollable=false, so content will overflow naturally.</p>
+            <p>Use this when you want to control overflow behavior differently.</p>
+            <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          </PdsBox>
+        </PdsModalContent>
+        <PdsModalFooter>
+          <PdsBox fit justifyContent="end" padding="md" gap="sm">
+            <PdsButton onClick={() => {
+              const modal = document.querySelector('#non-scroll-modal');
+              if (modal) modal.open = false;
+            }}>Close</PdsButton>
+          </PdsBox>
+        </PdsModalFooter>
+      </PdsModal>
+    </div>
+    `,
+    webComponent: `
+    <div>
+      <pds-button onClick={() => {
+        const modal = document.querySelector('#non-scroll-modal');
+        if (modal) modal.open = true;
+      }}>Non-Scrollable Modal</pds-button>
+
+      <pds-modal id="non-scroll-modal" component-id="non-scroll-modal" scrollable="false">
+        <pds-modal-header>
+          <pds-box direction="column" fit padding="md">
+            <pds-box align-items="center" fit justify-content="space-between">
+              <pds-text tag="h2" size="h3">Non-Scrollable Content</pds-text>
+              <pds-button
+                class="pds-modal__close"
+                variant="unstyled"
+                icon-only="true"
+                onclick="document.querySelector('#non-scroll-modal').open = false"
+                aria-label="Close modal"
+              >
+                <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+              </pds-button>
+            </pds-box>
+          </pds-box>
+        </pds-modal-header>
+        <pds-modal-content>
+          <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+            <p>This modal has scrollable="false", so content will overflow naturally.</p>
+            <p>Use this when you want to control overflow behavior differently.</p>
+            <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          </pds-box>
+        </pds-modal-content>
+        <pds-modal-footer>
+          <pds-box fit justify-content="end" padding="md" gap="sm">
+            <pds-button onClick={() => {
+              const modal = document.querySelector('#non-scroll-modal');
+              if (modal) modal.open = false;
+            }}>Close</pds-button>
+          </pds-box>
+        </pds-modal-footer>
+      </pds-modal>
+    </div>
+    `
+  }}
+>
+  <div>
+    <pds-button onClick={() => {
+      const modal = document.querySelector('#non-scroll-modal');
+      if (modal) modal.open = true;
+    }}>Non-Scrollable Modal</pds-button>
+
+    <pds-modal id="non-scroll-modal" component-id="non-scroll-modal" scrollable={false}>
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Non-Scrollable Content</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#non-scroll-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content>
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onClick={() => {
+            const modal = document.querySelector('#non-scroll-modal');
             if (modal) modal.open = false;
           }}>Close</pds-button>
         </pds-box>

--- a/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
+++ b/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
@@ -1,7 +1,6 @@
 pds-modal-content {
   display: block;
   flex: 1 1 auto;
-  overflow-y: auto;
   width: 100%;
 
   &:has(.pds-modal-content--border-none) {
@@ -27,7 +26,6 @@ pds-modal-content {
   flex: 1 1 auto;
   // Max height is set via inline styles based on header and footer heights
   min-height: 0;
-  overflow-y: auto;
   width: 100%;
 
 }

--- a/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
+++ b/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
@@ -3,21 +3,21 @@ pds-modal-content {
   flex: 1 1 auto;
   width: 100%;
 
-  &:has(.pds-modal-content--border-none) {
+  &:has(.pds-modal-content.pds-modal-content--border-none) {
     border: 0;
   }
 
-  &:has(.pds-modal-content--border-both) {
-    border-block-end: 1px solid var(--pine-color-grey-200) !important;
-    border-block-start: 1px solid var(--pine-color-grey-200) !important;
+  &:has(.pds-modal-content.pds-modal-content--border-both) {
+    border-block-end: 1px solid var(--pine-color-grey-200);
+    border-block-start: 1px solid var(--pine-color-grey-200);
   }
 
-  &:has(.pds-modal-content--border-top) {
-    border-block-start: 1px solid var(--pine-color-grey-200) !important;
+  &:has(.pds-modal-content.pds-modal-content--border-top) {
+    border-block-start: 1px solid var(--pine-color-grey-200);
   }
 
-  &:has(.pds-modal-content--border-bottom) {
-    border-block-end: 1px solid var(--pine-color-grey-200) !important;
+  &:has(.pds-modal-content.pds-modal-content--border-bottom) {
+    border-block-end: 1px solid var(--pine-color-grey-200);
   }
 }
 

--- a/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
+++ b/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.scss
@@ -8,16 +8,16 @@ pds-modal-content {
   }
 
   &:has(.pds-modal-content--border-both) {
-    border-block-end: 1px solid var(--pine-color-grey-200);
-    border-block-start: 1px solid var(--pine-color-grey-200);
+    border-block-end: 1px solid var(--pine-color-grey-200) !important;
+    border-block-start: 1px solid var(--pine-color-grey-200) !important;
   }
 
   &:has(.pds-modal-content--border-top) {
-    border-block-start: 1px solid var(--pine-color-grey-200);
+    border-block-start: 1px solid var(--pine-color-grey-200) !important;
   }
 
   &:has(.pds-modal-content--border-bottom) {
-    border-block-end: 1px solid var(--pine-color-grey-200);
+    border-block-end: 1px solid var(--pine-color-grey-200) !important;
   }
 }
 

--- a/libs/core/src/components/pds-modal/pds-modal-content/readme.md
+++ b/libs/core/src/components/pds-modal/pds-modal-content/readme.md
@@ -7,9 +7,9 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                                             | Type                                    | Default  |
-| -------- | --------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------- |
-| `border` | `border`  | The border style for the content area. Automatically set based on available space of the modal content. | `"both" \| "bottom" \| "none" \| "top"` | `'none'` |
+| Property | Attribute | Description                                                                                                     | Type                                    | Default  |
+| -------- | --------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------- | -------- |
+| `border` | `border`  | The border style for the content area. When not explicitly set, automatically determined based on scroll state. | `"both" \| "bottom" \| "none" \| "top"` | `'none'` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -88,6 +88,8 @@
 // Scrollable modal styles (default behavior)
 .pds-modal--scrollable {
   pds-modal-content {
+    border-block-end: 1px solid transparent;
+    border-block-start: 1px solid transparent;
     overflow-y: auto;
   }
 }

--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -43,8 +43,12 @@
   display: flex;
   flex-direction: column;
   margin: var(--pine-dimension-md);
-  max-height: calc(100vh - (calc(5vh + 96px)));
+  max-height: none;
   width: 100%;
+
+  &.pds-modal--scrollable {
+    max-height: calc(100vh - (calc(5vh + 96px)));
+  }
 
   @media (min-width: 992px) {
     margin-block-start: 6vh;
@@ -78,6 +82,20 @@
 .pds-modal-content {
   .pds-modal--fullscreen & {
     flex: 1;
+  }
+}
+
+// Scrollable modal styles (default behavior)
+.pds-modal--scrollable {
+  pds-modal-content {
+    overflow-y: auto;
+  }
+}
+
+// Non-scrollable modal styles
+.pds-modal:not(.pds-modal--scrollable) {
+  pds-modal-content {
+    overflow-y: visible;
   }
 }
 

--- a/libs/core/src/components/pds-modal/pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/pds-modal.tsx
@@ -35,7 +35,11 @@ export class PdsModal {
    */
   @Prop() size: 'sm' | 'md' | 'lg' | 'fullscreen' = 'md';
 
-  // Modal content is always scrollable by default
+  /**
+   * Whether the modal content should be scrollable
+   * @default true
+   */
+  @Prop() scrollable = true;
 
   /**
    * Emitted when the modal is opened
@@ -303,7 +307,11 @@ export class PdsModal {
         onClick={this.handleBackdropClick}
       >
         <div
-          class={`pds-modal pds-modal--${this.size} pds-modal--scrollable`}
+          class={{
+            'pds-modal': true,
+            [`pds-modal--${this.size}`]: true,
+            'pds-modal--scrollable': this.scrollable
+          }}
         >
           <slot></slot>
         </div>

--- a/libs/core/src/components/pds-modal/readme.md
+++ b/libs/core/src/components/pds-modal/readme.md
@@ -12,6 +12,7 @@
 | `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop           | `boolean`                              | `true`      |
 | `componentId`     | `component-id`     | A unique identifier used for the underlying component `id` attribute. | `string`                               | `undefined` |
 | `open`            | `open`             | Whether the modal is open                                             | `boolean`                              | `false`     |
+| `scrollable`      | `scrollable`       | Whether the modal content should be scrollable                        | `boolean`                              | `true`      |
 | `size`            | `size`             | The size of the modal                                                 | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -11,6 +11,7 @@ export default {
     backdropDismiss: true,
     componentId: 'modal-demo',
     open: false,
+    scrollable: true,
     size: 'md',
   },
   parameters: {
@@ -31,6 +32,7 @@ const BaseTemplate = (args) => html`
       component-id="${args.componentId}"
       size="${args.size}"
       ?backdrop-dismiss=${args.backdropDismiss}
+      ?scrollable=${args.scrollable}
       ?open=${args.open}
     >
       <pds-modal-header>
@@ -411,5 +413,86 @@ export const Fullscreen = FullscreenTemplate.bind({});
 Fullscreen.args = {
   size: 'fullscreen',
   componentId: 'fullscreen-modal',
+  open: false,
+};
+
+const NonScrollableTemplate = (args) => html`
+  <div style="padding: 1rem;">
+    <pds-button id="show-modal" onClick="document.querySelector('#${args.componentId}').open = true">
+      Open Non-Scrollable Modal
+    </pds-button>
+
+    <pds-modal
+      id="${args.componentId}"
+      component-id="${args.componentId}"
+      size="${args.size}"
+      ?backdrop-dismiss=${args.backdropDismiss}
+      ?scrollable=${args.scrollable}
+      ?open=${args.open}
+    >
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box
+            align-items="center"
+            fit
+            justify-content="space-between"
+          >
+            <pds-text tag="h2" size="h3">Non-Scrollable Modal</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#${args.componentId}').open = false"
+              aria-label="Close modal"
+              part="close-button"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+          <pds-box>
+            <pds-text tag="p" size="md">Content overflow is handled naturally</pds-text>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content>
+        <pds-box direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal has <code>scrollable={false}</code>, so content will overflow naturally without creating a scrollable area.</p>
+          <p>This is useful for:</p>
+          <ul>
+            <li>Fixed-height content</li>
+            <li>Custom overflow handling</li>
+            <li>Modals where you want content to extend beyond the modal bounds</li>
+          </ul>
+          <p>The content area will not have <code>overflow-y: auto</code> applied.</p>
+        </pds-box>
+      </pds-modal-content>
+
+      <pds-modal-footer>
+        <pds-box
+          justify-content="space-between"
+          fit
+          padding="md"
+        >
+          <pds-button variant="unstyled" onclick="document.querySelector('#${args.componentId}').open = false">Close</pds-button>
+          <pds-box gap="sm" justify-content="end">
+            <pds-button
+              variant="secondary"
+              onclick="document.querySelector('#${args.componentId}').open = false"
+            >
+              Cancel
+            </pds-button>
+            <pds-button variant="primary">Confirm</pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+  </div>
+`;
+
+export const NonScrollable = NonScrollableTemplate.bind({});
+NonScrollable.args = {
+  size: 'md',
+  componentId: 'non-scrollable-modal',
+  scrollable: false,
   open: false,
 };

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -32,8 +32,9 @@ const BaseTemplate = (args) => html`
       component-id="${args.componentId}"
       size="${args.size}"
       ?backdrop-dismiss=${args.backdropDismiss}
-      ?scrollable=${args.scrollable}
+      scrollable="${args.scrollable}"
       ?open=${args.open}
+      key="${args.scrollable ? 'scrollable' : 'non-scrollable'}"
     >
       <pds-modal-header>
         <pds-box direction="column" fit padding="md">
@@ -427,8 +428,9 @@ const NonScrollableTemplate = (args) => html`
       component-id="${args.componentId}"
       size="${args.size}"
       ?backdrop-dismiss=${args.backdropDismiss}
-      ?scrollable=${args.scrollable}
+      scrollable="${args.scrollable}"
       ?open=${args.open}
+      key="${args.scrollable ? 'scrollable' : 'non-scrollable'}"
     >
       <pds-modal-header>
         <pds-box direction="column" fit padding="md">

--- a/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
+++ b/libs/core/src/components/pds-modal/stories/pds-modal.stories.js
@@ -456,14 +456,23 @@ const NonScrollableTemplate = (args) => html`
       </pds-modal-header>
       <pds-modal-content>
         <pds-box direction="column" padding-inline-start="md" padding-inline-end="md">
-          <p>This modal has <code>scrollable={false}</code>, so content will overflow naturally without creating a scrollable area.</p>
-          <p>This is useful for:</p>
-          <ul>
-            <li>Fixed-height content</li>
-            <li>Custom overflow handling</li>
-            <li>Modals where you want content to extend beyond the modal bounds</li>
-          </ul>
-          <p>The content area will not have <code>overflow-y: auto</code> applied.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
+          <p>This modal has scrollable=false, so content will overflow naturally.</p>
+          <p>Use this when you want to control overflow behavior differently.</p>
+          <p>This is ideal for modals with fixed-height content or custom overflow handling.</p>
         </pds-box>
       </pds-modal-content>
 
@@ -495,4 +504,155 @@ NonScrollable.args = {
   componentId: 'non-scrollable-modal',
   scrollable: false,
   open: false,
+};
+
+const CustomBordersTemplate = () => html`
+  <div style="padding: 1rem;">
+    <pds-box gap="sm" direction="column">
+      <pds-text tag="h3" size="h4">Border Examples</pds-text>
+      <pds-box gap="sm" wrap>
+        <pds-button id="show-modal-none" onClick="document.querySelector('#border-none-modal').open = true">
+          border="none"
+        </pds-button>
+        <pds-button id="show-modal-top" onClick="document.querySelector('#border-top-modal').open = true">
+          border="top"
+        </pds-button>
+        <pds-button id="show-modal-bottom" onClick="document.querySelector('#border-bottom-modal').open = true">
+          border="bottom"
+        </pds-button>
+        <pds-button id="show-modal-both" onClick="document.querySelector('#border-both-modal').open = true">
+          border="both"
+        </pds-button>
+      </pds-box>
+    </pds-box>
+
+    <!-- Border None Modal -->
+    <pds-modal id="border-none-modal" component-id="border-none-modal" size="sm">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">No Borders</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#border-none-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content border="none">
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal content has <code>border="none"</code></p>
+          <p>No borders will be shown regardless of content length or scroll position.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onclick="document.querySelector('#border-none-modal').open = false">Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+
+    <!-- Border Top Modal -->
+    <pds-modal id="border-top-modal" component-id="border-top-modal" size="sm">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Top Border Only</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#border-top-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content border="top">
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal content has <code>border="top"</code></p>
+          <p>Only the top border is visible, indicating there's content above.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onclick="document.querySelector('#border-top-modal').open = false">Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+
+    <!-- Border Bottom Modal -->
+    <pds-modal id="border-bottom-modal" component-id="border-bottom-modal" size="sm">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Bottom Border Only</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#border-bottom-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content border="bottom">
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal content has <code>border="bottom"</code></p>
+          <p>Only the bottom border is visible, indicating there's content below.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onclick="document.querySelector('#border-bottom-modal').open = false">Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+
+    <!-- Border Both Modal -->
+    <pds-modal id="border-both-modal" component-id="border-both-modal" size="sm">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Both Borders</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#border-both-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content border="both">
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal content has <code>border="both"</code></p>
+          <p>Both top and bottom borders are visible, indicating content above and below.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onclick="document.querySelector('#border-both-modal').open = false">Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+  </div>
+`;
+
+export const CustomBorders = CustomBordersTemplate.bind({});
+CustomBorders.args = {
+  componentId: 'custom-borders-modal',
 };

--- a/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
@@ -31,7 +31,11 @@ export class MockPdsModal {
    */
   @Prop() size: 'sm' | 'md' | 'lg' | 'fullscreen' = 'md';
 
-  // Modal content is always scrollable by default
+  /**
+   * Whether the modal content should be scrollable
+   * @default true
+   */
+  @Prop() scrollable = true;
 
   /**
    * Whether the modal can be dismissed by clicking the backdrop
@@ -112,7 +116,7 @@ export class MockPdsModal {
     const modalClasses = {
       'pds-modal': true,
       [`pds-modal--${this.size}`]: true,
-      'pds-modal--scrollable': true, // Always scrollable by default
+      'pds-modal--scrollable': this.scrollable
     };
 
     const backdropClasses = {

--- a/libs/core/src/components/pds-modal/test/readme.md
+++ b/libs/core/src/components/pds-modal/test/readme.md
@@ -17,6 +17,7 @@ This component mimics the real PdsModal but without using the Popover API
 | `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop | `boolean`                              | `true`      |
 | `componentId`     | `component-id`     | The ID of the modal component                               | `string`                               | `undefined` |
 | `open`            | `open`             | Whether the modal is open                                   | `boolean`                              | `false`     |
+| `scrollable`      | `scrollable`       | Whether the modal content should be scrollable              | `boolean`                              | `true`      |
 | `size`            | `size`             | The size of the modal                                       | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 


### PR DESCRIPTION
# Description

- [x] add `scrollable` boolean to be able to opt out
- [x] fix dynamic border positioning on scroll


Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visit the Scrollable and non scrollable modal stories

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

