### PR TITLE
style(pds-modal): fix max height for fullscreen modals

### DIFF
--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -77,6 +77,10 @@
   margin: 0;
   max-height: 100vh;
   max-width: 100%;
+
+  &.pds-modal--scrollable {
+    max-height: 100vh;
+  }
 }
 
 .pds-modal-content {


### PR DESCRIPTION
# Description

- [x] resolve `max-height` not working for fullscreen modals

Fixes #(issue)

| Before | After |
|--------|--------|
|<img width="980" height="820" alt="Screenshot 2025-09-12 at 3 13 21 PM" src="https://github.com/user-attachments/assets/4d452def-63d5-4d83-ad87-203e9fd53e53" />|<img width="1005" height="825" alt="Screenshot 2025-09-12 at 3 13 07 PM" src="https://github.com/user-attachments/assets/96ab8874-419a-4072-93dd-1f5095465e9f" />|

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Visit the Modal view and verify the Fullscreen Modal covers the entire screen

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
