### PR TITLE
fix(pds-modal): add dvh unit to heights

### DIFF
--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -48,14 +48,26 @@
 
   &.pds-modal--scrollable {
     max-height: calc(100vh - (calc(5vh + 96px)));
+
+    @supports (height: 100dvh) {
+      max-height: calc(100dvh - (calc(5vh + 96px)));
+    }
   }
 
   @media (min-width: 992px) {
     margin-block-start: 6vh;
+
+    @supports (height: 100dvh) {
+      margin-block-start: 6dvh;
+    }
   }
 
   @media (min-width: 1200px) {
     margin-block-start: 8vh;
+
+    @supports (height: 100dvh) {
+      margin-block-start: 8dvh;
+    }
   }
 }
 
@@ -78,8 +90,16 @@
   max-height: 100vh;
   max-width: 100%;
 
+  @supports (height: 100dvh) {
+    max-height: 100dvh;
+  }
+
   &.pds-modal--scrollable {
     max-height: 100vh;
+
+    @supports (height: 100dvh) {
+      max-height: 100dvh;
+    }
   }
 }
 

--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -50,7 +50,7 @@
     max-height: calc(100vh - (calc(5vh + 96px)));
 
     @supports (height: 100dvh) {
-      max-height: calc(100dvh - (calc(5vh + 96px)));
+      max-height: calc(100dvh - (calc(5dvh + 96px)));
     }
   }
 


### PR DESCRIPTION
# Description
<!-- REQUIRED: add a short description of this update -->
- [x] add `dvh` units to resolve Safari height issue

Fixes [DSS-1532](https://kajabi.atlassian.net/browse/DSS-1532)

<!-- OPTIONAL(recommended): Show any visual updates -->
|  Before  |  After  |
|--------|--------|
|<img width="360" height="722" alt="Screenshot 2025-09-19 at 8 32 47 AM" src="https://github.com/user-attachments/assets/e351fd56-3af7-4437-88a2-43a07b98b318" />|<img width="1103" height="764" alt="Screenshot 2025-09-19 at 8 16 28 AM" src="https://github.com/user-attachments/assets/b4e0e62c-5f5b-4633-960a-4bf7550cae2d" />|


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
In Safari view the Modal view and verify it's using `dvh` units instead of `vh`

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS: Safari
- Browsers: IOS 18.3 at least Iphone 16
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

[DSS-1532]: https://kajabi.atlassian.net/browse/DSS-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

