### PR TITLE
fix: add combobox option group labels

### DIFF
--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -81,6 +81,7 @@ The secondary variant provides a subtle button appearance with a white backgroun
   }}
 >
   <pds-combobox component-id="combobox-trigger-secondary" label="Favorite Animal" placeholder="Select an animal" trigger="button" trigger-variant="secondary" mode="select-only">
+    <pds-text>Mammals</pds-text>
     <option value="cat">Cat</option>
     <option value="dog">Dog</option>
     <option value="panda">Panda</option>
@@ -819,3 +820,166 @@ When using custom layouts:
 3. **Maintain accessibility**: Ensure custom content is screen reader accessible
 4. **Keep it simple**: Don't overcomplicate layouts - focus on essential information
 5. **Test thoroughly**: Verify keyboard navigation and screen reader compatibility
+
+## Group Labels
+
+The combobox supports organizing options with group labels using either HTML `<optgroup>` elements or `<pds-text>` components. Group labels help categorize related options and improve the user experience when dealing with long lists.
+
+### Using Optgroup
+
+Use standard HTML `<optgroup>` elements to create semantic groupings:
+
+<DocCanvas client:only
+  mdxSource={{
+    webComponent: `<pds-combobox
+  component-id="combobox-optgroup-example"
+  label="Select Animal"
+  placeholder="Choose an animal"
+  trigger="button"
+  trigger-variant="secondary"
+  mode="select-only">
+  <optgroup label="Mammals">
+    <option value="cat">Cat</option>
+    <option value="dog">Dog</option>
+    <option value="elephant">Elephant</option>
+  </optgroup>
+  <optgroup label="Birds">
+    <option value="eagle">Eagle</option>
+    <option value="parrot">Parrot</option>
+    <option value="penguin">Penguin</option>
+  </optgroup>
+  <optgroup label="Fish">
+    <option value="salmon">Salmon</option>
+    <option value="shark">Shark</option>
+    <option value="tuna">Tuna</option>
+  </optgroup>
+</pds-combobox>`,
+    react: `<PdsCombobox
+  componentId="combobox-optgroup-example"
+  label="Select Animal"
+  placeholder="Choose an animal"
+  trigger="button"
+  triggerVariant="secondary"
+  mode="select-only">
+  <optgroup label="Mammals">
+    <option value="cat">Cat</option>
+    <option value="dog">Dog</option>
+    <option value="elephant">Elephant</option>
+  </optgroup>
+  <optgroup label="Birds">
+    <option value="eagle">Eagle</option>
+    <option value="parrot">Parrot</option>
+    <option value="penguin">Penguin</option>
+  </optgroup>
+  <optgroup label="Fish">
+    <option value="salmon">Salmon</option>
+    <option value="shark">Shark</option>
+    <option value="tuna">Tuna</option>
+  </optgroup>
+</PdsCombobox>`,
+  }}
+>
+  <pds-combobox
+    component-id="combobox-optgroup-example"
+    label="Select Animal"
+    placeholder="Choose an animal"
+    trigger="button"
+    trigger-variant="secondary"
+    mode="select-only">
+    <optgroup label="Mammals">
+      <option value="cat">Cat</option>
+      <option value="dog">Dog</option>
+      <option value="elephant">Elephant</option>
+    </optgroup>
+    <optgroup label="Birds">
+      <option value="eagle">Eagle</option>
+      <option value="parrot">Parrot</option>
+      <option value="penguin">Penguin</option>
+    </optgroup>
+    <optgroup label="Fish">
+      <option value="salmon">Salmon</option>
+      <option value="shark">Shark</option>
+      <option value="tuna">Tuna</option>
+    </optgroup>
+  </pds-combobox>
+</DocCanvas>
+
+### Using PDS Text Components
+
+Alternatively, use `<pds-text>` components as group labels for more styling control:
+
+<DocCanvas client:only
+  mdxSource={{
+    webComponent: `<pds-combobox
+  component-id="combobox-pds-text-example"
+  label="Select Product"
+  placeholder="Choose a product"
+  trigger="button"
+  trigger-variant="primary"
+  mode="select-only">
+  <pds-text>Software</pds-text>
+  <option value="ide">IDE</option>
+  <option value="editor">Code Editor</option>
+  <option value="compiler">Compiler</option>
+  <pds-text>Hardware</pds-text>
+  <option value="laptop">Laptop</option>
+  <option value="monitor">Monitor</option>
+  <option value="keyboard">Keyboard</option>
+  <pds-text>Services</pds-text>
+  <option value="hosting">Web Hosting</option>
+  <option value="domain">Domain Registration</option>
+  <option value="ssl">SSL Certificate</option>
+</pds-combobox>`,
+    react: `<PdsCombobox
+  componentId="combobox-pds-text-example"
+  label="Select Product"
+  placeholder="Choose a product"
+  trigger="button"
+  triggerVariant="primary"
+  mode="select-only">
+  <PdsText>Software</PdsText>
+  <option value="ide">IDE</option>
+  <option value="editor">Code Editor</option>
+  <option value="compiler">Compiler</option>
+  <PdsText>Hardware</PdsText>
+  <option value="laptop">Laptop</option>
+  <option value="monitor">Monitor</option>
+  <option value="keyboard">Keyboard</option>
+  <PdsText>Services</PdsText>
+  <option value="hosting">Web Hosting</option>
+  <option value="domain">Domain Registration</option>
+  <option value="ssl">SSL Certificate</option>
+</PdsCombobox>`,
+  }}
+>
+  <pds-combobox
+    component-id="combobox-pds-text-example"
+    label="Select Product"
+    placeholder="Choose a product"
+    trigger="button"
+    trigger-variant="primary"
+    mode="select-only">
+    <pds-text>Software</pds-text>
+    <option value="ide">IDE</option>
+    <option value="editor">Code Editor</option>
+    <option value="compiler">Compiler</option>
+    <pds-text>Hardware</pds-text>
+    <option value="laptop">Laptop</option>
+    <option value="monitor">Monitor</option>
+    <option value="keyboard">Keyboard</option>
+    <pds-text>Services</pds-text>
+    <option value="hosting">Web Hosting</option>
+    <option value="domain">Domain Registration</option>
+    <option value="ssl">SSL Certificate</option>
+  </pds-combobox>
+</DocCanvas>
+
+### Group Labels Best Practices
+
+When using group labels:
+
+1. **Keep labels concise**: Use short, descriptive labels that clearly categorize the options
+2. **Maintain logical grouping**: Group related options together in a way that makes sense to users
+3. **Consider filtering behavior**: Group labels are preserved when filtering, but only groups with matching options will be shown
+4. **Use consistent styling**: Choose either `<optgroup>` or `<pds-text>` consistently within a single combobox
+5. **Test accessibility**: Ensure group labels work well with screen readers and keyboard navigation

--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -919,15 +919,15 @@ Alternatively, use `<pds-text>` components as group labels for more styling cont
   trigger="button"
   trigger-variant="primary"
   mode="select-only">
-  <pds-text>Software</pds-text>
+  <pds-text color="secondary">Software</pds-text>
   <option value="ide">IDE</option>
   <option value="editor">Code Editor</option>
   <option value="compiler">Compiler</option>
-  <pds-text>Hardware</pds-text>
+  <pds-text color="secondary">Hardware</pds-text>
   <option value="laptop">Laptop</option>
   <option value="monitor">Monitor</option>
   <option value="keyboard">Keyboard</option>
-  <pds-text>Services</pds-text>
+  <pds-text color="secondary">Services</pds-text>
   <option value="hosting">Web Hosting</option>
   <option value="domain">Domain Registration</option>
   <option value="ssl">SSL Certificate</option>
@@ -939,15 +939,15 @@ Alternatively, use `<pds-text>` components as group labels for more styling cont
   trigger="button"
   triggerVariant="primary"
   mode="select-only">
-  <PdsText>Software</PdsText>
+  <PdsText color="secondary">Software</PdsText>
   <option value="ide">IDE</option>
   <option value="editor">Code Editor</option>
   <option value="compiler">Compiler</option>
-  <PdsText>Hardware</PdsText>
+  <PdsText color="secondary">Hardware</PdsText>
   <option value="laptop">Laptop</option>
   <option value="monitor">Monitor</option>
   <option value="keyboard">Keyboard</option>
-  <PdsText>Services</PdsText>
+  <PdsText color="secondary">Services</PdsText>
   <option value="hosting">Web Hosting</option>
   <option value="domain">Domain Registration</option>
   <option value="ssl">SSL Certificate</option>
@@ -961,15 +961,15 @@ Alternatively, use `<pds-text>` components as group labels for more styling cont
     trigger="button"
     trigger-variant="primary"
     mode="select-only">
-    <pds-text>Software</pds-text>
+    <pds-text color="secondary">Software</pds-text>
     <option value="ide">IDE</option>
     <option value="editor">Code Editor</option>
     <option value="compiler">Compiler</option>
-    <pds-text>Hardware</pds-text>
+    <pds-text color="secondary">Hardware</pds-text>
     <option value="laptop">Laptop</option>
     <option value="monitor">Monitor</option>
     <option value="keyboard">Keyboard</option>
-    <pds-text>Services</pds-text>
+    <pds-text color="secondary">Services</pds-text>
     <option value="hosting">Web Hosting</option>
     <option value="domain">Domain Registration</option>
     <option value="ssl">SSL Certificate</option>

--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -87,6 +87,8 @@ The secondary variant provides a subtle button appearance with a white backgroun
     <option value="panda">Panda</option>
     <option value="snake">Snake</option>
   </pds-combobox>
+
+> **Note**: The `pds-text` element above serves as a non-interactive group header. Users cannot select these labels - they only organize and categorize the selectable options below them.
 </DocCanvas>
 
 ### Primary
@@ -983,3 +985,12 @@ When using group labels:
 3. **Consider filtering behavior**: Group labels are preserved when filtering, but only groups with matching options will be shown
 4. **Use consistent styling**: Choose either `<optgroup>` or `<pds-text>` consistently within a single combobox
 5. **Test accessibility**: Ensure group labels work well with screen readers and keyboard navigation
+
+### ARIA and Accessibility Considerations
+
+Both `<optgroup>` and `<pds-text>` group labels are rendered as presentational items in the dropdown:
+
+- **`<optgroup>` elements**: Provide semantic grouping that is meaningful to screen readers. The `label` attribute is announced by assistive technology, helping users understand the relationship between options and their categories.
+- **`<pds-text>` elements**: Serve as visual group headers but are purely presentational. They do not provide semantic grouping information to screen readers.
+
+**Recommendation**: Use `<optgroup>` when semantic grouping is important for accessibility and screen reader users. Use `<pds-text>` when you only need visual organization without semantic meaning.

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -68,6 +68,7 @@
   align-items: center;
   background: transparent;
   border-radius: var(--pine-dimension-125);
+  color: var(--pine-color-text-secondary);
   cursor: pointer;
   display: flex;
   font: var(--pine-typography-body-medium);
@@ -105,12 +106,11 @@
 }
 
 .pds-combobox__group-label {
-  color: var(--pine-color-text-secondary);
+  color: var(--pine-color-text-placeholder);
   cursor: default;
-  font: var(--pine-typography-body-small);
-  font-weight: var(--pine-font-weight-semibold);
+  font: var(--pine-typography-heading-caption);
   margin-block-end: var(--pine-dimension-2xs);
-  margin-block-start: var(--pine-dimension-xs);
+  margin-block-start: var(--pine-dimension-150);
   padding: var(--pine-dimension-2xs) var(--pine-dimension-sm);
   text-transform: uppercase;
 

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -104,6 +104,21 @@
   margin-inline-start: var(--pine-dimension-150);
 }
 
+.pds-combobox__group-label {
+  color: var(--pine-color-text-secondary);
+  cursor: default;
+  font: var(--pine-typography-body-small);
+  font-weight: var(--pine-font-weight-semibold);
+  margin-block-end: var(--pine-dimension-2xs);
+  margin-block-start: var(--pine-dimension-xs);
+  padding: var(--pine-dimension-2xs) var(--pine-dimension-sm);
+  text-transform: uppercase;
+
+  &:first-child {
+    margin-block-start: 0;
+  }
+}
+
 .pds-combobox__button-trigger {
   align-items: center;
   background: var(--color-background-default, var(--pine-color-secondary));

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -373,7 +373,7 @@ export class PdsCombobox implements BasePdsProps {
    */
   @Method()
   async setFocus() {
-    this.inputEl?.focus();
+    (this.inputEl as HTMLElement | undefined)?.focus() ?? this.triggerEl?.focus();
   }
 
   /**

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -258,8 +258,13 @@ export class PdsCombobox implements BasePdsProps {
   }
 
   private filterOptions() {
+    // Ensure allItems includes optionEls if not already populated (for testing scenarios)
+    if (this.allItems.length === 0 && this.optionEls.length > 0) {
+      this.allItems = [...this.optionEls];
+    }
+
     if (this.mode === 'select-only') {
-      this.filteredItems = this.allItems;
+      this.filteredItems = [...this.allItems];
     } else {
       const val = this.value.toLowerCase();
       const filteredOptions = this.optionEls.filter(option => {
@@ -352,10 +357,20 @@ export class PdsCombobox implements BasePdsProps {
 
     switch (e.key) {
       case 'ArrowDown':
-        this.highlightedIndex = Math.min(this.highlightedIndex + 1, selectableOptions.length - 1);
+        // If no option is highlighted and we have options, start at 0
+        if (this.highlightedIndex < 0 && selectableOptions.length > 0) {
+          this.highlightedIndex = 0;
+        } else {
+          this.highlightedIndex = Math.min(this.highlightedIndex + 1, selectableOptions.length - 1);
+        }
         break;
       case 'ArrowUp':
-        this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+        // If no option is highlighted and we have options, start at last option
+        if (this.highlightedIndex < 0 && selectableOptions.length > 0) {
+          this.highlightedIndex = selectableOptions.length - 1;
+        } else {
+          this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+        }
         break;
       case 'Enter':
         if (this.isOpen && this.highlightedIndex >= 0 && this.highlightedIndex < selectableOptions.length) {

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -277,14 +277,22 @@ export class PdsCombobox implements BasePdsProps {
 
       this.allItems.forEach(item => {
         if (item.tagName === 'OPTGROUP' || item.tagName === 'PDS-TEXT') {
-          // This is a group label - store it but don't add yet
           currentGroupLabel = item as HTMLOptGroupElement | HTMLPdsTextElement;
         } else if (item.tagName === 'OPTION' && filteredOptions.includes(item as HTMLOptionElement)) {
-          // This is a matching option - add the group label first if we haven't already
-          if (currentGroupLabel && !this.filteredItems.includes(currentGroupLabel)) {
-            this.filteredItems.push(currentGroupLabel);
+          const optionEl = item as HTMLOptionElement;
+          const parent = optionEl.parentElement;
+          let labelToUse: HTMLOptGroupElement | HTMLPdsTextElement | null = null;
+          if (parent && parent.tagName === 'OPTGROUP') {
+            // Only use the actual parent optgroup as label
+            labelToUse = parent as HTMLOptGroupElement;
+          } else if (currentGroupLabel && currentGroupLabel.tagName === 'PDS-TEXT') {
+            // Allow pds-text to label subsequent top-level options until another label appears
+            labelToUse = currentGroupLabel as HTMLPdsTextElement;
           }
-          this.filteredItems.push(item);
+          if (labelToUse && !this.filteredItems.includes(labelToUse)) {
+            this.filteredItems.push(labelToUse);
+          }
+          this.filteredItems.push(optionEl);
         }
       });
     }

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -373,7 +373,11 @@ export class PdsCombobox implements BasePdsProps {
    */
   @Method()
   async setFocus() {
-    (this.inputEl as HTMLElement | undefined)?.focus() ?? this.triggerEl?.focus();
+    if (this.inputEl) {
+      this.inputEl.focus();
+    } else {
+      this.triggerEl?.focus();
+    }
   }
 
   /**

--- a/libs/core/src/components/pds-combobox/stories/pds-combobox.stories.js
+++ b/libs/core/src/components/pds-combobox/stories/pds-combobox.stories.js
@@ -192,3 +192,106 @@ Custom.args = {
   customTriggerContent: true,
   customOptionLayouts: true,
 };
+
+export const OptionGroupsOptgroup = (args) => html`
+<pds-combobox
+  component-id="combobox-optgroups"
+  label=${args.label}
+  placeholder=${args.placeholder}
+  trigger=${args.trigger}
+  trigger-variant=${args.triggerVariant}
+  mode=${args.mode}
+  trigger-width=${args.triggerWidth}
+  dropdown-width=${args.dropdownWidth}
+  max-height=${args.maxHeight}
+>
+  <optgroup label="Mammals">
+    <option value="cat">Cat</option>
+    <option value="dog">Dog</option>
+    <option value="elephant">Elephant</option>
+    <option value="whale">Whale</option>
+    <option value="dolphin">Dolphin</option>
+    <option value="tiger">Tiger</option>
+  </optgroup>
+  <optgroup label="Birds">
+    <option value="eagle">Eagle</option>
+    <option value="parrot">Parrot</option>
+    <option value="penguin">Penguin</option>
+    <option value="owl">Owl</option>
+    <option value="falcon">Falcon</option>
+  </optgroup>
+  <optgroup label="Fish">
+    <option value="salmon">Salmon</option>
+    <option value="shark">Shark</option>
+    <option value="tuna">Tuna</option>
+    <option value="goldfish">Goldfish</option>
+  </optgroup>
+  <optgroup label="Reptiles">
+    <option value="snake">Snake</option>
+    <option value="lizard">Lizard</option>
+    <option value="turtle">Turtle</option>
+    <option value="crocodile">Crocodile</option>
+  </optgroup>
+</pds-combobox>`;
+
+OptionGroupsOptgroup.args = {
+  componentId: 'combobox-optgroups',
+  label: 'Select Animal',
+  placeholder: 'Choose an animal',
+  trigger: 'button',
+  triggerVariant: 'secondary',
+  mode: 'select-only',
+  triggerWidth: '280px',
+  dropdownWidth: '280px',
+  maxHeight: '280px',
+};
+
+export const OptionGroupsPdsText = (args) => html`
+<pds-combobox
+  component-id="combobox-pds-text-groups"
+  label=${args.label}
+  placeholder=${args.placeholder}
+  trigger=${args.trigger}
+  trigger-variant=${args.triggerVariant}
+  mode=${args.mode}
+  trigger-width=${args.triggerWidth}
+  dropdown-width=${args.dropdownWidth}
+  max-height=${args.maxHeight}
+>
+  <pds-text>Frontend Technologies</pds-text>
+  <option value="react">React</option>
+  <option value="vue">Vue.js</option>
+  <option value="angular">Angular</option>
+  <option value="svelte">Svelte</option>
+  <option value="nextjs">Next.js</option>
+
+  <pds-text>Backend Technologies</pds-text>
+  <option value="nodejs">Node.js</option>
+  <option value="python">Python</option>
+  <option value="java">Java</option>
+  <option value="golang">Go</option>
+  <option value="rust">Rust</option>
+
+  <pds-text>Databases</pds-text>
+  <option value="postgresql">PostgreSQL</option>
+  <option value="mongodb">MongoDB</option>
+  <option value="mysql">MySQL</option>
+  <option value="redis">Redis</option>
+
+  <pds-text>Cloud Services</pds-text>
+  <option value="aws">AWS</option>
+  <option value="azure">Azure</option>
+  <option value="gcp">Google Cloud</option>
+  <option value="vercel">Vercel</option>
+</pds-combobox>`;
+
+OptionGroupsPdsText.args = {
+  componentId: 'combobox-pds-text-groups',
+  label: 'Select Technology',
+  placeholder: 'Choose a technology',
+  trigger: 'input',
+  mode: 'filter',
+  triggerWidth: '300px',
+  dropdownWidth: '300px',
+  maxHeight: '280px',
+};

--- a/libs/core/src/components/pds-combobox/stories/pds-combobox.stories.js
+++ b/libs/core/src/components/pds-combobox/stories/pds-combobox.stories.js
@@ -258,27 +258,27 @@ export const OptionGroupsPdsText = (args) => html`
   dropdown-width=${args.dropdownWidth}
   max-height=${args.maxHeight}
 >
-  <pds-text>Frontend Technologies</pds-text>
+  <pds-text color="secondary">Frontend Technologies</pds-text>
   <option value="react">React</option>
   <option value="vue">Vue.js</option>
   <option value="angular">Angular</option>
   <option value="svelte">Svelte</option>
   <option value="nextjs">Next.js</option>
 
-  <pds-text>Backend Technologies</pds-text>
+  <pds-text color="secondary">Backend Technologies</pds-text>
   <option value="nodejs">Node.js</option>
   <option value="python">Python</option>
   <option value="java">Java</option>
   <option value="golang">Go</option>
   <option value="rust">Rust</option>
 
-  <pds-text>Databases</pds-text>
+  <pds-text color="secondary">Databases</pds-text>
   <option value="postgresql">PostgreSQL</option>
   <option value="mongodb">MongoDB</option>
   <option value="mysql">MySQL</option>
   <option value="redis">Redis</option>
 
-  <pds-text>Cloud Services</pds-text>
+  <pds-text color="secondary">Cloud Services</pds-text>
   <option value="aws">AWS</option>
   <option value="azure">Azure</option>
   <option value="gcp">Google Cloud</option>

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -219,7 +219,7 @@ describe('pds-combobox', () => {
     component.optionEls = mockOptions;
     component.filterOptions();
 
-    expect(component.filteredOptions.length).toBe(3);
+    expect(component.filteredItems.length).toBe(3);
   });
 
     it('filters options in filter mode', async () => {
@@ -240,8 +240,9 @@ describe('pds-combobox', () => {
     component.value = 'ca';
     component.filterOptions();
 
-    expect(component.filteredOptions.length).toBe(1);
-    expect(component.filteredOptions[0].value).toBe('cat');
+    const filteredOptions = component.filteredItems.filter(item => item.tagName === 'OPTION');
+    expect(filteredOptions.length).toBe(1);
+    expect(filteredOptions[0].value).toBe('cat');
   });
 
     it('does not filter options in select-only mode', async () => {
@@ -262,7 +263,7 @@ describe('pds-combobox', () => {
     component.value = 'ca';
     component.filterOptions();
 
-    expect(component.filteredOptions.length).toBe(3);
+    expect(component.filteredItems.length).toBe(3);
   });
 
   it('opens dropdown when input is focused', async () => {
@@ -334,7 +335,7 @@ describe('pds-combobox', () => {
     ];
 
     component.optionEls = mockOptions;
-    component.filteredOptions = mockOptions;
+    component.filteredItems = mockOptions;
     component.isOpen = true;
 
     // Test arrow down
@@ -371,7 +372,7 @@ describe('pds-combobox', () => {
     const mockOption = createMockOption('cat', 'Cat');
 
     component.optionEls = [mockOption];
-    component.filteredOptions = [mockOption];
+    component.filteredItems = [mockOption];
     component.isOpen = true;
     component.highlightedIndex = 0;
 
@@ -514,7 +515,7 @@ describe('pds-combobox', () => {
       { value: 'dog', label: 'Dog', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
     ];
 
-    component.filteredOptions = mockOptions;
+    component.filteredItems = mockOptions;
     component.isOpen = true;
     await page.waitForChanges();
 
@@ -539,7 +540,7 @@ describe('pds-combobox', () => {
       { value: 'dog', label: 'Dog', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
     ];
 
-    component.filteredOptions = mockOptions;
+    component.filteredItems = mockOptions;
     component.isOpen = true;
     await page.waitForChanges();
 
@@ -569,7 +570,7 @@ describe('pds-combobox', () => {
       { value: 'cat', label: 'Cat', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
     ];
 
-    component.filteredOptions = mockOptions;
+    component.filteredItems = mockOptions;
     component.isOpen = true;
     await page.waitForChanges();
 
@@ -600,7 +601,7 @@ describe('pds-combobox', () => {
     // Use centralized state management to set selection
     (component as any).setSelectedOption(mockOption);
 
-    component.filteredOptions = [mockOption];
+    component.filteredItems = [mockOption];
     component.isOpen = true;
     await page.waitForChanges();
 
@@ -624,7 +625,7 @@ describe('pds-combobox', () => {
     ];
 
     component.optionEls = mockOptions;
-    component.filteredOptions = mockOptions;
+    component.filteredItems = mockOptions;
 
     // Test Enter key
     const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
@@ -827,7 +828,7 @@ describe('pds-combobox', () => {
       component.value = 'digital';
       component.filterOptions();
 
-      expect(component.filteredOptions).toContain(mockLayoutOption);
+      expect(component.filteredItems).toContain(mockLayoutOption);
     });
 
     it('renders layout options with innerHTML', async () => {
@@ -845,7 +846,7 @@ describe('pds-combobox', () => {
         innerHTML: '<pds-icon icon="card-paypal"></pds-icon>PayPal',
       } as unknown as HTMLOptionElement;
 
-      component.filteredOptions = [mockLayoutOption];
+      component.filteredItems = [mockLayoutOption];
       component.isOpen = true;
       await page.waitForChanges();
 
@@ -1005,7 +1006,7 @@ describe('pds-combobox', () => {
        } as unknown as HTMLOptionElement;
 
       component.optionEls = [mockLayoutOption];
-      component.filteredOptions = [mockLayoutOption];
+      component.filteredItems = [mockLayoutOption];
       component.isOpen = true;
       await page.waitForChanges();
 
@@ -1049,8 +1050,8 @@ describe('pds-combobox', () => {
       component.value = 'digital';
       component.filterOptions();
 
-      expect(component.filteredOptions).toContain(mockPayPalOption);
-      expect(component.filteredOptions).not.toContain(mockStripeOption);
+      expect(component.filteredItems).toContain(mockPayPalOption);
+      expect(component.filteredItems).not.toContain(mockStripeOption);
     });
   });
 
@@ -1089,7 +1090,7 @@ describe('pds-combobox', () => {
         hasAttribute: jest.fn((attr: string) => attr === 'data-layout'),
       } as unknown as HTMLOptionElement;
 
-      component.filteredOptions = [mockLayoutOption];
+      component.filteredItems = [mockLayoutOption];
       component.isOpen = true;
       await page.waitForChanges();
 

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -5,9 +5,12 @@ import { PdsCombobox } from '../pds-combobox';
 const createMockOption = (value: string, label: string, selected: boolean = false) => ({
   value,
   label,
+  tagName: 'OPTION',
+  textContent: label,
   hasAttribute: jest.fn((attr: string) => attr === 'selected' && selected),
   setAttribute: jest.fn(),
   removeAttribute: jest.fn(),
+  getAttribute: jest.fn(),
 } as unknown as HTMLOptionElement);
 
 describe('pds-combobox', () => {
@@ -511,8 +514,8 @@ describe('pds-combobox', () => {
 
     // Mock options
     const mockOptions = [
-      { value: 'cat', label: 'Cat', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
-      { value: 'dog', label: 'Dog', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
     ];
 
     component.filteredItems = mockOptions;
@@ -536,8 +539,8 @@ describe('pds-combobox', () => {
 
     // Mock options
     const mockOptions = [
-      { value: 'cat', label: 'Cat', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
-      { value: 'dog', label: 'Dog', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
     ];
 
     component.filteredItems = mockOptions;
@@ -567,7 +570,7 @@ describe('pds-combobox', () => {
 
     // Mock options
     const mockOptions = [
-      { value: 'cat', label: 'Cat', hasAttribute: jest.fn(() => false) } as unknown as HTMLOptionElement,
+      createMockOption('cat', 'Cat'),
     ];
 
     component.filteredItems = mockOptions;
@@ -592,11 +595,7 @@ describe('pds-combobox', () => {
     const component = page.rootInstance;
 
     // Mock selected option
-    const mockOption = {
-      value: 'cat',
-      label: 'Cat',
-      hasAttribute: jest.fn(() => false), // No longer relevant since we use React state
-    } as unknown as HTMLOptionElement;
+    const mockOption = createMockOption('cat', 'Cat');
 
     // Use centralized state management to set selection
     (component as any).setSelectedOption(mockOption);


### PR DESCRIPTION
# Description

<img width="410" height="450" alt="Screenshot 2025-09-24 at 6 52 28 PM" src="https://github.com/user-attachments/assets/e24c883f-0811-4333-8eca-3c72a1ae8873" />


Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any new dependencies or updates that are required for this change.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for non-selectable group labels in combobox options (via optgroup and pds-text), with grouped filtering, rendering, and navigation.
> 
> - **Combobox (`libs/core/src/components/pds-combobox`)**
>   - **Behavior**: Supports group labels in dropdown via `optgroup` and `pds-text`.
>     - Parses slotted items into `allItems`; filters into `filteredItems` preserving group structure.
>     - Keyboard navigation and selection operate only on `option` elements; group labels are presentational.
>     - `setFocus` falls back to trigger when no input; Enter/Arrow handling updated for selectable options.
>   - **Rendering**: Renders group labels as non-interactive list items with appropriate ARIA; options unchanged.
>   - **Styles**: Add `.pds-combobox__group-label` and set option text color to secondary.
> - **Docs (`docs/pds-combobox.mdx`)**
>   - Add "Group Labels" section with examples for `optgroup` and `pds-text`, best practices, and accessibility notes.
>   - Note about `pds-text` headers in examples.
> - **Stories (`stories/pds-combobox.stories.js`)**
>   - Add examples: `OptionGroupsOptgroup` and `OptionGroupsPdsText`.
> - **Tests (`test/pds-combobox.spec.tsx`)**
>   - Update to use `filteredItems` and tagName checks; adjust navigation/selection tests; extend layout filtering assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e610a904dca25e3c2140fc112e2fbb295acbd326. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->