### PR TITLE
fix(pds-tab): remove browser default focus ring

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -45,6 +45,10 @@ pds-tab {
     color: var(--pine-color-text);
   }
 
+  &:focus {
+    outline: none;
+  }
+
   &:focus-visible {
     outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);


### PR DESCRIPTION
# Description

- [x] overwrite the browser default focus ring to none

<img width="3016" height="746" alt="Screenshot 2025-09-25 at 15 06 56" src="https://github.com/user-attachments/assets/60c16fd8-858c-4ff8-b1fc-b3dcd2cdeb77" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
This is not visible in the pine design system. Only in the monolith. For certain tabs

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
