### PR TITLE
fix(pds-combobox): add enlarge icon to input trigger

### DIFF
--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -87,9 +87,8 @@ The secondary variant provides a subtle button appearance with a white backgroun
     <option value="panda">Panda</option>
     <option value="snake">Snake</option>
   </pds-combobox>
-
-> **Note**: The `pds-text` element above serves as a non-interactive group header. Users cannot select these labels - they only organize and categorize the selectable options below them.
 </DocCanvas>
+> **Note**: The `pds-text` element above serves as a non-interactive group header. Users cannot select these labels - they only organize and categorize the selectable options below them.
 
 ### Primary
 The primary variant uses Pine's primary color scheme, creating a more prominent button appearance suitable for primary actions.

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -2,6 +2,13 @@
   display: block;
 }
 
+:host([disabled="true"]) {
+  .pds-combobox__input-icon {
+    color: var(--pine-color-text-disabled);
+    pointer-events: none;
+  }
+}
+
 .pds-combobox {
   position: relative;
 }
@@ -57,7 +64,7 @@
   }
 }
 
-.pds-combobox__input-chevron {
+.pds-combobox__input-icon {
   color: var(--pine-color-text-secondary);
   pointer-events: none;
   position: absolute;

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -12,6 +12,13 @@
   margin-block-end: var(--pine-dimension-150);
 }
 
+.pds-combobox__input-wrapper {
+  align-items: center;
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+
 .pds-combobox__input {
   background: var(--pine-color-background-container);
   border: 1px solid var(--pine-color-border);
@@ -20,7 +27,7 @@
   color: var(--pine-color-text-active);
   flex: 1;
   font: var(--pine-typography-body-medium);
-  padding: var(--pine-dimension-xs) var(--pine-dimension-150);
+  padding: var(--pine-dimension-xs) var(--pine-dimension-450) var(--pine-dimension-xs) var(--pine-dimension-150);
   transition: border-color 0.2s ease;
   width: 100%;
 
@@ -48,6 +55,14 @@
   &::placeholder {
     color: var(--pine-color-text-placeholder);
   }
+}
+
+.pds-combobox__input-chevron {
+  color: var(--pine-color-text-secondary);
+  pointer-events: none;
+  position: absolute;
+  right: var(--pine-dimension-150);
+  z-index: 1;
 }
 
 .pds-combobox__listbox {

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -553,7 +553,7 @@ export class PdsCombobox implements BasePdsProps {
 
   // Helper method to render the caret icon
   private renderCaretIcon() {
-    return <pds-icon icon="caret-down" aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__button-trigger-chevron" />;
+    return <pds-icon icon="caret-down" aria-hidden="true" class="pds-combobox__button-trigger-chevron" />;
   }
 
   // Helper method to render layout content
@@ -634,7 +634,7 @@ export class PdsCombobox implements BasePdsProps {
                 autocomplete="off"
                 part="input"
               />
-              <pds-icon icon="enlarge" aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-chevron" />
+              <pds-icon icon="enlarge" aria-hidden="true" class="pds-combobox__input-chevron" />
             </div>
           ) : (
             <div

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -634,7 +634,7 @@ export class PdsCombobox implements BasePdsProps {
                 autocomplete="off"
                 part="input"
               />
-              <pds-icon icon="enlarge" aria-hidden="true" class="pds-combobox__input-chevron" />
+              <pds-icon icon="enlarge" aria-hidden="true" class="pds-combobox__input-icon" />
             </div>
           ) : (
             <div

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -609,31 +609,33 @@ export class PdsCombobox implements BasePdsProps {
             </label>
           )}
           {this.trigger === 'input' ? (
-            <input
-              ref={el => {
-                this.inputEl = el as HTMLInputElement;
-                this.triggerEl = el as HTMLElement;
-              }}
-              class="pds-combobox__input"
-              style={{ width: this.triggerWidth }}
-              type="text"
-              role="combobox"
-              aria-autocomplete="list"
-              aria-controls="pds-combobox-listbox"
-              aria-activedescendant={this.highlightedIndex >= 0 ? `pds-combobox-option-${this.highlightedIndex}` : undefined}
-              aria-expanded={this.isOpen ? 'true' : 'false'}
-              aria-disabled={this.disabled ? 'true' : 'false'}
-              aria-label={this.hideLabel ? this.label : undefined}
-              id={this.componentId}
-              value={this.value}
-              placeholder={this.placeholder}
-              disabled={this.disabled}
-              onInput={this.handleInput}
-              onFocus={this.handleFocus}
-              onKeyDown={this.handleKeyDown}
-              autocomplete="off"
-              part="input"
-            />
+            <div class="pds-combobox__input-wrapper" style={{ width: this.triggerWidth }}>
+              <input
+                ref={el => {
+                  this.inputEl = el as HTMLInputElement;
+                  this.triggerEl = el as HTMLElement;
+                }}
+                class="pds-combobox__input"
+                type="text"
+                role="combobox"
+                aria-autocomplete="list"
+                aria-controls="pds-combobox-listbox"
+                aria-activedescendant={this.highlightedIndex >= 0 ? `pds-combobox-option-${this.highlightedIndex}` : undefined}
+                aria-expanded={this.isOpen ? 'true' : 'false'}
+                aria-disabled={this.disabled ? 'true' : 'false'}
+                aria-label={this.hideLabel ? this.label : undefined}
+                id={this.componentId}
+                value={this.value}
+                placeholder={this.placeholder}
+                disabled={this.disabled}
+                onInput={this.handleInput}
+                onFocus={this.handleFocus}
+                onKeyDown={this.handleKeyDown}
+                autocomplete="off"
+                part="input"
+              />
+              <pds-icon icon="enlarge" aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-chevron" />
+            </div>
           ) : (
             <div
               class={triggerClass}

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -25,7 +25,7 @@ describe('pds-combobox', () => {
           <div class="pds-combobox" tabindex="-1">
             <div class="pds-combobox__input-wrapper" style="width: fit-content;">
               <input aria-autocomplete="list" aria-controls="pds-combobox-listbox" aria-disabled="false" aria-expanded="false" autocomplete="off" class="pds-combobox__input" id="test-combobox" part="input" role="combobox" type="text" value="" />
-              <pds-icon aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-chevron" icon="enlarge"></pds-icon>
+              <pds-icon aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-icon" icon="enlarge"></pds-icon>
             </div>
             <div style="display: none;">
               <slot></slot>

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -23,7 +23,10 @@ describe('pds-combobox', () => {
       <pds-combobox component-id="test-combobox">
         <mock:shadow-root>
           <div class="pds-combobox" tabindex="-1">
-            <input aria-autocomplete="list" aria-controls="pds-combobox-listbox" aria-disabled="false" aria-expanded="false" autocomplete="off" class="pds-combobox__input" id="test-combobox" part="input" role="combobox" style="width: fit-content;" type="text" value="" />
+            <div class="pds-combobox__input-wrapper" style="width: fit-content;">
+              <input aria-autocomplete="list" aria-controls="pds-combobox-listbox" aria-disabled="false" aria-expanded="false" autocomplete="off" class="pds-combobox__input" id="test-combobox" part="input" role="combobox" type="text" value="" />
+              <pds-icon aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-chevron" icon="enlarge"></pds-icon>
+            </div>
             <div style="display: none;">
               <slot></slot>
             </div>
@@ -929,9 +932,9 @@ describe('pds-combobox', () => {
         html: `<pds-combobox component-id="test-combobox" trigger="input" trigger-width="300px"></pds-combobox>`,
       });
 
-             const input = root?.shadowRoot?.querySelector('input') as HTMLInputElement;
-       expect(input?.style.width).toBe('300px');
-    });
+             const inputWrapper = root?.shadowRoot?.querySelector('.pds-combobox__input-wrapper') as HTMLElement;
+      expect(inputWrapper?.style.width).toBe('300px');
+   });
 
     it('applies trigger width to button trigger', async () => {
       const { root } = await newSpecPage({
@@ -949,8 +952,8 @@ describe('pds-combobox', () => {
         html: `<pds-combobox component-id="test-combobox" trigger="input"></pds-combobox>`,
       });
 
-             const input = root?.shadowRoot?.querySelector('input') as HTMLInputElement;
-       expect(input?.style.width).toBe('fit-content');
+             const inputWrapper = root?.shadowRoot?.querySelector('.pds-combobox__input-wrapper') as HTMLElement;
+      expect(inputWrapper?.style.width).toBe('fit-content');
     });
   });
 

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -25,7 +25,7 @@ describe('pds-combobox', () => {
           <div class="pds-combobox" tabindex="-1">
             <div class="pds-combobox__input-wrapper" style="width: fit-content;">
               <input aria-autocomplete="list" aria-controls="pds-combobox-listbox" aria-disabled="false" aria-expanded="false" autocomplete="off" class="pds-combobox__input" id="test-combobox" part="input" role="combobox" type="text" value="" />
-              <pds-icon aria-hidden="true" aria-label="dropdown indicator" class="pds-combobox__input-icon" icon="enlarge"></pds-icon>
+              <pds-icon aria-hidden="true" class="pds-combobox__input-icon" icon="enlarge"></pds-icon>
             </div>
             <div style="display: none;">
               <slot></slot>


### PR DESCRIPTION
# Description
- [x] Add dropdown icon to combobox input trigger variant

| Before | After |
|--------|--------|
|<img width="353" height="558" alt="Screenshot 2025-09-30 at 5 48 57 PM" src="https://github.com/user-attachments/assets/611d6979-4b93-4930-8213-47aff28edef2" />|<img width="505" height="565" alt="Screenshot 2025-09-30 at 5 48 33 PM" src="https://github.com/user-attachments/assets/188487a2-2cc9-4361-9cf3-6c4865b89f50" />|

## Summary
Enhanced the combobox input trigger to include a dropdown indicator icon on the right side, providing visual consistency with the button trigger variant.

## Changes
Component: Wrapped input in container div and added `enlarge` icon positioned on the right
Styles: Added input wrapper with flexbox layout and absolute positioning for icon
Tests: Updated test expectations to match new HTML structure

## Benefits
Visual Consistency: Input and button triggers now both show dropdown indicators
Better UX: Users can clearly see that the input has dropdown functionality
Accessibility: Icon properly hidden from screen readers while maintaining semantic meaning

## Testing
All existing functionality preserved
Updated unit tests pass
No breaking changes to public API



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the input trigger in a new container with a right-aligned `enlarge` icon, updates padding/disabled styles and width handling, removes caret aria-label, and updates tests/docs accordingly.
> 
> - **Component (`pds-combobox.tsx`)**:
>   - Wrap input trigger in `div.pds-combobox__input-wrapper`; add `<pds-icon icon="enlarge" class="pds-combobox__input-icon">`.
>   - Move `triggerWidth` style from `input` to wrapper; keep input full-width.
>   - Remove `aria-label` from caret icon in `renderCaretIcon`.
> - **Styles (`pds-combobox.scss`)**:
>   - Add `.pds-combobox__input-wrapper` and `.pds-combobox__input-icon` with positioning; increase input right padding to avoid overlap.
>   - Add disabled host rule to mute/harden input icon; general input disabled states unchanged.
> - **Tests**:
>   - Update snapshots/queries to expect `pds-combobox__input-wrapper` and input icon; assert width on wrapper (and default width).
> - **Docs**:
>   - Minor formatting fix: move group header note outside `DocCanvas` code block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7db2772e3d4b83ef23dcb04d95761082c1d8ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->