### PR TITLE
fix(pds-combobox): update keyboard button trigger open close functionality

### DIFF
--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -104,10 +104,7 @@
   }
 
   &:focus-visible {
-    border-color: var(--pine-color-border);
-    box-shadow: 0 0 0 2px var(--pine-color-focus-ring);
     outline: 0;
-    z-index: 1;
   }
 
   .pds-combobox__option--layout {

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -96,10 +96,18 @@
   font: var(--pine-typography-body-medium);
   justify-content: space-between;
   padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
+  position: relative;
   transition: background 0.15s;
 
   &[aria-selected="true"] {
     background: var(--pine-color-grey-150);
+  }
+
+  &:focus-visible {
+    border-color: var(--pine-color-border);
+    box-shadow: 0 0 0 2px var(--pine-color-focus-ring);
+    outline: 0;
+    z-index: 1;
   }
 
   .pds-combobox__option--layout {

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -149,11 +149,6 @@ export class PdsCombobox implements BasePdsProps {
     this.filterOptions();
   }
 
-  @Watch('isOpen')
-  handleIsOpenChange() {
-    // isOpen state changed - could add analytics or other side effects here if needed
-  }
-
   @Watch('selectedOption')
   handleSelectedOptionChange() {
     // Update the layout content when selected option changes
@@ -245,8 +240,6 @@ export class PdsCombobox implements BasePdsProps {
     return DOMPurify.sanitize(html, config);
   }
 
-
-
   // Helper method to check if option should render as layout
   private isOptionLayout(option: HTMLOptionElement): boolean {
     return this.customOptionLayouts && option.hasAttribute('data-layout');
@@ -263,7 +256,7 @@ export class PdsCombobox implements BasePdsProps {
   }
 
   private filterOptions() {
-    // Ensure allItems includes optionEls if not already populated (for testing scenarios)
+    // Ensure allItems includes optionEls if not already populated (for edge cases)
     if (this.allItems.length === 0 && this.optionEls.length > 0) {
       this.allItems = [...this.optionEls];
     }
@@ -343,12 +336,6 @@ export class PdsCombobox implements BasePdsProps {
     this.isOpen = true;
     this.filterOptions();
     setTimeout(() => this.openDropdownPositioning(), 0);
-  };
-
-  private handleFocus = () => {
-    // Don't automatically open dropdown on focus - wait for user interaction
-    // This matches the behavior of the button trigger variant
-    // The dropdown will open when user starts typing (handleInput) or presses arrow keys (handleKeyDown)
   };
 
   private handleInputClick = () => {
@@ -641,7 +628,7 @@ export class PdsCombobox implements BasePdsProps {
       if (!this.isOpen) {
         this.isOpen = true;
         this.filterOptions();
-        // Set highlighted index immediately for testing
+        // Set highlighted index immediately
         const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
         if (selectableOptions.length > 0) {
           this.highlightedIndex = 0;

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -348,7 +348,7 @@ export class PdsCombobox implements BasePdsProps {
   };
 
   private handleKeyDown = (e: KeyboardEvent) => {
-    if (!this.isOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Alt+ArrowDown')) {
+    if (!this.isOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp' || (e.altKey && e.key === 'ArrowDown'))) {
       e.preventDefault();
       this.isOpen = true;
       this.filterOptions();
@@ -359,7 +359,12 @@ export class PdsCombobox implements BasePdsProps {
       }
       setTimeout(() => {
         this.openDropdownPositioning();
-        this.focusFirstOption();
+        // For input trigger, use focusFirstOptionForArrowKeys to enable proper keyboard navigation
+        if (this.trigger === 'input') {
+          this.focusFirstOptionForArrowKeys();
+        } else {
+          this.focusFirstOption();
+        }
       }, 0);
       return;
     }

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -346,9 +346,18 @@ export class PdsCombobox implements BasePdsProps {
   };
 
   private handleFocus = () => {
-    this.isOpen = true;
-    this.filterOptions();
-    setTimeout(() => this.openDropdownPositioning(), 0);
+    // Don't automatically open dropdown on focus - wait for user interaction
+    // This matches the behavior of the button trigger variant
+    // The dropdown will open when user starts typing (handleInput) or presses arrow keys (handleKeyDown)
+  };
+
+  private handleInputClick = () => {
+    // Open dropdown when input is clicked (but not when tabbed into)
+    if (!this.isOpen) {
+      this.isOpen = true;
+      this.filterOptions();
+      setTimeout(() => this.openDropdownPositioning(), 0);
+    }
   };
 
   private handleKeyDown = (e: KeyboardEvent) => {

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -359,11 +359,12 @@ export class PdsCombobox implements BasePdsProps {
       }
       setTimeout(() => {
         this.openDropdownPositioning();
-        // For input trigger, use focusFirstOptionForArrowKeys to enable proper keyboard navigation
+        // For input trigger, keep focus on input and use aria-activedescendant
+        // For button trigger, move focus to first option for keyboard navigation
         if (this.trigger === 'input') {
-          this.focusFirstOptionForArrowKeys();
-        } else {
           this.focusFirstOption();
+        } else {
+          this.focusFirstOptionForArrowKeys();
         }
       }, 0);
       return;

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -862,7 +862,7 @@ export class PdsCombobox implements BasePdsProps {
                 role="combobox"
                 aria-autocomplete="list"
                 aria-controls="pds-combobox-listbox"
-                aria-activedescendant={this.highlightedIndex >= 0 ? `pds-combobox-option-${this.highlightedIndex}` : undefined}
+                aria-activedescendant={this.isOpen && this.highlightedIndex >= 0 ? `pds-combobox-option-${this.highlightedIndex}` : undefined}
                 aria-expanded={this.isOpen ? 'true' : 'false'}
                 aria-disabled={this.disabled ? 'true' : 'false'}
                 aria-label={this.hideLabel ? this.label : undefined}
@@ -871,7 +871,7 @@ export class PdsCombobox implements BasePdsProps {
                 placeholder={this.placeholder}
                 disabled={this.disabled}
                 onInput={this.handleInput}
-                onFocus={this.handleFocus}
+                onClick={this.handleInputClick}
                 onKeyDown={this.handleKeyDown}
                 autocomplete="off"
                 part="input"

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -622,29 +622,40 @@ export class PdsCombobox implements BasePdsProps {
   // Handler for button trigger click
   private onButtonTriggerClick = () => {
     this.isOpen = !this.isOpen;
-    if (this.isOpen) setTimeout(() => this.openDropdownPositioning(), 0);
+    if (this.isOpen) {
+      this.filterOptions();
+      // Set highlighted index and prepare for keyboard navigation
+      const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
+      if (selectableOptions.length > 0) {
+        this.highlightedIndex = 0;
+        // For button trigger, prepare for arrow-key navigation mode
+        this.isArrowKeyNavigationMode = true;
+      }
+      setTimeout(() => this.openDropdownPositioning(), 0);
+    } else {
+      // Reset navigation mode when closing
+      this.isArrowKeyNavigationMode = false;
+    }
   };
 
   // Handler for button trigger keyboard events
   private onButtonTriggerKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    if ((e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') && !this.isOpen) {
       e.preventDefault();
       e.stopPropagation(); // Prevent the event from bubbling and triggering click
 
-      if (!this.isOpen) {
-        this.isOpen = true;
-        this.filterOptions();
-        // Set highlighted index immediately
-        const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
-        if (selectableOptions.length > 0) {
-          this.highlightedIndex = 0;
-        }
-        setTimeout(() => {
-          this.openDropdownPositioning();
-          // For all button trigger keyboard opening, focus the first option so subsequent navigation works
-          this.focusFirstOptionForArrowKeys();
-        }, 0);
+      this.isOpen = true;
+      this.filterOptions();
+      // Set highlighted index immediately
+      const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
+      if (selectableOptions.length > 0) {
+        this.highlightedIndex = 0;
       }
+      setTimeout(() => {
+        this.openDropdownPositioning();
+        // For all button trigger keyboard opening, focus the first option so subsequent navigation works
+        this.focusFirstOptionForArrowKeys();
+      }, 0);
     } else if (e.key === 'Escape') {
       e.preventDefault();
       if (this.isOpen) {

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -411,6 +411,124 @@ describe('pds-combobox', () => {
     expect(component.isOpen).toBe(false);
   });
 
+  it('handles Home key to jump to first option', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
+      createMockOption('bird', 'Bird'),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 2; // Start at last option
+
+    const homeEvent = new KeyboardEvent('keydown', { key: 'Home' });
+    input?.dispatchEvent(homeEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(0);
+  });
+
+  it('handles End key to jump to last option', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
+      createMockOption('bird', 'Bird'),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 0; // Start at first option
+
+    const endEvent = new KeyboardEvent('keydown', { key: 'End' });
+    input?.dispatchEvent(endEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(2);
+  });
+
+  it('handles PageDown key to jump forward by 10 options', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    // Create 15 options
+    const mockOptions = Array.from({ length: 15 }, (_, i) =>
+      createMockOption(`option${i}`, `Option ${i}`)
+    );
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 0;
+
+    const pageDownEvent = new KeyboardEvent('keydown', { key: 'PageDown' });
+    input?.dispatchEvent(pageDownEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(10);
+
+    // Test that it doesn't go beyond last option
+    input?.dispatchEvent(pageDownEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(14); // Last option
+  });
+
+  it('handles PageUp key to jump backward by 10 options', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    // Create 15 options
+    const mockOptions = Array.from({ length: 15 }, (_, i) =>
+      createMockOption(`option${i}`, `Option ${i}`)
+    );
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 14; // Start at last option
+
+    const pageUpEvent = new KeyboardEvent('keydown', { key: 'PageUp' });
+    input?.dispatchEvent(pageUpEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(4);
+
+    // Test that it doesn't go below 0
+    input?.dispatchEvent(pageUpEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(0); // First option
+  });
+
   it('updates value when typing in input', async () => {
     const page = await newSpecPage({
       components: [PdsCombobox],
@@ -652,6 +770,61 @@ describe('pds-combobox', () => {
     await page.waitForChanges();
 
     expect(component.isOpen).toBe(true);
+
+    // Test ArrowUp key
+    component.isOpen = false;
+    const arrowUpEvent = new KeyboardEvent('keydown', { key: 'ArrowUp' });
+    button?.dispatchEvent(arrowUpEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(true);
+  });
+
+  it('handles button trigger escape key to close dropdown', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox" trigger="button"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const button = page.root?.shadowRoot?.querySelector('.pds-combobox__button-trigger');
+
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+    button?.dispatchEvent(escapeEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(false);
+    expect(component.highlightedIndex).toBe(-1);
+  });
+
+  it('delegates keyboard events to main handler when dropdown is open for button trigger', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox" trigger="button"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const button = page.root?.shadowRoot?.querySelector('.pds-combobox__button-trigger');
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 0;
+
+    // Test that Home key works when dropdown is open
+    const homeEvent = new KeyboardEvent('keydown', { key: 'Home' });
+    button?.dispatchEvent(homeEvent);
+    await page.waitForChanges();
+
+    expect(component.highlightedIndex).toBe(0);
   });
 
   it('handles disabled state for button trigger', async () => {
@@ -693,7 +866,7 @@ describe('pds-combobox', () => {
     expect(input?.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('updates aria-activedescendant when option is highlighted', async () => {
+  it('updates aria-activedescendant when option is highlighted and dropdown is open', async () => {
     const page = await newSpecPage({
       components: [PdsCombobox],
       html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
@@ -702,10 +875,148 @@ describe('pds-combobox', () => {
     const component = page.rootInstance;
     const input = page.root?.shadowRoot?.querySelector('input');
 
+    // Test that aria-activedescendant is not set when dropdown is closed
     component.highlightedIndex = 0;
+    component.isOpen = false;
+    await page.waitForChanges();
+
+    expect(input?.getAttribute('aria-activedescendant')).toBeNull();
+
+    // Test that aria-activedescendant is set when dropdown is open
+    component.isOpen = true;
     await page.waitForChanges();
 
     expect(input?.getAttribute('aria-activedescendant')).toBe('pds-combobox-option-0');
+  });
+
+  it('updates aria-activedescendant for button trigger when option is highlighted', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox" trigger="button"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const button = page.root?.shadowRoot?.querySelector('.pds-combobox__button-trigger');
+
+    component.highlightedIndex = 0;
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    expect(button?.getAttribute('aria-activedescendant')).toBe('pds-combobox-option-0');
+  });
+
+  it('renders options with proper ARIA attributes', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
+    ];
+
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    component.highlightedIndex = 0;
+    await page.waitForChanges();
+
+    const options = page.root?.shadowRoot?.querySelectorAll('.pds-combobox__option');
+    const firstOption = options?.[0];
+    const secondOption = options?.[1];
+
+    // Test aria-setsize and aria-posinset
+    expect(firstOption?.getAttribute('aria-setsize')).toBe('2');
+    expect(firstOption?.getAttribute('aria-posinset')).toBe('1');
+    expect(secondOption?.getAttribute('aria-setsize')).toBe('2');
+    expect(secondOption?.getAttribute('aria-posinset')).toBe('2');
+
+    // Test tabindex for highlighted vs non-highlighted options
+    expect(firstOption?.getAttribute('tabindex')).toBe('0');
+    expect(secondOption?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('renders listbox with proper ARIA attributes', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox" label="Choose Pet"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+    ];
+
+    component.filteredItems = mockOptions;
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    const listbox = page.root?.shadowRoot?.querySelector('.pds-combobox__listbox');
+
+    expect(listbox?.getAttribute('role')).toBe('listbox');
+    expect(listbox?.getAttribute('aria-label')).toBe('Choose Pet');
+    expect(listbox?.getAttribute('aria-multiselectable')).toBe('false');
+  });
+
+  it('handles Tab key to close dropdown and allow normal focus flow', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    component.isOpen = true;
+    component.highlightedIndex = 0;
+    await page.waitForChanges();
+
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab' });
+    input?.dispatchEvent(tabEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(false);
+    expect(component.highlightedIndex).toBe(-1);
+  });
+
+  it('handles space key on button trigger without triggering double toggle', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox" trigger="button"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const button = page.root?.shadowRoot?.querySelector('.pds-combobox__button-trigger');
+
+    const mockOptions = [
+      createMockOption('cat', 'Cat'),
+      createMockOption('dog', 'Dog'),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+
+    // Test space key - should open dropdown and stay open
+    const spaceKeyDownEvent = new KeyboardEvent('keydown', { key: ' ' });
+    const spaceKeyUpEvent = new KeyboardEvent('keyup', { key: ' ' });
+
+    button?.dispatchEvent(spaceKeyDownEvent);
+    button?.dispatchEvent(spaceKeyUpEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(true);
+    expect(component.highlightedIndex).toBe(0);
+
+    // Verify that clicking doesn't interfere with keyboard behavior
+    component.isOpen = false;
+    const clickEvent = new MouseEvent('click');
+    button?.dispatchEvent(clickEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(true);
   });
 
   it('restores selected option value when input is cleared and focus is lost', async () => {

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -272,7 +272,7 @@ describe('pds-combobox', () => {
     expect(component.filteredItems.length).toBe(3);
   });
 
-  it('opens dropdown when input is focused', async () => {
+  it('does not open dropdown when input is focused (consistent with button trigger)', async () => {
     const page = await newSpecPage({
       components: [PdsCombobox],
       html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
@@ -281,7 +281,41 @@ describe('pds-combobox', () => {
     const component = page.rootInstance;
     const input = page.root?.shadowRoot?.querySelector('input');
 
+    // Focus alone should not open the dropdown
     input?.dispatchEvent(new Event('focus'));
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(false);
+
+    // But typing should open the dropdown
+    const inputEvent = new Event('input');
+    Object.defineProperty(inputEvent, 'target', {
+      value: { value: 'test' },
+      enumerable: true,
+    });
+    input?.dispatchEvent(inputEvent);
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(true);
+  });
+
+  it('opens dropdown when input is clicked', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+    });
+
+    const component = page.rootInstance;
+    const input = page.root?.shadowRoot?.querySelector('input');
+
+    // Click should open the dropdown
+    input?.dispatchEvent(new Event('click'));
+    await page.waitForChanges();
+
+    expect(component.isOpen).toBe(true);
+
+    // Clicking again when already open should not close it (different from button behavior)
+    input?.dispatchEvent(new Event('click'));
     await page.waitForChanges();
 
     expect(component.isOpen).toBe(true);


### PR DESCRIPTION
# Description
- [x] resolved bug causing `isOpen` to close the panel when interacting with a keyboard
![combobox-keyboard-interaction](https://github.com/user-attachments/assets/6cff6c22-ef6b-4e16-909d-515cf02e25de)

Fixes [DSS-1541](https://kajabi.atlassian.net/browse/DSS-1541)

## Issues Fixed
- Critical bug: Button trigger was setting isOpen = false instead of true, preventing keyboard opening
- Shadow DOM focus: Focus detection failed when moving between trigger and dropdown options
- Inconsistent behavior: Arrow keys vs Enter/Space had different focus management strategies
- Focus desync: Visual highlight and DOM focus ring were out of sync during navigation

## Changes
- Fixed button trigger keyboard opening for all activation keys (Arrow Down/Up, Enter, Space)
- Added proper shadow DOM boundary handling in onComboboxFocusOut with listboxEl?.contains() check
- Implemented isArrowKeyNavigationMode flag to synchronize visual highlight with actual DOM focus
- Unified focus management so all keyboard opening methods move focus into dropdown consistently

## Result
Perfect keyboard accessibility with consistent behavior:
Tab to trigger → Focus on button 
Arrow/Enter/Space → Opens dropdown with focus on first option 
Arrow navigation → Visual highlight and focus ring move together 
Enter to select → Selects option and closes dropdown 
Escape → Closes dropdown and returns focus to trigger 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Comprehensive testing coverage:**
- **Unit tests** for all variants, events, component methods, and error handling
- **E2E tests** for user interactions, keyboard navigation, and popover behavior  
- **Cross-browser testing** for Firefox compatibility and fallback behavior
- **Manual testing** for visual consistency, accessibility, and positioning accuracy
- **Lint compliance** with Pine's strict boolean conditions and styling standards

**Test scenarios covered:**
- [x] unit tests
- [x] accessibility tests
- [x] tested manually

[DSS-1541]: https://kajabi.atlassian.net/browse/DSS-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves combobox keyboard/focus behavior, adds robust ARIA attributes, and updates tests for consistent, accessible input and button triggers.
> 
> - **Combobox Behavior & Focus**:
>   - Input: no longer opens on focus; opens on click/typing; supports Alt+ArrowDown to open.
>   - Button trigger: keyboard open via Enter/Space/ArrowUp/ArrowDown; prevents space key double-toggle; respects disabled tabIndex.
>   - Centralized focus helpers: `focusFirstOption`, `focusFirstOptionForArrowKeys`, `updateOptionFocus`, `restoreFocusToTrigger`; tracks `isArrowKeyNavigationMode`.
>   - Improved close logic: Escape/Tab close and restore focus; focus-out respects shadow DOM listbox.
> - **Keyboard Navigation**:
>   - Adds Home/End/PageUp/PageDown navigation and smoother ArrowUp/Down handling with scrolling.
> - **ARIA & Accessibility**:
>   - Uses `aria-activedescendant` (input and button) only when open; updates on highlight.
>   - Listbox: adds `aria-label`, `aria-multiselectable="false"`.
>   - Options: add `aria-setsize`, `aria-posinset`, optional `aria-label`, and managed `tabindex`.
> - **Rendering & Filtering**:
>   - Ensures `allItems` fallback for edge cases; minor comment tweak.
> - **Styles**:
>   - Options gain `position: relative`; suppress default `outline` on focus-visible.
> - **Tests**:
>   - Extensive new unit tests for open/close, key handling (Home/End/PageUp/PageDown/Escape/Tab), ARIA updates, button trigger behavior, and space-key handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd34470857ef3d68e493306810bd807a4e9468e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->