### PR TITLE
style(pds-dropdown-menu-separator): update separator styles for improved appearance

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
+++ b/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
@@ -26,7 +26,7 @@ import { components } from '../../../../dist/docs.json';
 
 
 ### Keyboard Interactions
-<pds-box border>
+<pds-box border border-radius="sm" fit>
   <pds-table component-id="keyboard-shortcuts" >
     <pds-table-head>
       <pds-table-head-cell>Key</pds-table-head-cell>
@@ -222,14 +222,14 @@ The dropdown menu can be positioned relative to the trigger using the placement 
   mdxSource={{
     react: `
 <PdsDropdownMenu placement="bottom-end">
-  <PdsButton slot="trigger">Open Menu</PdsButton>
+  <PdsChip slot="trigger" sentiment="success" variant="dropdown">Trigger/PdsChip>
   <PdsDropdownMenuItem>Item 1</PdsDropdownMenuItem>
   <PdsDropdownMenuItem>Item 2</PdsDropdownMenuItem>
 </PdsDropdownMenu>
 `,
     webComponent: `
 <pds-dropdown-menu placement="bottom-end">
-  <pds-button slot="trigger">Open Menu</pds-button>
+  <pds-chip slot="trigger" sentiment="success" variant="dropdown">Trigger</pds-chip>
   <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
   <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
 </pds-dropdown-menu>
@@ -237,13 +237,10 @@ The dropdown menu can be positioned relative to the trigger using the placement 
   }}
 >
 <div style={{ height: '200px', width: '100%', textAlign: 'center' }}>
-  <pds-dropdown-menu>
-   <pds-chip slot="trigger" sentiment="success">My trigger <pds-icon name="caret-down"></pds-icon></pds-chip>
+  <pds-dropdown-menu placement="bottom-end">
+   <pds-chip slot="trigger" sentiment="success" variant="dropdown">Trigger</pds-chip>
    <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
+   <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
   </pds-dropdown-menu>
-
 </div>
 </DocCanvas>
-
-
-

--- a/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
+++ b/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
@@ -83,20 +83,20 @@ The default dropdown menu displays a list of options that can be selected by the
 <DocCanvas client:only
   mdxSource={{
     react: `
-<PdsDropdown>
+<PdsDropdownMenu>
   <PdsButton slot="trigger">Trigger</PdsButton>
   <PdsDropdownItem>Item 1</PdsDropdownItem>
   <PdsDropdownItem>Item 2</PdsDropdownItem>
   <PdsDropdownItem>Item 3</PdsDropdownItem>
-</PdsDropdown>
+</PdsDropdownMenu>
 `,
     webComponent:`
-<pds-dropdown>
+<pds-dropdown-menu>
   <pds-button slot="trigger">Trigger</pds-button>
   <pds-dropdown-item>Item 1</pds-dropdown-item>
   <pds-dropdown-item>Item 2</pds-dropdown-item>
   <pds-dropdown-item>Item 3</pds-dropdown-item>
-</pds-dropdown>
+</pds-dropdown-menu>
 `
   }}
 >
@@ -144,6 +144,8 @@ The dropdown menu can also display a separator between items.
     <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
     <pds-dropdown-menu-separator />
     <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
+    <pds-dropdown-menu-separator />
+    <pds-dropdown-menu-item>Item 3</pds-dropdown-menu-item>
   </pds-dropdown-menu>
 </div>
 </DocCanvas>

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-separator/pds-dropdown-menu-separator.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-separator/pds-dropdown-menu-separator.scss
@@ -1,6 +1,9 @@
 :host {
   hr {
-    border: 1px solid var(--pine-color-border);
+    border: 0;
+    border-top: 1px solid var(--pine-color-border);
+    height: 0;
     margin-block: var(--pine-dimension-xs);
+    margin-inline: calc(var(--pine-dimension-xs) * -1);
   }
 }


### PR DESCRIPTION
# Description

Fixed the dropdown menu separator to render as exactly 1px thick by overriding default browser styles for the `<hr>` element. The separator was appearing thicker than intended due to browser default styles that apply borders on all sides and set a default height.

**Changes:**
- Reset `<hr>` border to 0 and height to 0
- Apply only `border-top: 1px solid` to ensure a crisp 1px separator line
- Corrected a few documentation inconsistencies

Fixes https://kajabi.atlassian.net/browse/DSS-1543

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="240" height="203" alt="Screenshot 2025-10-01 at 2 56 15 PM" src="https://github.com/user-attachments/assets/6b97ce9c-961f-4ee4-bbc4-e665ea9ef2ee" />|<img width="220" height="198" alt="Screenshot 2025-10-01 at 2 56 23 PM" src="https://github.com/user-attachments/assets/891ca4c1-8b1c-4fdb-baf9-3e5000ba4883" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test steps:**
1. Open a dropdown menu with separators in Storybook
2. Inspected the `<hr>` element in the separator component
3. Verified the separator now renders as exactly 1px thick without any additional browser default styling

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
