### PR TITLE
feat(pds-popover): implement methods control and events

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -10,12 +10,14 @@ import { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-in
 import { PlacementType } from "./utils/types";
 import { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 import { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
+import { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
 import { TextareaChangeEventDetail, TextareaInputEventDetail } from "./components/pds-textarea/textarea-interface";
 export { BoxColumnType, BoxShadowSizeType, BoxTShirtSizeType } from "./utils/types";
 export { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-interface";
 export { PlacementType } from "./utils/types";
 export { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 export { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
+export { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
 export { TextareaChangeEventDetail, TextareaInputEventDetail } from "./components/pds-textarea/textarea-interface";
 export namespace Components {
     /**
@@ -1261,6 +1263,10 @@ export namespace Components {
          */
         "componentId": string;
         /**
+          * Closes the popover programmatically
+         */
+        "hide": () => Promise<void>;
+        /**
           * Sets the maximum width of the popover content
           * @defaultValue 352
          */
@@ -1280,9 +1286,17 @@ export namespace Components {
          */
         "popoverType": 'auto' | 'manual';
         /**
+          * Opens the popover programmatically
+         */
+        "show": () => Promise<void>;
+        /**
           * Text that appears on the trigger element
          */
         "text": string;
+        /**
+          * Toggles the popover open/closed state programmatically
+         */
+        "toggle": () => Promise<void>;
     }
     interface PdsProgress {
         /**
@@ -1911,6 +1925,10 @@ export interface PdsModalCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsModalElement;
 }
+export interface PdsPopoverCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPdsPopoverElement;
+}
 export interface PdsRadioCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPdsRadioElement;
@@ -2240,7 +2258,19 @@ declare global {
         prototype: HTMLPdsModalHeaderElement;
         new (): HTMLPdsModalHeaderElement;
     };
+    interface HTMLPdsPopoverElementEventMap {
+        "pdsPopoverOpen": PdsPopoverEventDetail;
+        "pdsPopoverClose": PdsPopoverEventDetail;
+    }
     interface HTMLPdsPopoverElement extends Components.PdsPopover, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPdsPopoverElementEventMap>(type: K, listener: (this: HTMLPdsPopoverElement, ev: PdsPopoverCustomEvent<HTMLPdsPopoverElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPdsPopoverElementEventMap>(type: K, listener: (this: HTMLPdsPopoverElement, ev: PdsPopoverCustomEvent<HTMLPdsPopoverElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLPdsPopoverElement: {
         prototype: HTMLPdsPopoverElement;
@@ -3828,6 +3858,14 @@ declare namespace LocalJSX {
           * @defaultValue 352
          */
         "maxWidth"?: number;
+        /**
+          * Emitted when the popover is closed
+         */
+        "onPdsPopoverClose"?: (event: PdsPopoverCustomEvent<PdsPopoverEventDetail>) => void;
+        /**
+          * Emitted when the popover is opened
+         */
+        "onPdsPopoverOpen"?: (event: PdsPopoverCustomEvent<PdsPopoverEventDetail>) => void;
         /**
           * Determines the preferred position of the popover
           * @defaultValue "right"

--- a/libs/core/src/components/pds-popover/pds-popover.scss
+++ b/libs/core/src/components/pds-popover/pds-popover.scss
@@ -12,6 +12,12 @@
     max-width: var(--sizing-max-width-default);
     padding: var(--pine-dimension-md);
     position: fixed;
+
+    // Hide popover initially to prevent flash before positioning
+    // stylelint-disable-next-line selector-pseudo-class-no-unknown
+    &:popover-open:not(.pds-popover--positioned) {
+      visibility: hidden;
+    }
   }
 
   button {

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, Host, Listen, h, Method, Prop, State } from '@stencil/core';
 import { PlacementType } from '@utils/types';
-import { PdsPopoverEventDetail } from './popover-interface';
+import { PdsPopoverEventDetail, ToggleEvent } from './popover-interface';
 
 @Component({
   tag: 'pds-popover',
@@ -23,6 +23,11 @@ export class PdsPopover {
    * Bound reference to the toggle handler for proper cleanup
    */
   private boundToggleHandler: (event: Event) => void;
+
+  /**
+   * Tracks if the component is still mounted to prevent memory leaks
+   */
+  private isComponentMounted = true;
 
   /**
    * Emitted when the popover is opened
@@ -78,6 +83,8 @@ export class PdsPopover {
   }
 
   disconnectedCallback() {
+    this.isComponentMounted = false;
+
     // Clean up event listener
     const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
     if (popoverEl != null && this.boundToggleHandler != null) {
@@ -154,6 +161,9 @@ export class PdsPopover {
 
       // Position after the browser has rendered the popover, then show it
       requestAnimationFrame(() => {
+        // Prevent memory leak if component unmounts during animation frame
+        if (!this.isComponentMounted) return;
+
         this.handlePopoverPositioning();
         if (popoverEl != null) {
           popoverEl.classList.add('pds-popover--positioned');

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -1,5 +1,6 @@
-import { Component, Element, Host, Listen, h, Prop, State } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Host, Listen, h, Method, Prop, State } from '@stencil/core';
 import { PlacementType } from '@utils/types';
+import { PdsPopoverEventDetail } from './popover-interface';
 
 @Component({
   tag: 'pds-popover',
@@ -17,6 +18,21 @@ export class PdsPopover {
    * @defaultValue false
    */
   @State() active = false;
+
+  /**
+   * Bound reference to the toggle handler for proper cleanup
+   */
+  private boundToggleHandler: (event: Event) => void;
+
+  /**
+   * Emitted when the popover is opened
+   */
+  @Event() pdsPopoverOpen: EventEmitter<PdsPopoverEventDetail>;
+
+  /**
+   * Emitted when the popover is closed
+   */
+  @Event() pdsPopoverClose: EventEmitter<PdsPopoverEventDetail>;
 
   /**
    * Determines the action that triggers the popover. For manual popovers, the consumer is responsible for toggling this value.
@@ -52,15 +68,102 @@ export class PdsPopover {
    */
   @Prop({ reflect: true }) placement: PlacementType = 'right';
 
-  componentWillRender() {
-    this.handlePopoverPositioning();
+  componentDidLoad() {
+    // Attach toggle event listener to the popover element
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
+    if (popoverEl != null) {
+      this.boundToggleHandler = this.handleToggle.bind(this);
+      popoverEl.addEventListener('toggle', this.boundToggleHandler);
+    }
   }
 
-  @Listen('click', {
-    capture: true
-  })
-  handleClick() {
-    this.active = !this.active;
+  disconnectedCallback() {
+    // Clean up event listener
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
+    if (popoverEl != null && this.boundToggleHandler != null) {
+      popoverEl.removeEventListener('toggle', this.boundToggleHandler);
+    }
+  }
+
+  /**
+   * Opens the popover programmatically
+   */
+  @Method()
+  async show() {
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { showPopover?: () => void } | null;
+    if (popoverEl != null && typeof popoverEl.showPopover === 'function') {
+      try {
+        popoverEl.showPopover();
+      } catch (e) {
+        // Popover might already be open
+        console.warn('Failed to show popover:', e);
+      }
+    }
+  }
+
+  /**
+   * Closes the popover programmatically
+   */
+  @Method()
+  async hide() {
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { hidePopover?: () => void } | null;
+    if (popoverEl != null && typeof popoverEl.hidePopover === 'function') {
+      try {
+        popoverEl.hidePopover();
+      } catch (e) {
+        // Popover might already be closed
+        console.warn('Failed to hide popover:', e);
+      }
+    }
+  }
+
+  /**
+   * Toggles the popover open/closed state programmatically
+   */
+  @Method()
+  async toggle() {
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { togglePopover?: () => void } | null;
+    if (popoverEl != null && typeof popoverEl.togglePopover === 'function') {
+      try {
+        popoverEl.togglePopover();
+      } catch (e) {
+        console.warn('Failed to toggle popover:', e);
+      }
+    }
+  }
+
+  private handleToggle(event: Event) {
+    const toggleEvent = event as ToggleEvent;
+
+    // Prepare event detail
+    const eventDetail: PdsPopoverEventDetail = {
+      componentId: this.componentId,
+      popoverType: this.popoverType,
+      text: this.text,
+    };
+
+    // Update internal state based on native popover state
+    if (toggleEvent.newState === 'open') {
+      this.active = true;
+      const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
+
+      // Remove positioned class to hide popover via CSS
+      if (popoverEl != null) {
+        popoverEl.classList.remove('pds-popover--positioned');
+      }
+
+      // Position after the browser has rendered the popover, then show it
+      requestAnimationFrame(() => {
+        this.handlePopoverPositioning();
+        if (popoverEl != null) {
+          popoverEl.classList.add('pds-popover--positioned');
+        }
+      });
+      this.pdsPopoverOpen.emit(eventDetail);
+    } else if (toggleEvent.newState === 'closed') {
+      this.active = false;
+      this.pdsPopoverClose.emit(eventDetail);
+    }
   }
 
   @Listen('scroll', {
@@ -68,19 +171,25 @@ export class PdsPopover {
     capture: true
   })
   handleScroll() {
-    if (this.active) {
+    // Only reposition if the popover is actually open
+    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
+    if (popoverEl != null && this.active === true) {
       this.handlePopoverPositioning();
     }
   }
 
   private handlePopoverPositioning() {
-    const triggerEl = this.el.shadowRoot.querySelector('.pds-popover__trigger') as HTMLElement;
-    const popoverEl = this.el.shadowRoot.querySelector('div[popover]') as HTMLElement;
+    const triggerEl = this.el.shadowRoot.querySelector('.pds-popover__trigger');
+    const popoverEl = this.el.shadowRoot.querySelector('div[popover]');
 
-    if (!triggerEl || !popoverEl) return;
+    if (triggerEl == null || popoverEl == null) return;
 
-    const triggerRect = triggerEl.getBoundingClientRect();
-    const popoverRect = popoverEl.getBoundingClientRect();
+    // Cast to HTMLElement after null check for proper typing
+    const triggerElement = triggerEl as HTMLElement;
+    const popoverElement = popoverEl as HTMLElement;
+
+    const triggerRect = triggerElement.getBoundingClientRect();
+    const popoverRect = popoverElement.getBoundingClientRect();
 
     let top = 0;
     let left = 0;
@@ -137,8 +246,8 @@ export class PdsPopover {
         break;
     }
 
-    popoverEl.style.top = `${top}px`;
-    popoverEl.style.left = `${left}px`;
+    popoverElement.style.top = `${top}px`;
+    popoverElement.style.left = `${left}px`;
   }
 
   render() {
@@ -148,7 +257,6 @@ export class PdsPopover {
           class="pds-popover__trigger"
           popoverTarget={this.componentId}
           popoverTargetAction={this.popoverTargetAction}
-          onClick={this.handleClick}
         >
           {this.text}
         </button>

--- a/libs/core/src/components/pds-popover/popover-interface.ts
+++ b/libs/core/src/components/pds-popover/popover-interface.ts
@@ -1,0 +1,6 @@
+export interface PdsPopoverEventDetail {
+  componentId: string;
+  popoverType: 'auto' | 'manual';
+  text?: string;
+}
+

--- a/libs/core/src/components/pds-popover/popover-interface.ts
+++ b/libs/core/src/components/pds-popover/popover-interface.ts
@@ -4,3 +4,7 @@ export interface PdsPopoverEventDetail {
   text?: string;
 }
 
+export interface ToggleEvent extends Event {
+  newState: 'open' | 'closed';
+}
+

--- a/libs/core/src/components/pds-popover/readme.md
+++ b/libs/core/src/components/pds-popover/readme.md
@@ -17,6 +17,47 @@
 | `text`                | `text`                  | Text that appears on the trigger element                                                                                                                                                 | `string`                                                                                                                                                             | `undefined` |
 
 
+## Events
+
+| Event             | Description                        | Type                                 |
+| ----------------- | ---------------------------------- | ------------------------------------ |
+| `pdsPopoverClose` | Emitted when the popover is closed | `CustomEvent<PdsPopoverEventDetail>` |
+| `pdsPopoverOpen`  | Emitted when the popover is opened | `CustomEvent<PdsPopoverEventDetail>` |
+
+
+## Methods
+
+### `hide() => Promise<void>`
+
+Closes the popover programmatically
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `show() => Promise<void>`
+
+Opens the popover programmatically
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `toggle() => Promise<void>`
+
+Toggles the popover open/closed state programmatically
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ----------------------------------------------
 
 

--- a/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
+++ b/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
@@ -13,7 +13,7 @@ export default {
 	decorators: [withActions],
 	parameters: {
 		actions: {
-			handles: ['mouseEnter', 'mouseLeave', 'hidePdsPopover', 'showPdsPopover'],
+			handles: ['pdsPopoverOpen', 'pdsPopoverClose'],
 		},
 	},
 	title: 'components/Popover'

--- a/libs/core/src/components/pds-popover/test/pds-popover.e2e.ts
+++ b/libs/core/src/components/pds-popover/test/pds-popover.e2e.ts
@@ -9,9 +9,9 @@ describe('pds-popover', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('should handle trigger click interactions', async () => {
+  it('should handle trigger click interactions with toggle action', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+    await page.setContent('<pds-popover component-id="my-popover" popover-target-action="toggle" text="Show popover"></pds-popover>');
 
     const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
     const popoverContent = await page.find('pds-popover >>> div[popover]');
@@ -46,7 +46,7 @@ describe('pds-popover', () => {
 
   it('should respect manual mode', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" popover-type="manual" text="Show popover"></pds-popover>');
+    await page.setContent('<pds-popover component-id="my-popover" popover-type="manual" popover-target-action="toggle" text="Show popover"></pds-popover>');
 
     const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
     const popoverContent = await page.find('pds-popover >>> div[popover]');
@@ -59,5 +59,145 @@ describe('pds-popover', () => {
     await page.mouse.click(0, 0);
     await page.waitForChanges();
     expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+  });
+
+  it('should handle default show action (does not close on second click)', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+
+    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
+    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+
+    // First click opens
+    await triggerButton.click();
+    await page.waitForChanges();
+    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    expect(openSpy).toHaveReceivedEventTimes(1);
+
+    // Second click does nothing with default "show" action
+    await triggerButton.click();
+    await page.waitForChanges();
+    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    expect(openSpy).toHaveReceivedEventTimes(1); // Should not emit again
+  });
+
+  it('should emit events when opening and closing with toggle action', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="my-popover" popover-target-action="toggle" text="Show popover"></pds-popover>');
+
+    const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+    const closeSpy = await page.spyOnEvent('pdsPopoverClose');
+
+    // Open the popover by clicking trigger
+    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
+    await triggerButton.click();
+    await page.waitForChanges();
+
+    expect(openSpy).toHaveReceivedEvent();
+    expect(openSpy).toHaveReceivedEventTimes(1);
+
+    // Close the popover by clicking trigger again
+    await triggerButton.click();
+    await page.waitForChanges();
+
+    expect(closeSpy).toHaveReceivedEvent();
+    expect(closeSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it('should include event details in emitted events', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="test-popover" popover-type="auto" popover-target-action="toggle" text="Test Popover"></pds-popover>');
+
+    const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+    const closeSpy = await page.spyOnEvent('pdsPopoverClose');
+
+    // Open the popover
+    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
+    await triggerButton.click();
+    await page.waitForChanges();
+
+    expect(openSpy).toHaveReceivedEvent();
+    const openEvent = openSpy.firstEvent;
+    expect(openEvent.detail.componentId).toBe('test-popover');
+    expect(openEvent.detail.popoverType).toBe('auto');
+    expect(openEvent.detail.text).toBe('Test Popover');
+
+    // Close the popover
+    await triggerButton.click();
+    await page.waitForChanges();
+
+    expect(closeSpy).toHaveReceivedEvent();
+    const closeEvent = closeSpy.firstEvent;
+    expect(closeEvent.detail.componentId).toBe('test-popover');
+    expect(closeEvent.detail.popoverType).toBe('auto');
+    expect(closeEvent.detail.text).toBe('Test Popover');
+  });
+
+  it('should support programmatic show method', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+
+    const popover = await page.find('pds-popover');
+    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+
+    // Initially closed
+    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+
+    // Show programmatically
+    await popover.callMethod('show');
+    await page.waitForChanges();
+
+    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    expect(openSpy).toHaveReceivedEvent();
+    expect(openSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it('should support programmatic hide method', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+
+    const popover = await page.find('pds-popover');
+    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const closeSpy = await page.spyOnEvent('pdsPopoverClose');
+
+    // Open first
+    await popover.callMethod('show');
+    await page.waitForChanges();
+    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+
+    // Hide programmatically
+    await popover.callMethod('hide');
+    await page.waitForChanges();
+
+    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+    expect(closeSpy).toHaveReceivedEvent();
+    expect(closeSpy).toHaveReceivedEventTimes(1);
+  });
+
+  it('should support programmatic toggle method', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+
+    const popover = await page.find('pds-popover');
+    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+    const closeSpy = await page.spyOnEvent('pdsPopoverClose');
+
+    // Initially closed
+    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+
+    // Toggle to open
+    await popover.callMethod('toggle');
+    await page.waitForChanges();
+    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    expect(openSpy).toHaveReceivedEventTimes(1);
+
+    // Toggle to close
+    await popover.callMethod('toggle');
+    await page.waitForChanges();
+    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+    expect(closeSpy).toHaveReceivedEventTimes(1);
   });
 });


### PR DESCRIPTION
# Description

Added events and programmatic control methods to the `pds-popover` component, enabling developers to listen for open/close events and control the popover programmatically.

**Key Changes:**
- Added `pdsPopoverOpen` and `pdsPopoverClose` events with detailed payload (`componentId`, `popoverType`, `text`)
- Added `show()`, `hide()`, and `toggle()` public methods for programmatic control
- Improved integration with native Popover API by listening to native `toggle` events
- Updated Storybook stories to display events in the Actions tab

Fixes https://kajabi.atlassian.net/browse/DSS-1547

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests - Added 8 new unit tests covering events, methods, and event details
- [x] e2e tests - Added 3 new E2E tests for event emission and default behavior
- [x] tested manually - Verified in Storybook that events appear in the Actions tab and methods work correctly

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
