### PR TITLE
style(pds-input): correct styles for append/prepend button height

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -7,6 +7,7 @@
   --pds-button-border-radius-end-end: var(--pine-border-radius-full);
   --pds-button-border-radius-end-start: var(--pine-border-radius-full);
   --pds-button-min-height: var(--pine-dimension-450);
+  --pds-button-outline-offset: var(--pine-border-width);
   --color-border-default: transparent;
   --color-border-disabled: transparent;
   --color-border-focus: transparent;
@@ -48,9 +49,10 @@
   background-color: var(--pds-button-background, var(--color-background-default));
   border: var(--pds-button-border);
   border-color: var(--color-border-default);
+  border-radius: var(--pds-button-border-radius);
+  /* stylelint-disable-next-line order/properties-alphabetical-order */
   border-end-end-radius: var(--pds-button-border-radius-end-end, var(--pds-button-border-radius));
   border-end-start-radius: var(--pds-button-border-radius-end-start, var(--pds-button-border-radius));
-  border-radius: var(--pds-button-border-radius);
   border-start-end-radius: var(--pds-button-border-radius-start-end, var(--pds-button-border-radius));
   border-start-start-radius: var(--pds-button-border-radius-start-start, var(--pds-button-border-radius));
   box-sizing: border-box;
@@ -76,8 +78,9 @@
 
   &:focus-visible {
     border-color: var(--color-border-focus);
-    outline: var(--pine-outline-focus);
-    outline-offset: var(--pine-border-width);
+    box-shadow: var(--pds-button-box-shadow-focus, none);
+    outline: var(--pds-button-outline-focus, var(--pine-outline-focus));
+    outline-offset: var(--pds-button-outline-offset);
   }
 
   &:disabled {

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -65,6 +65,7 @@
     border: var(--pds-input-border-width) solid var(--pds-input-border-color);
     color: var(--pds-input-addon-color);
     display: flex;
+    overflow: visible;
   }
 
   &::part(prepend) {
@@ -84,18 +85,28 @@
 :host([has-prepend]) ::slotted(pds-button[slot="prepend"]) {
   --pds-button-background: var(--pds-input-addon-background);
   --pds-button-border: var(--pine-border-width-none);
+  --pds-button-border-radius: var(--pine-dimension-none);
   --pds-button-border-radius-end-end: var(--pine-dimension-none);
   --pds-button-border-radius-start-end: var(--pine-dimension-none);
-  --pds-button-min-height: var(--pine-dimension-450);
+  --pds-button-border-radius-start-start: var(--pds-input-border-radius);
+  --pds-button-border-radius-end-start: var(--pds-input-border-radius);
+  --pds-button-min-height: calc(var(--pine-dimension-450) - calc(2 * var(--pine-border-width)));
+  --pds-button-box-shadow-focus: 0 0 0 3px var(--pine-color-focus-ring);
+  --pds-button-outline-focus: none;
 }
 
 /* stylelint-disable-next-line */
 :host([has-append]) ::slotted(pds-button[slot="append"]) {
   --pds-button-background: var(--pds-input-addon-background);
   --pds-button-border: var(--pine-border-width-none);
+  --pds-button-border-radius: var(--pine-dimension-none);
   --pds-button-border-radius-end-start: var(--pine-dimension-none);
   --pds-button-border-radius-start-start: var(--pine-dimension-none);
-  --pds-button-min-height: var(--pine-dimension-450);
+  --pds-button-border-radius-start-end: var(--pds-input-border-radius);
+  --pds-button-border-radius-end-end: var(--pds-input-border-radius);
+  --pds-button-min-height: calc(var(--pine-dimension-450) - calc(2 * var(--pine-border-width)));
+  --pds-button-box-shadow-focus: 0 0 0 3px var(--pine-color-focus-ring);
+  --pds-button-outline-focus: none;
 }
 
 /* stylelint-disable-next-line */
@@ -235,6 +246,8 @@
     border-color: var(--pine-color-border-active);
     outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
+    position: relative;
+    z-index: 1;
 
     :host([has-prepend]) &,
     :host([has-append]) &,
@@ -254,6 +267,8 @@
 
     &:focus-visible {
       outline-color: var(--pine-color-focus-ring-danger);
+      position: relative;
+      z-index: 1;
     }
   }
 }

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -212,6 +212,27 @@ export const withPrependSelect = (args) => html`<pds-input
   </pds-select>
 </pds-input>`;
 
+export const withPrependButton = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-prepend-secondary-button"
+  debounce="${args.debounce}"
+  ?disabled=${args.disabled}
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  ?hide-label=${args.hideLabel}
+  ?invalid=${args.invalid}
+  label="Search Query"
+  name="${args.name}"
+  placeholder="Enter your search terms..."
+  ?readonly=${args.readonly}
+  ?required=${args.required}
+  type="text"
+  value="${args.value}">
+  <pds-button slot="prepend" variant="secondary" class="pds-input__prepend">
+    Filter
+  </pds-button>
+</pds-input>`;
+
 export const withAppendSelect = (args) => html`<pds-input
   autocomplete="${args.autocomplete}"
   component-id="pds-input-append-select"
@@ -233,6 +254,27 @@ export const withAppendSelect = (args) => html`<pds-input
     <option value="home">Home</option>
     <option value="work">Work</option>
   </pds-select>
+</pds-input>`;
+
+export const withAppendButton = (args) => html`<pds-input
+  autocomplete="${args.autocomplete}"
+  component-id="pds-input-append-secondary-button"
+  debounce="${args.debounce}"
+  ?disabled=${args.disabled}
+  error-message="${args.errorMessage}"
+  helper-message="${args.helperMessage}"
+  ?hide-label=${args.hideLabel}
+  ?invalid=${args.invalid}
+  label="Search Query"
+  name="${args.name}"
+  placeholder="Enter your search terms..."
+  ?readonly=${args.readonly}
+  ?required=${args.required}
+  type="text"
+  value="${args.value}">
+  <pds-button slot="append" variant="secondary" class="pds-input__append">
+    Search
+  </pds-button>
 </pds-input>`;
 
 export const withPrefixAndAppend = (args) => html`<pds-input


### PR DESCRIPTION
# Description

Fixed button alignment and focus state issues when using buttons in `pds-input` prepend/append slots.

**Issues fixed:**
- Button height was 2px taller than the input field (not accounting for prepend/append container borders)
- Button focus ring had incorrect border-radius (fully rounded instead of squared off where it meets the input)
- Button focus ring was thinner (2px) than input outline (3px)
- Input focus outline was clipped when adjacent to buttons

**Changes:**
- Updated button component to support customizable focus states via CSS variables (`--pds-button-box-shadow-focus`, `--pds-button-outline-focus`, `--pds-button-outline-offset`)
- Fixed button height calculation in prepend/append slots to account for container borders
- Switched button focus state from `outline` to `box-shadow` in input slots (box-shadow respects complex border-radius)
- Set all four button corner radii explicitly to achieve proper mixed-radius appearance
- Added `z-index` and `overflow: visible` to prevent input focus outline clipping
- Added Storybook story for prepend button variant

Fixes: https://kajabi.atlassian.net/browse/DSS-1551

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="527" height="93" alt="Screenshot 2025-10-06 at 4 36 08 PM" src="https://github.com/user-attachments/assets/3814d294-5ff4-4c28-964b-9d491f7d9fff" />|<img width="524" height="98" alt="Screenshot 2025-10-06 at 4 36 16 PM" src="https://github.com/user-attachments/assets/6adb6780-f467-433d-96f0-5a2bd5ec1d9a" />|
|<img width="527" height="91" alt="Screenshot 2025-10-06 at 4 36 51 PM" src="https://github.com/user-attachments/assets/e74bc50f-326f-4f0c-906f-5ef93a3c8492" />|<img width="527" height="92" alt="Screenshot 2025-10-06 at 4 37 00 PM" src="https://github.com/user-attachments/assets/c437afc7-5ff1-4c91-bbd9-82d635d998f2" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually
- [x] other: Storybook visual testing with new `withPrependSecondaryButton` and existing `withAppendSecondaryButton` stories

**Test scenarios:**
1. Verified button aligns vertically with input field
2. Verified button focus ring has correct border-radius (rounded outer corners, squared where it meets input)
3. Verified button and input focus rings are same thickness (3px)
4. Verified input focus ring is not clipped by prepend/append containers
5. Tested with both prepend and append button placements

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
