### PR TITLE
docs(): add responsive breakpoints section to layout documentation

### DIFF
--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -1046,6 +1046,10 @@ Control whether flex items wrap to new lines when they don't fit in the containe
 
 All the following properties support responsive variants that allow different values at different screen sizes. This enables fine-grained control over layout behavior across devices.
 
+### Responsive Breakpoints
+
+For detailed information about responsive breakpoints and how they work with the layout system, see the [Layout documentation](/docs/components-layout--docs#responsive-breakpoints).
+
 ### Responsive Gap
 
 Control spacing between items at different breakpoints:

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -53,6 +53,10 @@ The pds-row component creates a 12-column grid system for responsive layouts. It
 - `size-md="6"` + `size-md="6"` = 50/50 on medium+ screens
 - `size-sm="12"` + `size-md="6"` = Full width on small, half on medium+
 
+## Responsive Breakpoints
+
+For detailed information about responsive breakpoints and how they work with the grid system, see the [Layout documentation](/docs/components-layout--docs#responsive-breakpoints).
+
 ## Variants
 
 ### Default

--- a/libs/core/src/stories/guides/layout.docs.mdx
+++ b/libs/core/src/stories/guides/layout.docs.mdx
@@ -737,6 +737,63 @@ This creates a two-column layout, and you can customize the `size` and arrangeme
 
 Using the size modifiers such as `-xs`, `-md`, etc, enable responsive behavior for you `pds-box`. The layout components are designed to be responsive, allowing you to create layouts that adapt to different screen sizes. Take advantage of properties like `size-xs`, `offset-sm`, etc., to customize the layout for specific breakpoints. Be sure to optimize your layout for mobile devices, as well as larger screens.
 
+### Responsive Breakpoints
+
+The layout system uses the following breakpoints for responsive sizing and properties:
+
+<pds-box border border-radius="sm" fit>
+  <pds-table component-id="layout-breakpoints" responsive>
+    <pds-table-head>
+      <pds-table-head-cell>Breakpoint</pds-table-head-cell>
+      <pds-table-head-cell>Suffix</pds-table-head-cell>
+      <pds-table-head-cell>Media Query</pds-table-head-cell>
+      <pds-table-head-cell>Screen Size</pds-table-head-cell>
+    </pds-table-head>
+    <pds-table-body>
+      <pds-table-row>
+        <pds-table-cell>Extra Small</pds-table-cell>
+        <pds-table-cell><code>-xs</code></pds-table-cell>
+        <pds-table-cell><code>max-width: 575px</code></pds-table-cell>
+        <pds-table-cell>Up to 575px (mobile devices)</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Small</pds-table-cell>
+        <pds-table-cell><code>-sm</code></pds-table-cell>
+        <pds-table-cell><code>min-width: 576px</code></pds-table-cell>
+        <pds-table-cell>576px and up (tablets)</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Medium</pds-table-cell>
+        <pds-table-cell><code>-md</code></pds-table-cell>
+        <pds-table-cell><code>min-width: 768px</code></pds-table-cell>
+        <pds-table-cell>768px and up (larger tablets, small desktops)</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Large</pds-table-cell>
+        <pds-table-cell><code>-lg</code></pds-table-cell>
+        <pds-table-cell><code>min-width: 992px</code></pds-table-cell>
+        <pds-table-cell>992px and up (desktops)</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Extra Large</pds-table-cell>
+        <pds-table-cell><code>-xl</code></pds-table-cell>
+        <pds-table-cell><code>min-width: 1200px</code></pds-table-cell>
+        <pds-table-cell>1200px and up (large desktops)</pds-table-cell>
+      </pds-table-row>
+    </pds-table-body>
+  </pds-table>
+</pds-box>
+
+**How breakpoints work:**
+- **`xs`**: Applies only on extra small screens (up to 575px)
+- **`sm`, `md`, `lg`, `xl`**: Apply at their breakpoint and larger (mobile-first approach)
+- **Cascading**: Larger breakpoints override smaller ones
+
+**Common responsive patterns:**
+- Stack on mobile, columns on tablet: Use `size-xs="12" size-sm="6"`
+- Progressive refinement: Use `size-md="6" size-lg="4" size-xl="3"` for 2/3/4 column layouts
+- Hide/show at breakpoints: Use `size-xs="0" size-md="12"` to hide on mobile
+
 <DocCanvas client:only
   mdxSource={{
     react: `


### PR DESCRIPTION
# Description

Added comprehensive responsive breakpoint documentation to the Layout guide and updated component documentation to reference this centralized source.

**Changes:**
- Added detailed responsive breakpoints table to Layout documentation (`layout.docs.mdx`)
- Documented all 5 breakpoints (xs, sm, md, lg, xl) with media queries and screen sizes
- Updated `pds-box` and `pds-row` documentation to link to the centralized breakpoints section
- Used `pds-table` component for consistent formatting matching other documentation tables

**Benefits:**
- Single source of truth for responsive breakpoint information
- Easier maintenance - updates only needed in one location
- Better organization with breakpoints documented at the layout system level

Fixes https://kajabi.atlassian.net/browse/DSS-1548


|  Screenshot   | 
|--------|
| <img width="1068" height="675" alt="Screenshot 2025-10-07 at 4 25 21 PM" src="https://github.com/user-attachments/assets/5747cad3-ef59-438c-9127-af1493a5d41c" />|

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually - verified documentation renders correctly in Storybook
- [x] Verified links navigate properly between component docs and Layout guide
- [x] Confirmed table displays correctly with responsive prop
- [x] No linting errors introduced

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
