### PR TITLE
fix(pds-combobox): update hightlighed option logic when selected

### DIFF
--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -343,6 +343,7 @@ export class PdsCombobox implements BasePdsProps {
     if (!this.isOpen) {
       this.isOpen = true;
       this.filterOptions();
+      this.setInitialHighlightedIndex();
       setTimeout(() => this.openDropdownPositioning(), 0);
     }
   };
@@ -353,10 +354,7 @@ export class PdsCombobox implements BasePdsProps {
       this.isOpen = true;
       this.filterOptions();
       // Set highlighted index immediately for testing
-      const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
-      if (selectableOptions.length > 0) {
-        this.highlightedIndex = 0;
-      }
+      this.setInitialHighlightedIndex();
       setTimeout(() => {
         this.openDropdownPositioning();
         // For input trigger, keep focus on input and use aria-activedescendant
@@ -464,13 +462,38 @@ export class PdsCombobox implements BasePdsProps {
   }
 
   /**
+   * Sets the initial highlighted index when dropdown opens.
+   * If there's a selected option, highlight it. Otherwise, highlight the first option.
+   */
+  private setInitialHighlightedIndex() {
+    const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION') as HTMLOptionElement[];
+
+    if (selectableOptions.length === 0) {
+      this.highlightedIndex = -1;
+      return;
+    }
+
+    // If there's a selected option, find its index in the filtered options
+    if (this.selectedOption) {
+      const selectedIndex = selectableOptions.findIndex(option => option === this.selectedOption);
+      if (selectedIndex >= 0) {
+        this.highlightedIndex = selectedIndex;
+        return;
+      }
+    }
+
+    // No selected option or selected option not in filtered results, highlight first option
+    this.highlightedIndex = 0;
+  }
+
+  /**
    * Focus management helper - moves focus to the first option when dropdown opens
    */
   private focusFirstOption() {
     if (this.isOpen) {
       const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
       if (selectableOptions.length > 0) {
-        this.highlightedIndex = 0;
+        this.setInitialHighlightedIndex();
         // DON'T focus the option elements - keep focus on trigger and use aria-activedescendant
         // This prevents the focusout event that was closing the dropdown
         // But still call updateOptionFocus for scrolling
@@ -491,20 +514,20 @@ export class PdsCombobox implements BasePdsProps {
 
       const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
       if (selectableOptions.length > 0) {
-        this.highlightedIndex = 0;
-        // For arrow key navigation, actually focus the first option
+        this.setInitialHighlightedIndex();
+        // For arrow key navigation, actually focus the highlighted option
         if (this.listboxEl) {
           const optionElements = this.listboxEl.querySelectorAll('[role="option"]');
-          const firstOption = optionElements[0] as HTMLElement;
-          if (firstOption) {
+          const highlightedOption = optionElements[this.highlightedIndex] as HTMLElement;
+          if (highlightedOption) {
             // Remove tabindex from all options first
             optionElements.forEach(option => {
               (option as HTMLElement).setAttribute('tabindex', '-1');
             });
-            // Set tabindex and focus on first option
-            firstOption.setAttribute('tabindex', '0');
-            firstOption.focus();
-            firstOption.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            // Set tabindex and focus on highlighted option
+            highlightedOption.setAttribute('tabindex', '0');
+            highlightedOption.focus();
+            highlightedOption.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
           }
         }
         // Update aria-activedescendant on trigger
@@ -625,12 +648,9 @@ export class PdsCombobox implements BasePdsProps {
     if (this.isOpen) {
       this.filterOptions();
       // Set highlighted index and prepare for keyboard navigation
-      const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
-      if (selectableOptions.length > 0) {
-        this.highlightedIndex = 0;
-        // For button trigger, prepare for arrow-key navigation mode
-        this.isArrowKeyNavigationMode = true;
-      }
+      this.setInitialHighlightedIndex();
+      // For button trigger, prepare for arrow-key navigation mode
+      this.isArrowKeyNavigationMode = true;
       setTimeout(() => this.openDropdownPositioning(), 0);
     } else {
       // Reset navigation mode when closing
@@ -647,10 +667,7 @@ export class PdsCombobox implements BasePdsProps {
       this.isOpen = true;
       this.filterOptions();
       // Set highlighted index immediately
-      const selectableOptions = this.filteredItems.filter(item => item.tagName === 'OPTION');
-      if (selectableOptions.length > 0) {
-        this.highlightedIndex = 0;
-      }
+      this.setInitialHighlightedIndex();
       setTimeout(() => {
         this.openDropdownPositioning();
         // For all button trigger keyboard opening, focus the first option so subsequent navigation works

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -861,6 +861,105 @@ describe('pds-combobox', () => {
     expect(component.highlightedIndex).toBe(0);
   });
 
+  it('highlights selected option when dropdown reopens', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `
+        <pds-combobox component-id="test-combobox">
+          <option value="dog">Dog</option>
+          <option value="cat">Cat</option>
+          <option value="bird">Bird</option>
+        </pds-combobox>
+      `,
+    });
+
+    const component = page.rootInstance;
+    const mockOptions = [
+      createMockOption('dog', 'Dog', false),
+      createMockOption('cat', 'Cat', true), // Selected
+      createMockOption('bird', 'Bird', false),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    (component as any).setSelectedOption(mockOptions[1]);
+
+    // Open dropdown
+    component.isOpen = true;
+    (component as any).setInitialHighlightedIndex();
+    await page.waitForChanges();
+
+    // Should highlight the selected option (index 1), not the first option (index 0)
+    expect(component.highlightedIndex).toBe(1);
+  });
+
+  it('highlights first option when no option is selected', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `
+        <pds-combobox component-id="test-combobox">
+          <option value="dog">Dog</option>
+          <option value="cat">Cat</option>
+          <option value="bird">Bird</option>
+        </pds-combobox>
+      `,
+    });
+
+    const component = page.rootInstance;
+    const mockOptions = [
+      createMockOption('dog', 'Dog', false),
+      createMockOption('cat', 'Cat', false),
+      createMockOption('bird', 'Bird', false),
+    ];
+
+    component.optionEls = mockOptions;
+    component.filteredItems = mockOptions;
+    // No selected option set
+
+    // Open dropdown
+    component.isOpen = true;
+    (component as any).setInitialHighlightedIndex();
+    await page.waitForChanges();
+
+    // Should highlight the first option (index 0)
+    expect(component.highlightedIndex).toBe(0);
+  });
+
+  it('highlights first option when selected option is filtered out', async () => {
+    const page = await newSpecPage({
+      components: [PdsCombobox],
+      html: `
+        <pds-combobox component-id="test-combobox">
+          <option value="dog">Dog</option>
+          <option value="cat">Cat</option>
+          <option value="bird">Bird</option>
+        </pds-combobox>
+      `,
+    });
+
+    const component = page.rootInstance;
+    const allOptions = [
+      createMockOption('dog', 'Dog', false),
+      createMockOption('cat', 'Cat', true), // Selected
+      createMockOption('bird', 'Bird', false),
+    ];
+
+    // Only show filtered options (cat is filtered out)
+    const filteredOptions = [allOptions[0], allOptions[2]]; // dog and bird only
+
+    component.optionEls = allOptions;
+    component.filteredItems = filteredOptions;
+    (component as any).setSelectedOption(allOptions[1]); // cat is selected but filtered out
+
+    // Open dropdown
+    component.isOpen = true;
+    (component as any).setInitialHighlightedIndex();
+    await page.waitForChanges();
+
+    // Should highlight the first visible option (index 0) since selected option is not visible
+    expect(component.highlightedIndex).toBe(0);
+  });
+
   it('handles disabled state for button trigger', async () => {
     const { root } = await newSpecPage({
       components: [PdsCombobox],


### PR DESCRIPTION
# Description
- [x] update option highlight logic when option is selected

| Before | After |
|--------|--------|
|![combobox-option-highlight-before](https://github.com/user-attachments/assets/bdc1c08f-6a9f-4fb4-b34d-2b0614ee8289)|![combobox-option-highlight-after](https://github.com/user-attachments/assets/149577b3-6a6f-4b64-95a7-439dab6cfb2c)|

Fixes [DSS-1553](https://kajabi.atlassian.net/browse/DSS-1553)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Visit the Combobox page. Click to open one, select an option, click to open again, press up or down to verify highlight starts from the selected option; not the first one

- [x] accessibility tests
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-1553]: https://kajabi.atlassian.net/browse/DSS-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ