### PR TITLE
fix(pds-tabs): correct keyboard navigation for tabs when panels have focusable elements

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tabs.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabs.tsx
@@ -56,16 +56,15 @@ export class PdsTabs {
   handleKeyDown(ev: KeyboardEvent) {
     const keySet = ["ArrowLeft", "ArrowRight", "Home", "End"];
 
-    // Only handle keyboard navigation if the event did NOT originate from within
-    // a tabpanel that belongs to THIS tabs component
+    // Only handle keyboard navigation if the event originated from a tab button
+    // that belongs to THIS tabs component
     const target = ev.target as HTMLElement;
-    const closestTabpanel = target.closest('pds-tabpanel');
+    const targetTab = target.closest('pds-tab');
 
-    // If there's a tabpanel, check if it belongs to this tabs instance
-    // by seeing if this tabs element is the closest tabs parent of the tabpanel
-    const isOwnTabpanel = closestTabpanel && closestTabpanel.closest('pds-tabs') === this.el;
+    // Check if the tab belongs to this tabs instance (not a nested one)
+    const isOwnTab = targetTab && targetTab.closest('pds-tabs') === this.el;
 
-    if (keySet.includes(ev.key) && !isOwnTabpanel) {
+    if (keySet.includes(ev.key) && isOwnTab) {
       ev.preventDefault();
       this.moveActiveTab(ev.key);
     }

--- a/libs/core/src/components/pds-tabs/pds-tabs.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabs.tsx
@@ -56,7 +56,16 @@ export class PdsTabs {
   handleKeyDown(ev: KeyboardEvent) {
     const keySet = ["ArrowLeft", "ArrowRight", "Home", "End"];
 
-    if (keySet.includes(ev.key)) {
+    // Only handle keyboard navigation if the event did NOT originate from within
+    // a tabpanel that belongs to THIS tabs component
+    const target = ev.target as HTMLElement;
+    const closestTabpanel = target.closest('pds-tabpanel');
+
+    // If there's a tabpanel, check if it belongs to this tabs instance
+    // by seeing if this tabs element is the closest tabs parent of the tabpanel
+    const isOwnTabpanel = closestTabpanel && closestTabpanel.closest('pds-tabs') === this.el;
+
+    if (keySet.includes(ev.key) && !isOwnTabpanel) {
       ev.preventDefault();
       this.moveActiveTab(ev.key);
     }
@@ -90,8 +99,13 @@ export class PdsTabs {
   }
 
   private findAllChildren() {
-    this.tabs = this.el.querySelectorAll('pds-tab');
-    this.tabPanels = this.el.querySelectorAll('pds-tabpanel');
+    // Only select direct children tabs/tabpanels, not nested ones
+    const allTabs = Array.from(this.el.querySelectorAll('pds-tab'));
+    const allTabPanels = Array.from(this.el.querySelectorAll('pds-tabpanel'));
+
+    // Filter to only include tabs that belong to this tabs component (not nested)
+    this.tabs = allTabs.filter(tab => tab.closest('pds-tabs') === this.el);
+    this.tabPanels = allTabPanels.filter(panel => panel.closest('pds-tabs') === this.el);
   }
 
   private propGeneration(child, index = 0) {

--- a/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
+++ b/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
@@ -8,7 +8,7 @@ export default {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['pdsTabClick', 'keydown']
+      handles: ['pdsTabClick']
     },
   },
   title: 'components/Tabs',

--- a/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
+++ b/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
@@ -252,4 +252,35 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).toHaveClass('is-active');
   });
+
+  it('ignores keyboard events from panel content', async () => {
+    const page = await newSpecPage({
+      components: [PdsTabs, PdsTab, PdsTabpanel],
+      html: `
+        <pds-tabs active-tab-name="one" tablist-label="test label" component-id="test" variant="primary">
+          <pds-tab name="one">One</pds-tab>
+          <pds-tab name="two">Two</pds-tab>
+          <pds-tabpanel name="one">
+            <input type="text" id="test-input" />
+          </pds-tabpanel>
+          <pds-tabpanel name="two">Two</pds-tabpanel>
+        </pds-tabs>`,
+    });
+
+    await page.waitForChanges();
+
+    // Verify initial state
+    expect(page.body.querySelector('pds-tab[name="one"] > button')).toHaveClass('is-active');
+    expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
+
+    // Dispatch ArrowRight from input (should NOT trigger navigation)
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight', bubbles: true});
+    const input = page.body.querySelector('#test-input');
+    input?.dispatchEvent(event);
+    await page.waitForChanges();
+
+    // Active tab should remain unchanged
+    expect(page.body.querySelector('pds-tab[name="one"] > button')).toHaveClass('is-active');
+    expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
+  });
 });

--- a/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
+++ b/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
@@ -91,10 +91,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).not.toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'ArrowLeft'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `ArrowLeft` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowLeft', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="two"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted
@@ -121,10 +121,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).not.toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'ArrowLeft'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `ArrowLeft` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowLeft', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="one"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted
@@ -151,10 +151,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).not.toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `ArrowRight` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="two"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted
@@ -181,10 +181,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `ArrowRight` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'ArrowRight', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="three"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted
@@ -211,10 +211,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).not.toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'Home'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `Home` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'Home', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="two"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted
@@ -241,10 +241,10 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="two"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="three"] > button')).not.toHaveClass('is-active');
 
-    // Create and dispatch `ArrowLeft` keydown
-    const event = new KeyboardEvent('keydown', {'key': 'End'});
-    const tabs = page.body.querySelector('pds-tabs');
-    tabs?.dispatchEvent(event);
+    // Create and dispatch `End` keydown on the active tab button
+    const event = new KeyboardEvent('keydown', {'key': 'End', bubbles: true});
+    const activeTabButton = page.body.querySelector('pds-tab[name="two"] > button');
+    activeTabButton?.dispatchEvent(event);
     await page.waitForChanges();
 
     // Expect active tab to have shifted


### PR DESCRIPTION
# Description

Fixed keyboard event handling in `pds-tabs` component to prevent unintended tab navigation when interacting with focusable content inside tab panels.

## Problem
- Keyboard events (arrow keys, Home, End) from inputs, links, and other focusable elements inside tab panels were bubbling up and triggering tab navigation
- All keyboard events were being logged in Storybook actions, creating noise

## Solution
- Updated keyboard event handler to only respond to events from tab buttons belonging to the current tabs instance, not from content within tab panels
- Modified child selection (`querySelectorAll`) to filter only direct children using `closest('pds-tabs')` check
- Cleaned up Storybook actions to only track `pdsTabClick` events

Fixes: https://kajabi.atlassian.net/browse/DSS-1554

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests - All existing pds-tabs unit tests pass (1202 tests)
- [x] tested manually - Verified in Storybook with new FocusTest story:
  - Arrow keys in input fields work correctly without switching tabs
  - Links can be navigated with keyboard without switching tabs  
  - Nested tabs respond to arrow keys independently
  - Tab keyboard navigation still works as expected on tab buttons
- [ ] e2e tests
- [ ] accessibility tests


**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
