### PR TITLE
docs: display pine version in storybook

### DIFF
--- a/libs/core/.storybook/manager.js
+++ b/libs/core/.storybook/manager.js
@@ -1,8 +1,47 @@
 import { addons } from '@storybook/manager-api';
 import { themes } from '@storybook/theming';
 import PineTheme from './PineTheme';
+import packageJson from '../package.json';
 
 addons.setConfig({
   panelPosition: 'right',
   theme: PineTheme
 });
+
+
+// Add version number next to the logo
+const version = packageJson.version;
+const addVersionToSidebar = () => {
+  const sidebarHeader = document.querySelector('.sidebar-header');
+
+  if (sidebarHeader && !document.querySelector('.pine-version')) {
+    const versionElement = document.createElement('div');
+    versionElement.className = 'pine-version';
+    versionElement.textContent = `v${version}`;
+    versionElement.style.cssText = `
+      color: var(--pine-color-text-secondary);
+      font: var(--pine-typography-body-sm-medium);
+      display: inline-flex;
+      align-items: center;
+      margin-inline-start: var(--pine-dimension-xs);
+    `;
+
+    sidebarHeader.appendChild(versionElement);
+    return true;
+  }
+  return false;
+};
+
+// Retry logic with exponential backoff
+let attempts = 0;
+const maxAttempts = 5;
+
+const tryAddVersion = () => {
+  if (addVersionToSidebar() || attempts >= maxAttempts) {
+    return;
+  }
+  attempts++;
+  setTimeout(tryAddVersion, 100 * attempts);
+};
+
+tryAddVersion();

--- a/libs/core/.storybook/manager.js
+++ b/libs/core/.storybook/manager.js
@@ -32,7 +32,7 @@ const addVersionToSidebar = () => {
   return false;
 };
 
-// Retry logic with exponential backoff
+// Retry logic with linear backoff
 let attempts = 0;
 const maxAttempts = 5;
 


### PR DESCRIPTION
# Description

Adds version number display to Storybook sidebar next to the Pine logo. The version is dynamically pulled from `package.json` and automatically updates with each release.

**Changes:**
- Added version display in Storybook manager using inline rendering next to logo
- Imports version from `libs/core/package.json` 
- Styled using Pine design tokens (`--pine-typography-body-sm-medium`, `--pine-color-text-secondary`, `--pine-dimension-xs`)
- Uses CSS logical properties (`margin-inline-start`) for internationalization support
- Implements linear backoff retry logic for optimal performance

Fixes https://kajabi.atlassian.net/browse/DSS-1559

|  Screenshot   |
|--------|
|<img width="297" height="216" alt="Screenshot 2025-10-16 at 2 27 38 PM" src="https://github.com/user-attachments/assets/e596ccee-6d2f-4b1b-91d5-27ae21f3672a" />|


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [x] tested manually
  - Verified version displays correctly next to Pine logo in Storybook sidebar
  - Confirmed version auto-updates from package.json (currently shows v3.8.0)
  - Tested that Pine design tokens render correctly
  - Verified retry logic successfully adds version after DOM loads
  - Validated styling with logical properties
  
**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
