### PR TITLE
style(pds-tab): remove z-index from pill variant

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -205,7 +205,6 @@ pds-tab {
       border-color: var(--pine-color-border);
       box-shadow: var(--pine-box-shadow-100);
       color: var(--pine-color-text-active);
-      z-index: var(--pine-z-index-raised);
 
       &:focus-visible {
         border-color: var(--color-border-focus);


### PR DESCRIPTION
# Description
Removes z-index styling from pill variant of tab. Recent adjustment causes issue with stacking order.


## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
