### PR TITLE
style(pds-progress): update progress bar background color styles

### DIFF
--- a/libs/core/src/components/pds-progress/docs/pds-progress.mdx
+++ b/libs/core/src/components/pds-progress/docs/pds-progress.mdx
@@ -77,6 +77,17 @@ Allows for `pds-progress` to be filled with a custom color. Accepts any valid co
   <pds-progress component-id="fillcolor" label="Fill color" percent="95" fill-color="#86D5BC"></pds-progress>
 </DocCanvas>
 
+### Fill Color with Gradient
+
+You can also use CSS gradients for more visual interest.
+
+<DocCanvas client:only mdxSource={{
+  react: `<PdsProgress componentId="fillcolor-gradient" label="Gradient fill color" percent="75" fillColor="linear-gradient(to right, var(--pine-color-red-300), var(--pine-color-green-300))"></PdsProgress>`,
+  webComponent: `<pds-progress component-id="fillcolor-gradient" label="Gradient fill color" percent="75" fill-color="linear-gradient(to right, var(--pine-color-red-300), var(--pine-color-green-300))"></pds-progress>
+`}}>
+  <pds-progress component-id="fillcolor-gradient" label="Gradient fill color" percent="75" fill-color="linear-gradient(to right, var(--pine-color-red-300), var(--pine-color-green-300))"></pds-progress>
+</DocCanvas>
+
 ### Tooltip
 
 A tooltip can be added by combining the `progress` component with a [tooltip](/docs/components-tooltip--default).

--- a/libs/core/src/components/pds-progress/pds-progress.scss
+++ b/libs/core/src/components/pds-progress/pds-progress.scss
@@ -44,12 +44,12 @@ progress::-webkit-progress-bar {
 }
 
 progress::-webkit-progress-value {
-  background-color: var(--color-progress-fill, var(--pine-color-brand));
+  background: var(--color-progress-fill, var(--pine-color-brand));
   border-radius: var(--pine-dimension-2xs);
 }
 
 progress::-moz-progress-bar {
-  background-color: var(--color-progress-fill, var(--pine-color-brand));
+  background: var(--color-progress-fill, var(--pine-color-brand));
   border-radius: var(--pine-dimension-2xs);
 }
 


### PR DESCRIPTION
# Description

This PR enables CSS gradient support for the `pds-progress` component's fill color by changing the `background-color` property to `background` in the progress bar styling.

Previously, users could not use gradients (e.g., `linear-gradient()`, `radial-gradient()`) with the `fillColor` prop or `--color-progress-fill` CSS variable because `background-color` only accepts solid color values. This change maintains backward compatibility with solid colors while unlocking support for gradients and other advanced background properties.

Fixes: https://kajabi.atlassian.net/browse/DSS-1560

## Changes Made
- Updated `pds-progress.scss` to use `background` instead of `background-color` for WebKit and Mozilla progress bar pseudo-elements
- Added documentation example demonstrating gradient usage with Pine color tokens

|  Screenshot  | 
|--------|
|<img width="1064" height="278" alt="Screenshot 2025-10-21 at 2 07 35 PM" src="https://github.com/user-attachments/assets/27042f8b-f018-4d07-9058-8fd3f32fada4" />|

## Type of change

- [x] Style fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually - Verified gradient rendering in progress component
- [x] Tested solid color compatibility to ensure no regression
- [x] Validated documentation example displays correctly

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
