### PR TITLE
docs: add changelogs to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ For use within React files, components should follow PascalCase to match React c
 
 For the full list of properties available for each component and more robust documentation, please see Pine's [Storybook](https://pine-design-system.netlify.app/).
 
+## Changelogs
+
+Stay up to date with the latest releases and updates across the Pine Design System:
+
+- **Pine**: [View Releases](https://github.com/Kajabi/pine/releases)
+- **Pine Icons**: [View Releases](https://github.com/Kajabi/pine-icons/releases)
+- **Design Tokens**: [View Releases](https://github.com/Kajabi/ds-tokens/releases)
+
 ## Contribution
 
 To learn more about contributing to Pine, please see the [Contribution](./CONTRIBUTING.md) docs.

--- a/libs/core/src/stories/resources/changelogs.docs.mdx
+++ b/libs/core/src/stories/resources/changelogs.docs.mdx
@@ -1,0 +1,23 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Resources/Changelogs" parameters={{ previewTabs: { canvas: { hidden: true }, } }} />
+
+# Changelogs
+
+Stay up to date with the latest releases and updates across the Pine Design System:
+
+## Pine
+View the latest releases, new features, bug fixes, and improvements for the Pine component library.
+
+<pds-link href="https://github.com/Kajabi/pine/releases" external>View Pine Releases</pds-link>
+
+## Pine Icons
+Track updates to the Pine icon library, including new icons, modifications, and deprecations.
+
+<pds-link href="https://github.com/Kajabi/pine-icons/releases" external>View Pine Icons Releases</pds-link>
+
+## Design Tokens
+Follow changes to design tokens including colors, spacing, typography, and other foundational design values.
+
+<pds-link href="https://github.com/Kajabi/ds-tokens/releases" external>View Design Tokens Releases</pds-link>
+


### PR DESCRIPTION
# Description

Added a Changelogs section to provide developers with easy access to release information across the Pine Design System.

**Changes:**
- Added Changelogs section to main README.md with links to Pine, Pine Icons, and Design Tokens releases
- Created new Storybook documentation page under Resources/Changelogs with the same links using `pds-link` components

This addresses developer feedback requesting more visibility into design system updates.

Fixes: https://kajabi.atlassian.net/browse/DSS-1564

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually (verified links open in new tabs, Storybook page renders correctly)
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
