### PR TITLE
fix(pds-accordion): add accordion-icon part for styling

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.tsx
+++ b/libs/core/src/components/pds-accordion/pds-accordion.tsx
@@ -4,6 +4,7 @@ import { downSmall } from '@pine-ds/icons/icons';
 /**
  * @part accordion-body - Accordion body styles.
  * @part accordion-button - Accordion button/trigger styles.
+ * @part accordion-icon - Accordion icon styles.
  * @slot (default) - Accordion body content.
  * @slot label - Accordion trigger button content.
  */
@@ -57,7 +58,7 @@ export class PdsAccordion {
         <details {...this.getOpenAttribute()} ref={(el) => (this.detailsEl = el as HTMLDetailsElement)}>
           <summary part="accordion-button">
             <slot name="label">Details</slot>
-            <pds-icon icon={downSmall} />
+            <pds-icon icon={downSmall} part="accordion-icon" />
           </summary>
           <div part="accordion-body" class="pds-accordion__body">
             <slot />

--- a/libs/core/src/components/pds-accordion/readme.md
+++ b/libs/core/src/components/pds-accordion/readme.md
@@ -27,6 +27,7 @@
 | -------------------- | -------------------------------- |
 | `"accordion-body"`   | Accordion body styles.           |
 | `"accordion-button"` | Accordion button/trigger styles. |
+| `"accordion-icon"`   | Accordion icon styles.           |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
@@ -14,7 +14,7 @@ describe('pds-accordion', () => {
             <details>
               <summary part="accordion-button">
                 <slot name="label">Details</slot>
-                <pds-icon icon="${downSmall}"></pds-icon>
+                <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
               </summary>
               <div part="accordion-body" class="pds-accordion__body">
                 <slot />
@@ -36,7 +36,7 @@ describe('pds-accordion', () => {
             <details open>
               <summary part="accordion-button">
                 <slot name="label">Details</slot>
-                <pds-icon icon="${downSmall}"></pds-icon>
+                <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
               </summary>
               <div part="accordion-body" class="pds-accordion__body">
                 <slot />
@@ -59,7 +59,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -82,7 +82,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -106,7 +106,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -130,7 +130,7 @@ describe('pds-accordion', () => {
           <details open>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon icon="${downSmall}" part="accordion-icon"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />


### PR DESCRIPTION
# Description

Added a CSS `part` attribute to the icon element in the `pds-accordion` component to allow external styling via the `::part()` pseudo-element.

This change exposes the accordion's chevron icon as `accordion-icon`, enabling developers to customize the icon's appearance from outside the shadow DOM using standard CSS parts syntax.

The component now exposes three parts for styling:
- `accordion-button` - The summary/trigger button
- `accordion-body` - The expandable content area  
- `accordion-icon` - The chevron icon (newly added)

Fixes: https://kajabi.atlassian.net/browse/DSS-1566

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] unit tests - Updated all existing unit test snapshots to include the new `part="accordion-icon"` attribute
- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
