### PR TITLE
fix(pds-popover): convert to slot for trigger and portal rendering

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1334,10 +1334,6 @@ export namespace Components {
          */
         "show": () => Promise<void>;
         /**
-          * Text that appears on the trigger element
-         */
-        "text": string;
-        /**
           * Toggles the popover open/closed state programmatically
          */
         "toggle": () => Promise<void>;
@@ -3999,10 +3995,6 @@ declare namespace LocalJSX {
           * @default 'auto'
          */
         "popoverType"?: 'auto' | 'manual';
-        /**
-          * Text that appears on the trigger element
-         */
-        "text"?: string;
     }
     interface PdsProgress {
         /**

--- a/libs/core/src/components/pds-popover/docs/pds-popover.mdx
+++ b/libs/core/src/components/pds-popover/docs/pds-popover.mdx
@@ -22,6 +22,84 @@ Popovers display contextual information when users click or initiates a keyboard
 
 <DocArgsTable componentName="pds-popover" docSource={components} />
 
+## Usage
+
+### Trigger Slot
+
+Use the `trigger` slot to provide the element that will open the popover. You can use any Pine component - buttons, chips, avatars, or other interactive elements.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+      <PdsBox display="flex" gap="md" align-items="center" flex-wrap="wrap">
+        <PdsPopover componentId="button-trigger" placement="bottom-start" popoverTargetAction="toggle">
+          <PdsButton slot="trigger">Button Trigger</PdsButton>
+          <p>Popover content is displayed here</p>
+        </PdsPopover>
+
+        <PdsPopover componentId="icon-trigger" placement="bottom-start" popoverTargetAction="toggle">
+          <PdsButton slot="trigger" variant="secondary" iconOnly icon="info-circle" ariaLabel="Information" />
+          <p>Popover content is displayed here</p>
+        </PdsPopover>
+
+        <PdsPopover componentId="chip-trigger" placement="bottom-start" popoverTargetAction="toggle">
+          <PdsChip slot="trigger" variant="dropdown">Chip Trigger</PdsChip>
+          <p>Popover content is displayed here</p>
+        </PdsPopover>
+
+        <PdsPopover componentId="avatar-trigger" placement="bottom-start" popoverTargetAction="toggle">
+          <PdsAvatar slot="trigger" name="John Doe" size="md" dropdown={true} />
+          <p>Popover content is displayed here</p>
+        </PdsPopover>
+      </PdsBox>
+    `,
+    webComponent: `
+      <pds-box display="flex" gap="md" align-items="center" flex-wrap="wrap">
+        <pds-popover component-id="button-trigger" placement="bottom-start" popover-target-action="toggle">
+          <pds-button slot="trigger">Button Trigger</pds-button>
+          <p>Popover content is displayed here</p>
+        </pds-popover>
+
+        <pds-popover component-id="icon-trigger" placement="bottom-start" popover-target-action="toggle">
+          <pds-button slot="trigger" variant="secondary" icon-only icon="info-circle" aria-label="Information"></pds-button>
+          <p>Popover content is displayed here</p>
+        </pds-popover>
+
+        <pds-popover component-id="chip-trigger" placement="bottom-start" popover-target-action="toggle">
+          <pds-chip slot="trigger" variant="dropdown">Chip Trigger</pds-chip>
+          <p>Popover content is displayed here</p>
+        </pds-popover>
+
+        <pds-popover component-id="avatar-trigger" placement="bottom-start" popover-target-action="toggle">
+          <pds-avatar slot="trigger" name="John Doe" size="md" dropdown="true"></pds-avatar>
+          <p>Popover content is displayed here</p>
+        </pds-popover>
+      </pds-box>
+    `
+  }}>
+  <pds-box display="flex" gap="md" align-items="center" flex-wrap="wrap">
+    <pds-popover component-id="button-trigger" placement="bottom-start" popover-target-action="toggle">
+      <pds-button slot="trigger">Button Trigger</pds-button>
+      <p>Popover content is displayed here</p>
+    </pds-popover>
+
+    <pds-popover component-id="icon-trigger" placement="bottom-start" popover-target-action="toggle">
+      <pds-button slot="trigger" variant="secondary" icon-only icon="info-circle" aria-label="Information"></pds-button>
+      <p>Popover content is displayed here</p>
+    </pds-popover>
+
+    <pds-popover component-id="chip-trigger" placement="bottom-start" popover-target-action="toggle">
+      <pds-chip slot="trigger" variant="dropdown">Chip Trigger</pds-chip>
+      <p>Popover content is displayed here</p>
+    </pds-popover>
+
+    <pds-popover component-id="avatar-trigger" placement="bottom-start" popover-target-action="toggle">
+      <pds-avatar slot="trigger" name="John Doe" size="md" dropdown="true"></pds-avatar>
+      <p>Popover content is displayed here</p>
+    </pds-popover>
+  </pds-box>
+</DocCanvas>
+
 ### Behavior Types
 
 #### Auto (Default)
@@ -31,17 +109,20 @@ Closes automatically when clicking outside the popover content. Can also be clos
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsPopover componentId="auto" text="Auto Popover">
+      <PdsPopover componentId="auto" placement="bottom-start">
+        <PdsButton slot="trigger">Auto Popover</PdsButton>
         <p>Clicks outside will close this popover</p>
       </PdsPopover>
     `,
     webComponent: `
-      <pds-popover component-id="auto" text="Auto Popover">
+      <pds-popover component-id="auto" placement="bottom-start">
+        <pds-button slot="trigger">Auto Popover</pds-button>
         <p>Clicks outside will close this popover</p>
       </pds-popover>
     `
   }}>
-  <pds-popover component-id="auto" text="Auto Popover">
+  <pds-popover component-id="auto" placement="bottom-start">
+    <pds-button slot="trigger">Auto Popover</pds-button>
     <p>Clicks outside will close this popover</p>
   </pds-popover>
 </DocCanvas>
@@ -62,17 +143,20 @@ Learn more about popover target actions in the [MDN Documentation](https://devel
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsPopover componentId="manual" text="Manual Popover" popoverTargetAction="toggle" popoverType="manual">
+      <PdsPopover componentId="manual" placement="bottom-start" popoverTargetAction="toggle" popoverType="manual">
+        <PdsButton slot="trigger">Manual Popover</PdsButton>
         <p>This popover requires explicit closing</p>
       </PdsPopover>
     `,
     webComponent: `
-      <pds-popover component-id="manual" text="Manual Popover" popover-target-action="toggle" popover-type="manual">
+      <pds-popover component-id="manual" placement="bottom-start" popover-target-action="toggle" popover-type="manual">
+        <pds-button slot="trigger">Manual Popover</pds-button>
         <p>This popover requires explicit closing</p>
       </pds-popover>
     `
   }}>
-  <pds-popover component-id="manual" text="Manual Popover" popover-target-action="toggle" popover-type="manual">
+  <pds-popover component-id="manual" placement="bottom-start" popover-target-action="toggle" popover-type="manual">
+    <pds-button slot="trigger">Manual Popover</pds-button>
     <p>This popover requires explicit closing</p>
   </pds-popover>
 </DocCanvas>
@@ -88,17 +172,20 @@ Shows the popover when triggered. Clicking the popover trigger while open will n
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsPopover componentId="show" text="Show Action">
+      <PdsPopover componentId="show" placement="bottom-start">
+        <PdsButton slot="trigger">Show Action</PdsButton>
         <p>This popover uses the show action</p>
       </PdsPopover>
     `,
     webComponent: `
-      <pds-popover component-id="show" text="Show Action">
+      <pds-popover component-id="show" placement="bottom-start">
+        <pds-button slot="trigger">Show Action</pds-button>
         <p>This popover uses the show action</p>
       </pds-popover>
     `
   }}>
-  <pds-popover component-id="show" text="Show Action">
+  <pds-popover component-id="show" placement="bottom-start">
+    <pds-button slot="trigger">Show Action</pds-button>
     <p>This popover uses the show action</p>
   </pds-popover>
 </DocCanvas>
@@ -110,17 +197,20 @@ Toggles the popover visibility state when triggered. Clicking the popover trigge
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsPopover componentId="toggle" text="Toggle Action" popoverTargetAction="toggle">
+      <PdsPopover componentId="toggle" placement="bottom-start" popoverTargetAction="toggle">
+        <PdsButton slot="trigger">Toggle Action</PdsButton>
         <p>This popover uses the toggle action</p>
       </PdsPopover>
     `,
     webComponent: `
-      <pds-popover component-id="toggle" text="Toggle Action" popover-target-action="toggle">
+      <pds-popover component-id="toggle" placement="bottom-start" popover-target-action="toggle">
+        <pds-button slot="trigger">Toggle Action</pds-button>
         <p>This popover uses the toggle action</p>
       </pds-popover>
     `
   }}>
-  <pds-popover component-id="toggle" text="Toggle Action" popover-target-action="toggle">
+  <pds-popover component-id="toggle" placement="bottom-start" popover-target-action="toggle">
+    <pds-button slot="trigger">Toggle Action</pds-button>
     <p>This popover uses the toggle action</p>
   </pds-popover>
 </DocCanvas>
@@ -132,26 +222,20 @@ The `max-width` prop allows adjusting the maximum width of the popover content. 
 <DocCanvas client:only
   mdxSource={{
     react: `
-      <PdsPopover componentId="wide" text="Wide Popover" maxWidth="520px">
+      <PdsPopover componentId="wide" placement="bottom-start" maxWidth="520px">
+        <PdsButton slot="trigger">Wide Popover</PdsButton>
         <p>This is a wider popover with more content space available.</p>
       </PdsPopover>
     `,
     webComponent: `
-      <pds-popover component-id="wide" text="Wide Popover" max-width="520px">
+      <pds-popover component-id="wide" placement="bottom-start" max-width="520px">
+        <pds-button slot="trigger">Wide Popover</pds-button>
         <p>This is a wider popover with more content space available.</p>
       </pds-popover>
     `
   }}>
-  <pds-popover component-id="wide" text="Wide Popover" max-width="520px">
+  <pds-popover component-id="wide" placement="bottom-start" max-width="520px">
+    <pds-button slot="trigger">Wide Popover</pds-button>
     <p>This is a wider popover with more content space available.</p>
   </pds-popover>
 </DocCanvas>
-
-
-## Additional Resources
-
-[Mdn Web Docs: Popover Attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/popover)
-
-[MDN Web Docs: Popover Api](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
-
-[MDN: Using the Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using)

--- a/libs/core/src/components/pds-popover/pds-popover.scss
+++ b/libs/core/src/components/pds-popover/pds-popover.scss
@@ -3,43 +3,13 @@
 
   display: inline-block;
 
-  [popover] {
-    background-color: var(--pine-color-background-container);
-    border: var(--pine-border);
-    border-radius: var(--pine-dimension-125);
-    box-shadow: var(--pine-box-shadow-200);
-    margin: var(--pine-dimension-none);
-    max-width: var(--sizing-max-width-default);
-    padding: var(--pine-dimension-md);
-    position: fixed;
-
-    // Hide popover initially to prevent flash before positioning
-    // stylelint-disable-next-line selector-pseudo-class-no-unknown
-    &:popover-open:not(.pds-popover--positioned) {
-      visibility: hidden;
-    }
+  // Trigger wrapper for slotted content
+  .pds-popover__trigger-wrapper {
+    display: inline-block;
   }
 
-  button {
-    align-items: center;
-    background-color: var(--pine-color-secondary);
-    border: var(--pine-border);
-    border-radius: var(--pine-border-radius-full);
-    color: var(--pine-color-text-secondary);
-    display: flex;
-    font: var(--pine-typography-body-medium);
-    font-family: var(--pine-font-family-heading);
-    letter-spacing: var(--pine-letter-spacing);
-    min-height: 40px;
-    padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
-
-    &:focus-visible {
-      outline: var(--pine-outline-focus);
-      outline-offset: var(--pine-border-width);
-    }
-
-    &:hover {
-      background-color: var(--pine-color-secondary-hover);
-    }
+  // Content slot wrapper is hidden (content is rendered in portal)
+  .pds-popover__content-slot-wrapper {
+    display: none;
   }
 }

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -1,7 +1,11 @@
-import { Component, Element, Event, EventEmitter, Host, Listen, h, Method, Prop, State } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Host, h, Method, Prop, State } from '@stencil/core';
 import { PlacementType } from '@utils/types';
-import { PdsPopoverEventDetail, ToggleEvent } from './popover-interface';
+import { PdsPopoverEventDetail } from './popover-interface';
 
+/**
+ * @slot trigger - The trigger element for the popover
+ * @slot (default) - The content to display inside the popover
+ */
 @Component({
   tag: 'pds-popover',
   styleUrl: 'pds-popover.scss',
@@ -20,14 +24,53 @@ export class PdsPopover {
   @State() active = false;
 
   /**
-   * Bound reference to the toggle handler for proper cleanup
-   */
-  private boundToggleHandler: (event: Event) => void;
-
-  /**
    * Tracks if the component is still mounted to prevent memory leaks
    */
   private isComponentMounted = true;
+
+  /**
+   * Reference to the trigger element
+   */
+  private triggerEl: HTMLElement | null = null;
+
+  /**
+   * Portal element rendered in document.body
+   */
+  private portalEl: HTMLElement | null = null;
+
+  /**
+   * Guard to prevent repositioning loops
+   */
+  private isRepositioning = false;
+
+  /**
+   * Debounce timers for performance optimization
+   */
+  private scrollDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Track moved nodes and their placeholders for restoration
+   */
+  private movedNodes: Array<{ node: Node; placeholder: Comment }> = [];
+
+  /**
+   * Timestamp when popover was opened (for preventing immediate close)
+   */
+  private openTimestamp = 0;
+
+  /**
+   * Instance counter for unique IDs
+   */
+  private static instanceCounter = 0;
+
+  /**
+   * Bound handlers for cleanup
+   */
+  private boundClickOutsideHandler: (event: MouseEvent) => void;
+  private boundEscapeKeyHandler: (event: KeyboardEvent) => void;
+  private boundScrollHandler: () => void;
+  private boundResizeHandler: () => void;
 
   /**
    * Emitted when the popover is opened
@@ -57,11 +100,6 @@ export class PdsPopover {
   @Prop() componentId: string;
 
   /**
-   * Text that appears on the trigger element
-   */
-  @Prop() text: string;
-
-  /**
    * Sets the maximum width of the popover content
    * @defaultValue 352
    */
@@ -74,22 +112,255 @@ export class PdsPopover {
   @Prop({ reflect: true }) placement: PlacementType = 'right';
 
   componentDidLoad() {
-    // Attach toggle event listener to the popover element
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
-    if (popoverEl != null) {
-      this.boundToggleHandler = this.handleToggle.bind(this);
-      popoverEl.addEventListener('toggle', this.boundToggleHandler);
+    // Bind event handlers for cleanup
+    this.boundClickOutsideHandler = this.handleClickOutside.bind(this);
+    this.boundEscapeKeyHandler = this.handleEscapeKey.bind(this);
+    this.boundScrollHandler = this.handleScroll.bind(this);
+    this.boundResizeHandler = this.handleResize.bind(this);
+
+    // Create portal element
+    this.createPortal();
+
+    // Initialize trigger element by calling slot change handler
+    // This is a fallback for environments where slot change might not fire reliably
+    const triggerSlot = this.el.shadowRoot?.querySelector('slot[name="trigger"]') as HTMLSlotElement;
+    if (triggerSlot && this.triggerEl == null) {
+      const CustomEvent = (typeof window !== 'undefined' ? window.Event : global.Event) as any;
+      const slotChangeEvent = new CustomEvent('slotchange');
+      Object.defineProperty(slotChangeEvent, 'target', { value: triggerSlot, enumerable: true });
+      this.handleTriggerSlotChange(slotChangeEvent);
     }
   }
+
+  /**
+   * Handles changes to the trigger slot
+   */
+  private handleTriggerSlotChange = (event: Event) => {
+    const slot = event.target as HTMLSlotElement;
+    const assignedElements = slot.assignedElements();
+
+    // Clean up previous trigger's event listener if it exists
+    if (this.triggerEl != null) {
+      this.triggerEl.removeEventListener('click', this.handleTriggerClick);
+    }
+
+    if (assignedElements.length > 0) {
+      // Use the first assigned element as the trigger
+      this.triggerEl = assignedElements[0] as HTMLElement;
+
+      // Set ARIA attributes to establish relationship between trigger and popover
+      // This mirrors the native Popover API's accessibility behavior
+      if (this.portalEl) {
+        this.triggerEl.setAttribute('aria-expanded', String(this.active));
+        this.triggerEl.setAttribute('aria-controls', this.portalEl.id);
+      }
+
+      // Attach click listener to handle popover visibility
+      this.triggerEl.addEventListener('click', this.handleTriggerClick);
+    } else {
+      this.triggerEl = null;
+    }
+  };
+
+  /**
+   * Handles clicks on the trigger element
+   */
+  private handleTriggerClick = (event: Event) => {
+    // Only prevent default if the trigger is not an anchor with href
+    // This allows link navigation while still controlling popover visibility
+    const composedPath = event.composedPath();
+    const anchorWithHref = composedPath.find(
+      (el) => el instanceof HTMLAnchorElement && (el as HTMLAnchorElement).href
+    );
+
+    if (!anchorWithHref) {
+      event.preventDefault();
+    }
+
+    // Execute the appropriate action based on popoverTargetAction prop
+    switch (this.popoverTargetAction) {
+      case 'show':
+        this.show();
+        break;
+      case 'hide':
+        this.hide();
+        break;
+      case 'toggle':
+      default:
+        this.toggle();
+        break;
+    }
+  };
 
   disconnectedCallback() {
     this.isComponentMounted = false;
 
-    // Clean up event listener
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
-    if (popoverEl != null && this.boundToggleHandler != null) {
-      popoverEl.removeEventListener('toggle', this.boundToggleHandler);
+    // Clean up trigger click event listener
+    if (this.triggerEl != null) {
+      this.triggerEl.removeEventListener('click', this.handleTriggerClick);
     }
+
+    // Clean up all event listeners
+    this.removeLightDismissListeners();
+    this.removeScrollAndResizeListeners();
+
+    // Clear any pending debounce timers
+    this.clearDebounceTimers();
+
+    // Remove portal from DOM
+    this.removePortal();
+  }
+
+  /**
+   * Clears any pending debounce timers
+   */
+  private clearDebounceTimers() {
+    if (this.scrollDebounceTimer !== null) {
+      clearTimeout(this.scrollDebounceTimer);
+      this.scrollDebounceTimer = null;
+    }
+    if (this.resizeDebounceTimer !== null) {
+      clearTimeout(this.resizeDebounceTimer);
+      this.resizeDebounceTimer = null;
+    }
+  }
+
+  private createPortal() {
+    if (this.portalEl !== null) return;
+
+    this.portalEl = document.createElement('div');
+    this.portalEl.className = 'pds-popover';
+
+    // Apply all styles inline since portal is outside shadow DOM
+    this.portalEl.style.position = 'fixed';
+    this.portalEl.style.zIndex = 'var(--pine-z-index-raised)';
+    this.portalEl.style.maxWidth = `${this.maxWidth}px`;
+    this.portalEl.style.display = 'none';
+    this.portalEl.style.opacity = '0';
+    this.portalEl.style.visibility = 'hidden';
+    this.portalEl.style.backgroundColor = 'var(--pine-color-background-container)';
+    this.portalEl.style.borderRadius = 'var(--pine-dimension-125)';
+    this.portalEl.style.boxShadow = 'var(--pine-box-shadow-200)';
+    this.portalEl.style.margin = 'var(--pine-dimension-none)';
+    this.portalEl.style.padding = 'var(--pine-dimension-md)';
+
+    // Generate unique ID
+    if (!this.componentId) {
+      const suffix = PdsPopover.instanceCounter++;
+      this.portalEl.id = `pds-popover-portal-${suffix}`;
+    } else {
+      this.portalEl.id = `${this.componentId}-portal`;
+    }
+
+    // Add accessibility attributes for screen readers
+    // Note: Native Popover API doesn't add a specific role, keeping semantic HTML
+    this.portalEl.setAttribute('aria-modal', 'false'); // Not a modal, can interact with rest of page
+
+    // Append to body
+    document.body.appendChild(this.portalEl);
+
+    // Add global focus styles to match Pine design system
+    // This is done after appending to ensure it's part of the document and can access CSS variables
+    this.addPortalFocusStyles();
+  }
+
+  /**
+   * Adds Pine design system focus styles to the portal element
+   * Uses CSS variables from Pine's design tokens
+   */
+  private addPortalFocusStyles() {
+    if (!this.portalEl) return;
+
+    const portalId = this.portalEl.id;
+
+    // Check if style element already exists
+    const existingStyle = document.querySelector(`style[data-pds-popover-focus="${portalId}"]`);
+    if (existingStyle) return;
+
+    // Create style element with Pine's focus ring styles
+    const styleEl = document.createElement('style');
+    styleEl.setAttribute('data-pds-popover-focus', portalId);
+    styleEl.textContent = `
+      #${portalId}:focus {
+        outline: var(--pine-outline-focus, 2px solid var(--pine-color-focus-ring, #6366f1)) !important;
+        outline-offset: var(--pine-border-width, 1px);
+      }
+      #${portalId}:focus:not(:focus-visible) {
+        outline: none;
+      }
+    `;
+
+    document.head.appendChild(styleEl);
+  }
+
+  /**
+   * Moves slot content into portal (preserves event handlers and component instances)
+   */
+  private updatePortalContent() {
+    if (!this.portalEl) return;
+
+    const contentSlotWrapper = this.el.shadowRoot?.querySelector('.pds-popover__content-slot-wrapper');
+    const defaultSlot = contentSlotWrapper?.querySelector('slot');
+
+    if (defaultSlot) {
+      const assignedNodes = defaultSlot.assignedNodes();
+
+      // Move each node into portal and track with placeholder for restoration
+      assignedNodes.forEach(node => {
+        // Skip if node is already in the portal or already tracked
+        const isAlreadyInPortal = node.parentNode === this.portalEl;
+        const isAlreadyTracked = this.movedNodes.some(moved => moved.node === node);
+
+        if (isAlreadyInPortal || isAlreadyTracked) {
+          return;
+        }
+
+        // Create a placeholder comment to mark original position
+        const placeholder = document.createComment('pds-popover-placeholder');
+
+        // Insert placeholder before moving the node
+        node.parentNode?.insertBefore(placeholder, node);
+
+        // Move the actual node to portal (preserves all handlers and state)
+        this.portalEl!.appendChild(node);
+
+        // Track for restoration
+        this.movedNodes.push({ node, placeholder });
+      });
+    }
+  }
+
+  /**
+   * Restores moved nodes back to their original positions
+   */
+  private restorePortalContent() {
+    // Restore each moved node to its original position
+    this.movedNodes.forEach(({ node, placeholder }) => {
+      if (placeholder.parentNode) {
+        placeholder.parentNode.insertBefore(node, placeholder);
+        placeholder.parentNode.removeChild(placeholder);
+      }
+    });
+
+    // Clear tracking array
+    this.movedNodes = [];
+  }
+
+  private removePortal() {
+    if (this.portalEl) {
+      // Remove the portal element from DOM
+      if (this.portalEl.parentNode) {
+        this.portalEl.parentNode.removeChild(this.portalEl);
+      }
+
+      // Remove the associated focus style element
+      const portalId = this.portalEl.id;
+      const styleEl = document.querySelector(`style[data-pds-popover-focus="${portalId}"]`);
+      if (styleEl && styleEl.parentNode) {
+        styleEl.parentNode.removeChild(styleEl);
+      }
+    }
+    this.portalEl = null;
   }
 
   /**
@@ -97,15 +368,45 @@ export class PdsPopover {
    */
   @Method()
   async show() {
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { showPopover?: () => void } | null;
-    if (popoverEl != null && typeof popoverEl.showPopover === 'function') {
-      try {
-        popoverEl.showPopover();
-      } catch (e) {
-        // Popover might already be open
-        console.warn('Failed to show popover:', e);
-      }
+    if (this.active || !this.portalEl) return;
+
+    this.active = true;
+
+    // Record open timestamp to prevent immediate close from opening click
+    this.openTimestamp = Date.now();
+
+    // Update ARIA expanded state on trigger
+    if (this.triggerEl) {
+      this.triggerEl.setAttribute('aria-expanded', 'true');
     }
+
+    // Update portal content with latest slot content
+    this.updatePortalContent();
+
+    // Show portal
+    this.portalEl.style.display = 'block';
+    this.portalEl.style.opacity = '1';
+    this.portalEl.style.visibility = 'visible';
+
+    // Position the popover
+    requestAnimationFrame(() => {
+      if (!this.isComponentMounted) return;
+      this.handlePopoverPositioning();
+    });
+
+    // Add scroll and resize listeners for repositioning (always)
+    this.addScrollAndResizeListeners();
+
+    // Add document listeners for light dismiss and escape key (auto type only)
+    if (this.popoverType === 'auto') {
+      this.addLightDismissListeners();
+    }
+
+    // Emit open event
+    this.pdsPopoverOpen.emit({
+      componentId: this.componentId,
+      popoverType: this.popoverType,
+    });
   }
 
   /**
@@ -113,15 +414,39 @@ export class PdsPopover {
    */
   @Method()
   async hide() {
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { hidePopover?: () => void } | null;
-    if (popoverEl != null && typeof popoverEl.hidePopover === 'function') {
-      try {
-        popoverEl.hidePopover();
-      } catch (e) {
-        // Popover might already be closed
-        console.warn('Failed to hide popover:', e);
-      }
+    if (!this.active || !this.portalEl) return;
+
+    this.active = false;
+
+    // Update ARIA expanded state on trigger
+    if (this.triggerEl) {
+      this.triggerEl.setAttribute('aria-expanded', 'false');
     }
+
+    // Restore content back to original slot positions
+    this.restorePortalContent();
+
+    // Hide portal
+    this.portalEl.style.display = 'none';
+    this.portalEl.style.opacity = '0';
+    this.portalEl.style.visibility = 'hidden';
+
+    // Return focus to trigger for keyboard accessibility
+    // This mirrors native Popover API behavior on close
+    this.returnFocusToTrigger();
+
+    // Remove all listeners
+    this.removeLightDismissListeners();
+    this.removeScrollAndResizeListeners();
+
+    // Clear any pending timers
+    this.clearDebounceTimers();
+
+    // Emit close event
+    this.pdsPopoverClose.emit({
+      componentId: this.componentId,
+      popoverType: this.popoverType,
+    });
   }
 
   /**
@@ -129,77 +454,157 @@ export class PdsPopover {
    */
   @Method()
   async toggle() {
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]') as HTMLElement & { togglePopover?: () => void } | null;
-    if (popoverEl != null && typeof popoverEl.togglePopover === 'function') {
-      try {
-        popoverEl.togglePopover();
-      } catch (e) {
-        console.warn('Failed to toggle popover:', e);
-      }
+    if (this.active) {
+      this.hide();
+    } else {
+      this.show();
     }
   }
 
-  private handleToggle(event: Event) {
-    const toggleEvent = event as ToggleEvent;
+  /**
+   * Adds light dismiss listeners (click outside and escape key)
+   */
+  private addLightDismissListeners() {
+    // Add listeners immediately - handleClickOutside will check timestamp
+    document.addEventListener('click', this.boundClickOutsideHandler, true);
+    document.addEventListener('keydown', this.boundEscapeKeyHandler);
+  }
 
-    // Prepare event detail
-    const eventDetail: PdsPopoverEventDetail = {
-      componentId: this.componentId,
-      popoverType: this.popoverType,
-      text: this.text,
-    };
+  /**
+   * Removes light dismiss listeners
+   */
+  private removeLightDismissListeners() {
+    document.removeEventListener('click', this.boundClickOutsideHandler, true);
+    document.removeEventListener('keydown', this.boundEscapeKeyHandler);
+  }
 
-    // Update internal state based on native popover state
-    if (toggleEvent.newState === 'open') {
-      this.active = true;
-      const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
+  /**
+   * Adds scroll and resize listeners for repositioning
+   */
+  private addScrollAndResizeListeners() {
+    window.addEventListener('scroll', this.boundScrollHandler, true);
+    window.addEventListener('resize', this.boundResizeHandler);
+  }
 
-      // Remove positioned class to hide popover via CSS
-      if (popoverEl != null) {
-        popoverEl.classList.remove('pds-popover--positioned');
-      }
+  /**
+   * Removes scroll and resize listeners
+   */
+  private removeScrollAndResizeListeners() {
+    window.removeEventListener('scroll', this.boundScrollHandler, true);
+    window.removeEventListener('resize', this.boundResizeHandler);
+  }
 
-      // Position after the browser has rendered the popover, then show it
-      requestAnimationFrame(() => {
-        // Prevent memory leak if component unmounts during animation frame
-        if (!this.isComponentMounted) return;
+  /**
+   * Handles clicks outside the popover for light dismiss (auto type only)
+   */
+  private handleClickOutside(event: MouseEvent) {
+    // Ignore events that occurred at or before the popover opened
+    // This prevents the opening click from immediately closing the popover
+    // Convert event.timeStamp (DOMHighResTimeStamp from performance.now()) to epoch time
+    // by calculating: currentEpochTime - (currentPerfTime - eventPerfTime)
+    const eventTime = event.timeStamp
+      ? Date.now() - (performance.now() - event.timeStamp)
+      : Date.now();
 
-        this.handlePopoverPositioning();
-        if (popoverEl != null) {
-          popoverEl.classList.add('pds-popover--positioned');
-        }
-      });
-      this.pdsPopoverOpen.emit(eventDetail);
-    } else if (toggleEvent.newState === 'closed') {
-      this.active = false;
-      this.pdsPopoverClose.emit(eventDetail);
+    if (eventTime <= this.openTimestamp) {
+      return;
+    }
+
+    const target = event.target as Node;
+
+    // Check if click is outside both the popover portal and the trigger
+    const clickedInsidePopover = this.portalEl?.contains(target);
+    const clickedInsideTrigger = this.triggerEl?.contains(target);
+
+    if (!clickedInsidePopover && !clickedInsideTrigger) {
+      this.hide();
     }
   }
 
-  @Listen('scroll', {
-    target: 'window',
-    capture: true
-  })
-  handleScroll() {
-    // Only reposition if the popover is actually open
-    const popoverEl = this.el.shadowRoot?.querySelector('div[popover]');
-    if (popoverEl != null && this.active === true) {
+  /**
+   * Returns focus to the trigger element with visible focus indicator
+   * This ensures focus rings/outlines are shown as they would be with keyboard navigation
+   */
+  private returnFocusToTrigger() {
+    if (!this.triggerEl) return;
+
+    // Focus immediately while still in keyboard event context
+    // This ensures the browser treats it as keyboard-initiated and shows focus ring
+    this.triggerEl.focus({ preventScroll: true });
+  }
+
+  /**
+   * Handles escape key press to close the popover
+   * Mirrors native Popover API: Escape closes and returns focus to trigger
+   */
+  private handleEscapeKey(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      // Prevent default Escape behavior and stop propagation
+      // This mirrors native Popover API which handles Escape exclusively
+      event.preventDefault();
+      event.stopPropagation();
+
+      // Close popover and return focus to trigger
+      this.hide();
+    }
+  }
+
+  /**
+   * Handles scroll events to reposition the popover (debounced for performance)
+   */
+  private handleScroll() {
+    if (!this.active) return;
+
+    if (this.scrollDebounceTimer !== null) {
+      clearTimeout(this.scrollDebounceTimer);
+    }
+
+    this.scrollDebounceTimer = setTimeout(() => {
       this.handlePopoverPositioning();
-    }
+      this.scrollDebounceTimer = null;
+    }, 10); // 10ms debounce for smooth repositioning
   }
 
+  /**
+   * Handles resize events to reposition the popover (debounced for performance)
+   */
+  private handleResize() {
+    if (!this.active) return;
+
+    if (this.resizeDebounceTimer !== null) {
+      clearTimeout(this.resizeDebounceTimer);
+    }
+
+    this.resizeDebounceTimer = setTimeout(() => {
+      this.handlePopoverPositioning();
+      this.resizeDebounceTimer = null;
+    }, 100); // 100ms debounce for resize
+  }
+
+  /**
+   * Positions the popover relative to its trigger element
+   */
   private handlePopoverPositioning() {
-    const triggerEl = this.el.shadowRoot.querySelector('.pds-popover__trigger');
-    const popoverEl = this.el.shadowRoot.querySelector('div[popover]');
+    // Prevent repositioning loops
+    if (this.isRepositioning) {
+      return;
+    }
 
-    if (triggerEl == null || popoverEl == null) return;
+    this.isRepositioning = true;
 
-    // Cast to HTMLElement after null check for proper typing
-    const triggerElement = triggerEl as HTMLElement;
-    const popoverElement = popoverEl as HTMLElement;
+    if (this.triggerEl == null || this.portalEl == null) {
+      this.isRepositioning = false;
+      return;
+    }
 
-    const triggerRect = triggerElement.getBoundingClientRect();
-    const popoverRect = popoverElement.getBoundingClientRect();
+    const triggerRect = this.triggerEl.getBoundingClientRect();
+    const popoverRect = this.portalEl.getBoundingClientRect();
+
+    // Safety check: ensure trigger has valid dimensions (is rendered and visible)
+    if (triggerRect.width === 0 || triggerRect.height === 0) {
+      this.isRepositioning = false;
+      return;
+    }
 
     let top = 0;
     let left = 0;
@@ -256,26 +661,23 @@ export class PdsPopover {
         break;
     }
 
-    popoverElement.style.top = `${top}px`;
-    popoverElement.style.left = `${left}px`;
+    this.portalEl.style.top = `${top}px`;
+    this.portalEl.style.left = `${left}px`;
+
+    // Reset the repositioning guard after a short delay
+    setTimeout(() => {
+      this.isRepositioning = false;
+    }, 16); // ~1 frame at 60fps
   }
 
   render() {
     return (
-      <Host>
-        <button
-          class="pds-popover__trigger"
-          popoverTarget={this.componentId}
-          popoverTargetAction={this.popoverTargetAction}
-        >
-          {this.text}
-        </button>
-        <div
-          class={`pds-popover ${this.active ? 'pds-popover--active' : ''}`}
-          id={this.componentId}
-          popover={this.popoverType}
-          style={{ maxWidth: `${this.maxWidth}px` }}
-        >
+      <Host id={this.componentId}>
+        <span class="pds-popover__trigger-wrapper">
+          <slot name="trigger" onSlotchange={this.handleTriggerSlotChange}></slot>
+        </span>
+
+        <div class="pds-popover__content-slot-wrapper">
           <slot></slot>
         </div>
       </Host>

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -163,6 +163,15 @@ export class PdsPopover {
   };
 
   /**
+   * Handles changes to the default slot (popover content)
+   * When the popover is active, re-sync content with portal to handle dynamic updates
+   */
+  private handleContentSlotChange = () => {
+    if (!this.active) return;
+    this.updatePortalContent();
+  };
+
+  /**
    * Handles clicks on the trigger element
    */
   private handleTriggerClick = (event: Event) => {
@@ -678,7 +687,7 @@ export class PdsPopover {
         </span>
 
         <div class="pds-popover__content-slot-wrapper">
-          <slot></slot>
+          <slot onSlotchange={this.handleContentSlotChange}></slot>
         </div>
       </Host>
     );

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -617,7 +617,7 @@ export class PdsPopover {
 
     let top = 0;
     let left = 0;
-    const offset = 8
+    const offset = 8;
 
     switch (this.placement) {
       case 'top':

--- a/libs/core/src/components/pds-popover/popover-interface.ts
+++ b/libs/core/src/components/pds-popover/popover-interface.ts
@@ -1,10 +1,5 @@
 export interface PdsPopoverEventDetail {
   componentId: string;
   popoverType: 'auto' | 'manual';
-  text?: string;
-}
-
-export interface ToggleEvent extends Event {
-  newState: 'open' | 'closed';
 }
 

--- a/libs/core/src/components/pds-popover/readme.md
+++ b/libs/core/src/components/pds-popover/readme.md
@@ -14,7 +14,6 @@
 | `placement`           | `placement`             | Determines the preferred position of the popover                                                                                                                                         | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'right'`   |
 | `popoverTargetAction` | `popover-target-action` | Determines the action that triggers the popover. For manual popovers, the consumer is responsible for toggling this value.                                                               | `"hide" \| "show" \| "toggle"`                                                                                                                                       | `'show'`    |
 | `popoverType`         | `popover-type`          | Determines the type of popover. Auto popovers can be "light dismissed" by clicking outside of the popover. Manual popovers require the consumer to handle the visibility of the popover. | `"auto" \| "manual"`                                                                                                                                                 | `'auto'`    |
-| `text`                | `text`                  | Text that appears on the trigger element                                                                                                                                                 | `string`                                                                                                                                                             | `undefined` |
 
 
 ## Events
@@ -56,6 +55,14 @@ Toggles the popover open/closed state programmatically
 Type: `Promise<void>`
 
 
+
+
+## Slots
+
+| Slot          | Description                               |
+| ------------- | ----------------------------------------- |
+| `"(default)"` | The content to display inside the popover |
+| `"trigger"`   | The trigger element for the popover       |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
+++ b/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
@@ -1,13 +1,14 @@
 import { html } from 'lit';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { extractArgTypes } from '@pxtrn/storybook-addon-docs-stencil';
 import { withActions } from '@storybook/addon-actions/decorator';
 
 export default {
 	argTypes: extractArgTypes('pds-popover'),
 	args: {
-		popoverTargetAction: 'show',
+		popoverTargetAction: 'toggle',
 		popoverType: 'auto',
+		placement: 'bottom-start',
+		componentId: 'popover-playground',
 	},
 	component: 'pds-popover',
 	decorators: [withActions],
@@ -20,25 +21,54 @@ export default {
 }
 
 const BaseTemplate = (args) => html`
-<pds-popover component-id=${args.componentId}  popover-type=${args.popoverType} popover-target-action=${args.popoverTargetAction} text=${args.text} max-width=${args.maxWidth} placement=${args.placement}>
-	${unsafeHTML(args.slot)}
-</pds-popover>
+	<pds-popover
+		component-id=${args.componentId}
+		popover-target-action=${args.popoverTargetAction}
+		popover-type=${args.popoverType}
+		placement=${args.placement}
+		.maxWidth=${args.maxWidth}
+	>
+		<pds-button slot="trigger">Show popover</pds-button>
+		<p>This is popover content that can be configured using the controls below.</p>
+	</pds-popover>
 `;
 
 export const Default = BaseTemplate.bind({});
-Default.args = {
-	componentId: 'popover-1',
-  placement: "right",
-  text: "Show popover",
-	slot: "<p>Popover content</p><p>Popover content</p>"
-};
 
-export const Toggle = BaseTemplate.bind({});
-Toggle.args = {
-	componentId: 'popover-1',
-  placement: "bottom",
-	popoverType: "manual",
-	popoverTargetAction: "toggle",
-  text: "Toggle popover",
-	slot: "<p>Popover content</p><p>Popover content</p>"
-};
+export const Toggle = () => html`
+	<pds-popover component-id="popover-toggle" popover-target-action="toggle" placement="bottom-start">
+		<pds-button slot="trigger">Toggle popover</pds-button>
+		<p>Click the trigger again to close this popover.</p>
+	</pds-popover>
+`;
+
+export const WithContent = () => html`
+	<pds-popover component-id="popover-rich" popover-target-action="toggle" placement="bottom-start">
+		<pds-button slot="trigger" variant="accent">Popover trigger</pds-button>
+		<pds-box direction="column" gap="md" fit="true">
+			<!-- Header with title and close button -->
+			<pds-box direction="column" gap="xs">
+				<pds-box display="flex" direction="row" justify-content="space-between" align-items="center" gap="300">
+					<pds-text tag="h3" size="xl" weight="semibold">Popover Heading</pds-text>
+					<pds-button
+						variant="unstyled"
+						icon-only
+						onclick="document.getElementById('popover-rich').hide()"
+						aria-label="Close"
+					>
+						<pds-icon slot="start" name="remove"></pds-icon>
+						Close
+					</pds-button>
+				</pds-box>
+				<pds-text tag="p" size="sm" color="secondary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</pds-text>
+			</pds-box>
+
+			<!-- Footer with buttons and page indicator -->
+			<pds-box justify-content="space-between" align-items="center" gap="200">
+				<pds-button variant="secondary" size="small">Previous</pds-button>
+				<pds-text tag="span" size="sm" weight="medium" color="secondary">1 / 3</pds-text>
+				<pds-button variant="primary" size="small">Next</pds-button>
+			</pds-box>
+		</pds-box>
+	</pds-popover>
+`;

--- a/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
+++ b/libs/core/src/components/pds-popover/stories/pds-popover.stories.js
@@ -35,15 +35,30 @@ const BaseTemplate = (args) => html`
 
 export const Default = BaseTemplate.bind({});
 
-export const Toggle = () => html`
-	<pds-popover component-id="popover-toggle" popover-target-action="toggle" placement="bottom-start">
+export const Toggle = (args) => html`
+	<pds-popover
+		component-id=${args.componentId || 'popover-toggle'}
+		popover-target-action=${args.popoverTargetAction}
+		popover-type=${args.popoverType}
+		placement=${args.placement}
+		.maxWidth=${args.maxWidth}
+	>
 		<pds-button slot="trigger">Toggle popover</pds-button>
 		<p>Click the trigger again to close this popover.</p>
 	</pds-popover>
 `;
+Toggle.args = {
+	componentId: 'popover-toggle'
+};
 
-export const WithContent = () => html`
-	<pds-popover component-id="popover-rich" popover-target-action="toggle" placement="bottom-start">
+export const WithContent = (args) => html`
+	<pds-popover
+		component-id=${args.componentId || 'popover-rich'}
+		popover-target-action=${args.popoverTargetAction}
+		popover-type=${args.popoverType}
+		placement=${args.placement}
+		.maxWidth=${args.maxWidth}
+	>
 		<pds-button slot="trigger" variant="accent">Popover trigger</pds-button>
 		<pds-box direction="column" gap="md" fit="true">
 			<!-- Header with title and close button -->
@@ -53,7 +68,7 @@ export const WithContent = () => html`
 					<pds-button
 						variant="unstyled"
 						icon-only
-						onclick="document.getElementById('popover-rich').hide()"
+						onclick="document.getElementById('${args.componentId || 'popover-rich'}').hide()"
 						aria-label="Close"
 					>
 						<pds-icon slot="start" name="remove"></pds-icon>
@@ -72,3 +87,6 @@ export const WithContent = () => html`
 		</pds-box>
 	</pds-popover>
 `;
+WithContent.args = {
+	componentId: 'popover-rich'
+};

--- a/libs/core/src/components/pds-popover/test/pds-popover.e2e.ts
+++ b/libs/core/src/components/pds-popover/test/pds-popover.e2e.ts
@@ -9,95 +9,105 @@ describe('pds-popover', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('should handle trigger click interactions with toggle action', async () => {
+  it('should toggle popover visibility when clicking trigger', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" popover-target-action="toggle" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover" popover-target-action="toggle">
+        <button slot="trigger">Show popover</button>
+        <p>Popover content</p>
+      </pds-popover>
+    `);
 
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const triggerButton = await page.find('button[slot="trigger"]');
 
+    // Click to open
     await triggerButton.click();
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
 
+    // Portal should exist in document.body
+    const portalEl = await page.find('#my-popover-portal');
+    expect(portalEl).toBeTruthy();
+    expect(await portalEl.isVisible()).toBe(true);
+
+    // Click to close
     await triggerButton.click();
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+    expect(await portalEl.isVisible()).toBe(false);
   });
 
-  it('should update position on scroll when active', async () => {
+  it('should respect manual mode (no auto-dismiss)', async () => {
     const page = await newE2EPage();
-    await page.setContent('<div style="height: 200vh"><pds-popover component-id="my-popover" text="Show popover"></pds-popover></div>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover" popover-type="manual" popover-target-action="toggle">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const triggerButton = await page.find('button[slot="trigger"]');
 
     await triggerButton.click();
     await page.waitForChanges();
 
-    const initialTop = await popoverContent.getComputedStyle('top');
-
-    await page.evaluate(() => window.scrollBy(0, 100));
-    await page.waitForChanges();
-
-    const newTop = await popoverContent.getComputedStyle('top');
-    expect(newTop).not.toBe(initialTop);
-  });
-
-  it('should respect manual mode', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" popover-type="manual" popover-target-action="toggle" text="Show popover"></pds-popover>');
-
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
-
-    await triggerButton.click();
-    await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    const portalEl = await page.find('#my-popover-portal');
+    expect(await portalEl.isVisible()).toBe(true);
 
     // Click outside should not close in manual mode
     await page.mouse.click(0, 0);
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+
+    // Should still be visible
+    expect(await portalEl.isVisible()).toBe(true);
   });
 
-  it('should handle default show action (does not close on second click)', async () => {
+  it('should handle default show action', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
+    const triggerButton = await page.find('button[slot="trigger"]');
     const openSpy = await page.spyOnEvent('pdsPopoverOpen');
 
     // First click opens
     await triggerButton.click();
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+
+    const portalEl = await page.find('#my-popover-portal');
+    expect(await portalEl.isVisible()).toBe(true);
     expect(openSpy).toHaveReceivedEventTimes(1);
 
     // Second click does nothing with default "show" action
     await triggerButton.click();
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    expect(await portalEl.isVisible()).toBe(true);
     expect(openSpy).toHaveReceivedEventTimes(1); // Should not emit again
   });
 
-  it('should emit events when opening and closing with toggle action', async () => {
+  it('should emit events when opening and closing', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" popover-target-action="toggle" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover" popover-target-action="toggle">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
     const openSpy = await page.spyOnEvent('pdsPopoverOpen');
     const closeSpy = await page.spyOnEvent('pdsPopoverClose');
 
-    // Open the popover by clicking trigger
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
+    // Open the popover
+    const triggerButton = await page.find('button[slot="trigger"]');
     await triggerButton.click();
     await page.waitForChanges();
 
     expect(openSpy).toHaveReceivedEvent();
     expect(openSpy).toHaveReceivedEventTimes(1);
 
-    // Close the popover by clicking trigger again
+    // Close the popover
     await triggerButton.click();
     await page.waitForChanges();
 
@@ -105,15 +115,18 @@ describe('pds-popover', () => {
     expect(closeSpy).toHaveReceivedEventTimes(1);
   });
 
-  it('should include event details in emitted events', async () => {
+  it('should include event details', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="test-popover" popover-type="auto" popover-target-action="toggle" text="Test Popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="test-popover" popover-type="auto" popover-target-action="toggle">
+        <button slot="trigger">Test Popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
     const openSpy = await page.spyOnEvent('pdsPopoverOpen');
-    const closeSpy = await page.spyOnEvent('pdsPopoverClose');
 
-    // Open the popover
-    const triggerButton = await page.find('pds-popover >>> .pds-popover__trigger');
+    const triggerButton = await page.find('button[slot="trigger"]');
     await triggerButton.click();
     await page.waitForChanges();
 
@@ -121,83 +134,182 @@ describe('pds-popover', () => {
     const openEvent = openSpy.firstEvent;
     expect(openEvent.detail.componentId).toBe('test-popover');
     expect(openEvent.detail.popoverType).toBe('auto');
-    expect(openEvent.detail.text).toBe('Test Popover');
-
-    // Close the popover
-    await triggerButton.click();
-    await page.waitForChanges();
-
-    expect(closeSpy).toHaveReceivedEvent();
-    const closeEvent = closeSpy.firstEvent;
-    expect(closeEvent.detail.componentId).toBe('test-popover');
-    expect(closeEvent.detail.popoverType).toBe('auto');
-    expect(closeEvent.detail.text).toBe('Test Popover');
   });
 
   it('should support programmatic show method', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
     const popover = await page.find('pds-popover');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
     const openSpy = await page.spyOnEvent('pdsPopoverOpen');
-
-    // Initially closed
-    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
 
     // Show programmatically
     await popover.callMethod('show');
     await page.waitForChanges();
 
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+    const portalEl = await page.find('#my-popover-portal');
+    expect(await portalEl.isVisible()).toBe(true);
     expect(openSpy).toHaveReceivedEvent();
-    expect(openSpy).toHaveReceivedEventTimes(1);
   });
 
   it('should support programmatic hide method', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
     const popover = await page.find('pds-popover');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
     const closeSpy = await page.spyOnEvent('pdsPopoverClose');
 
     // Open first
     await popover.callMethod('show');
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+
+    const portalEl = await page.find('#my-popover-portal');
+    expect(await portalEl.isVisible()).toBe(true);
 
     // Hide programmatically
     await popover.callMethod('hide');
     await page.waitForChanges();
 
-    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+    expect(await portalEl.isVisible()).toBe(false);
     expect(closeSpy).toHaveReceivedEvent();
-    expect(closeSpy).toHaveReceivedEventTimes(1);
   });
 
   it('should support programmatic toggle method', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-popover component-id="my-popover" text="Show popover"></pds-popover>');
+    await page.setContent(`
+      <pds-popover component-id="my-popover">
+        <button slot="trigger">Show popover</button>
+        <p>Content</p>
+      </pds-popover>
+    `);
 
     const popover = await page.find('pds-popover');
-    const popoverContent = await page.find('pds-popover >>> div[popover]');
     const openSpy = await page.spyOnEvent('pdsPopoverOpen');
     const closeSpy = await page.spyOnEvent('pdsPopoverClose');
-
-    // Initially closed
-    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
 
     // Toggle to open
     await popover.callMethod('toggle');
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).toContain('pds-popover--active');
+
+    const portalEl = await page.find('#my-popover-portal');
+    expect(await portalEl.isVisible()).toBe(true);
     expect(openSpy).toHaveReceivedEventTimes(1);
 
     // Toggle to close
     await popover.callMethod('toggle');
     await page.waitForChanges();
-    expect(await popoverContent.getProperty('className')).not.toContain('pds-popover--active');
+    expect(await portalEl.isVisible()).toBe(false);
     expect(closeSpy).toHaveReceivedEventTimes(1);
+  });
+
+  describe('Trigger Slot', () => {
+    it('should render with slotted trigger', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-popover component-id="popover-1" popover-target-action="toggle">
+          <button slot="trigger" id="custom-trigger">Custom Trigger</button>
+          <p>Popover content</p>
+        </pds-popover>
+      `);
+
+      const customTrigger = await page.find('button#custom-trigger');
+      expect(customTrigger).toBeTruthy();
+      expect(customTrigger.textContent).toBe('Custom Trigger');
+    });
+
+    it('should handle click events on slotted trigger', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-popover component-id="test-popover" popover-target-action="toggle">
+          <button slot="trigger" id="custom-trigger">Custom Trigger</button>
+          <p>Popover content</p>
+        </pds-popover>
+      `);
+
+      const customTrigger = await page.find('button#custom-trigger');
+      await customTrigger.click();
+      await page.waitForChanges();
+
+      const portalEl = await page.find('#test-popover-portal');
+      expect(await portalEl.isVisible()).toBe(true);
+    });
+
+    it('should toggle popover with slotted trigger', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-popover component-id="my-popover" popover-target-action="toggle">
+          <button slot="trigger" id="custom-trigger">Custom Trigger</button>
+          <p>Popover content</p>
+        </pds-popover>
+      `);
+
+      const customTrigger = await page.find('button#custom-trigger');
+
+      // Open
+      await customTrigger.click();
+      await page.waitForChanges();
+
+      const portalEl = await page.find('#my-popover-portal');
+      expect(await portalEl.isVisible()).toBe(true);
+
+      // Close
+      await customTrigger.click();
+      await page.waitForChanges();
+      expect(await portalEl.isVisible()).toBe(false);
+    });
+
+    it('should emit events when using slotted trigger', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-popover component-id="event-test" popover-target-action="toggle">
+          <button slot="trigger" id="custom-trigger">Custom Trigger</button>
+          <p>Popover content</p>
+        </pds-popover>
+      `);
+
+      const openSpy = await page.spyOnEvent('pdsPopoverOpen');
+      const closeSpy = await page.spyOnEvent('pdsPopoverClose');
+      const customTrigger = await page.find('button#custom-trigger');
+
+      // Open
+      await customTrigger.click();
+      await page.waitForChanges();
+      expect(openSpy).toHaveReceivedEvent();
+
+      // Close
+      await customTrigger.click();
+      await page.waitForChanges();
+      expect(closeSpy).toHaveReceivedEvent();
+    });
+
+    it('should work with link trigger', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-popover component-id="link-popover" popover-target-action="toggle">
+          <a href="#" slot="trigger" id="link-trigger">Info</a>
+          <p>Additional information</p>
+        </pds-popover>
+      `);
+
+      const linkTrigger = await page.find('a#link-trigger');
+      expect(linkTrigger).toBeTruthy();
+
+      // Clicking the link should open the popover
+      await linkTrigger.click();
+      await page.waitForChanges();
+
+      const portalEl = await page.find('#link-popover-portal');
+      expect(await portalEl.isVisible()).toBe(true);
+    });
   });
 });

--- a/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
+++ b/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
@@ -352,6 +352,43 @@ describe('pds-popover', () => {
     });
   });
 
+  describe('Content Slot Changes', () => {
+    it('should update portal content when slot changes while popover is active', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set popover to active state
+      page.rootInstance.active = true;
+
+      // Spy on updatePortalContent
+      const updateSpy = jest.spyOn(page.rootInstance as any, 'updatePortalContent');
+
+      // Simulate slot change
+      await (page.rootInstance as any).handleContentSlotChange();
+
+      expect(updateSpy).toHaveBeenCalled();
+    });
+
+    it('should not update portal content when slot changes while popover is inactive', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set popover to inactive state
+      page.rootInstance.active = false;
+
+      // Spy on updatePortalContent
+      const updateSpy = jest.spyOn(page.rootInstance as any, 'updatePortalContent');
+
+      // Simulate slot change
+      await (page.rootInstance as any).handleContentSlotChange();
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
 
   describe('Trigger Click Handling', () => {
     it('should call show() when popoverTargetAction is "show"', async () => {

--- a/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
+++ b/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
@@ -2,6 +2,17 @@ import { newSpecPage } from '@stencil/core/testing';
 import { PdsPopover } from '../pds-popover';
 
 describe('pds-popover', () => {
+  // Clean up portal elements after each test to prevent test pollution
+  afterEach(() => {
+    // Remove all portal elements
+    const portals = document.querySelectorAll('[id*="pds-popover-portal"]');
+    portals.forEach(portal => portal.remove());
+    
+    // Remove all portal focus style elements
+    const styles = document.querySelectorAll('style[data-pds-popover-focus]');
+    styles.forEach(style => style.remove());
+  });
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [PdsPopover],

--- a/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
+++ b/libs/core/src/components/pds-popover/test/pds-popover.spec.tsx
@@ -1,10 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { PdsPopover } from '../pds-popover';
 
-interface ToggleEvent extends Event {
-  newState: 'open' | 'closed';
-}
-
 describe('pds-popover', () => {
   it('renders', async () => {
     const page = await newSpecPage({
@@ -14,8 +10,10 @@ describe('pds-popover', () => {
     expect(page.root).toEqualHtml(`
       <pds-popover component-id="popover-1" placement="right">
         <mock:shadow-root>
-          <button class="pds-popover__trigger" popovertarget="popover-1" popovertargetaction="show"></button>
-          <div class="pds-popover" id="popover-1" popover="auto" style="max-width: 352px;">
+          <span class="pds-popover__trigger-wrapper">
+            <slot name="trigger"></slot>
+          </span>
+          <div class="pds-popover__content-slot-wrapper">
             <slot></slot>
           </div>
         </mock:shadow-root>
@@ -23,35 +21,17 @@ describe('pds-popover', () => {
     `);
   });
 
-  it('should apply a maxWidth to the popover', async () => {
-    const maxWidthValue = '450px';
+  it('should create portal on componentDidLoad', async () => {
     const page = await newSpecPage({
       components: [PdsPopover],
-      html: `
-      <pds-popover component-id="popover-1" max-width="450px">
-        <mock:shadow-root>
-          <button class="pds-popover__trigger" popovertarget="popover-1" popovertargetaction="show"></button>
-          <div class="pds-popover" id="popover-1" popover="auto" style="max-width: 450px;">
-            <slot></slot>
-          </div>
-        </mock:shadow-root>
-      </pds-popover>`,
+      html: `<pds-popover component-id="popover-1"></pds-popover>`,
     });
 
-    const contentElement = page.root?.shadowRoot?.querySelector('[popover]') as HTMLElement;
-    expect(contentElement.style.maxWidth).toBe(maxWidthValue);
+    expect((page.rootInstance as any).portalEl).toBeTruthy();
+    expect((page.rootInstance as any).portalEl.id).toBe('popover-1-portal');
   });
 
-  it('should handle positioning for all placements with scroll offsets', async () => {
-    const page = await newSpecPage({
-      components: [PdsPopover],
-      html: '<pds-popover component-id="my-popover"></pds-popover>'
-    });
-
-    // Mock window scroll position
-    Object.defineProperty(window, 'pageXOffset', { value: 10 });
-    Object.defineProperty(window, 'pageYOffset', { value: 20 });
-
+  it('should handle positioning for all placements', async () => {
     const mockTriggerRect = {
       top: 100,
       right: 200,
@@ -65,17 +45,6 @@ describe('pds-popover', () => {
       width: 200,
       height: 100
     };
-
-    const triggerEl = page.root?.shadowRoot?.querySelector('.pds-popover__trigger') as HTMLElement;
-    const popoverEl = page.root?.shadowRoot?.querySelector('div[popover]') as HTMLElement;
-
-    Object.defineProperty(triggerEl, 'getBoundingClientRect', {
-      value: () => mockTriggerRect
-    });
-
-    Object.defineProperty(popoverEl, 'getBoundingClientRect', {
-      value: () => mockPopoverRect
-    });
 
     const OFFSET = 8;
     const placements = {
@@ -129,116 +98,70 @@ describe('pds-popover', () => {
       }
     };
 
+    // Test each placement separately to avoid prop immutability issues
     for (const [placement, expected] of Object.entries(placements)) {
-      page.rootInstance.placement = placement;
-      // Directly call the private positioning method
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `<pds-popover component-id="my-popover" placement="${placement}"></pds-popover>`
+      });
+
+      // Mock trigger element
+      const mockTriggerEl = { getBoundingClientRect: () => mockTriggerRect } as HTMLElement;
+      (page.rootInstance as any).triggerEl = mockTriggerEl;
+
+      // Mock portal element
+      const portalEl = (page.rootInstance as any).portalEl as HTMLElement;
+      Object.defineProperty(portalEl, 'getBoundingClientRect', {
+        value: () => mockPopoverRect
+      });
+
+      // Reset positioning guard
+      (page.rootInstance as any).isRepositioning = false;
       (page.rootInstance as any).handlePopoverPositioning();
+
+      // Wait for the positioning timeout to complete (16ms guard reset)
+      await new Promise(resolve => setTimeout(resolve, 20));
       await page.waitForChanges();
 
-      expect(popoverEl.style.top).toBe(`${expected.top}px`);
-      expect(popoverEl.style.left).toBe(`${expected.left}px`);
+      expect(portalEl.style.top).toBe(`${expected.top}px`);
+      expect(portalEl.style.left).toBe(`${expected.left}px`);
     }
   });
 
-  it('should handle scroll events and update positioning only when active', async () => {
+  it('should emit pdsPopoverOpen event when show() is called', async () => {
     const page = await newSpecPage({
       components: [PdsPopover],
-      html: '<pds-popover component-id="my-popover"></pds-popover>'
-    });
-
-    const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
-
-    window.dispatchEvent(new Event('scroll'));
-    await page.waitForChanges();
-    expect(positioningSpy).not.toHaveBeenCalled();
-
-    page.rootInstance.active = true;
-    await page.waitForChanges();
-
-    // Clear previous spy calls
-    positioningSpy.mockClear();
-
-    window.dispatchEvent(new Event('scroll'));
-    await page.waitForChanges();
-    expect(positioningSpy).toHaveBeenCalled();
-  });
-
-  it('should call native showPopover when show() method is called', async () => {
-    const page = await newSpecPage({
-      components: [PdsPopover],
-      html: '<pds-popover component-id="my-popover"></pds-popover>'
-    });
-
-    const popoverEl = page.root?.shadowRoot?.querySelector('div[popover]') as HTMLElement & { showPopover?: jest.Mock };
-    popoverEl.showPopover = jest.fn();
-
-    await page.rootInstance.show();
-    expect(popoverEl.showPopover).toHaveBeenCalled();
-  });
-
-  it('should call native hidePopover when hide() method is called', async () => {
-    const page = await newSpecPage({
-      components: [PdsPopover],
-      html: '<pds-popover component-id="my-popover"></pds-popover>'
-    });
-
-    const popoverEl = page.root?.shadowRoot?.querySelector('div[popover]') as HTMLElement & { hidePopover?: jest.Mock };
-    popoverEl.hidePopover = jest.fn();
-
-    await page.rootInstance.hide();
-    expect(popoverEl.hidePopover).toHaveBeenCalled();
-  });
-
-  it('should call native togglePopover when toggle() method is called', async () => {
-    const page = await newSpecPage({
-      components: [PdsPopover],
-      html: '<pds-popover component-id="my-popover"></pds-popover>'
-    });
-
-    const popoverEl = page.root?.shadowRoot?.querySelector('div[popover]') as HTMLElement & { togglePopover?: jest.Mock };
-    popoverEl.togglePopover = jest.fn();
-
-    await page.rootInstance.toggle();
-    expect(popoverEl.togglePopover).toHaveBeenCalled();
-  });
-
-  it('should emit pdsPopoverOpen event with details when toggle event fires with open state', async () => {
-    const page = await newSpecPage({
-      components: [PdsPopover],
-      html: '<pds-popover component-id="test-popover" popover-type="auto" text="Test"></pds-popover>'
+      html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
     });
 
     const openEventSpy = jest.fn();
     page.root?.addEventListener('pdsPopoverOpen', openEventSpy);
 
-    // Simulate toggle event with open state
-    const toggleEvent = new Event('toggle') as ToggleEvent;
-    Object.defineProperty(toggleEvent, 'newState', { value: 'open' });
+    // Mock trigger element for positioning
+    (page.rootInstance as any).triggerEl = {
+      getBoundingClientRect: () => ({ top: 100, left: 100, width: 50, height: 30, right: 150, bottom: 130 })
+    };
 
-    (page.rootInstance as any).handleToggle(toggleEvent);
+    await page.rootInstance.show();
     await page.waitForChanges();
 
     expect(openEventSpy).toHaveBeenCalled();
     expect(page.rootInstance.active).toBe(true);
   });
 
-  it('should emit pdsPopoverClose event with details when toggle event fires with closed state', async () => {
+  it('should emit pdsPopoverClose event when hide() is called', async () => {
     const page = await newSpecPage({
       components: [PdsPopover],
-      html: '<pds-popover component-id="test-popover" popover-type="auto" text="Test"></pds-popover>'
+      html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
     });
 
     const closeEventSpy = jest.fn();
     page.root?.addEventListener('pdsPopoverClose', closeEventSpy);
 
-    // Set active to true first
+    // Set active first
     page.rootInstance.active = true;
 
-    // Simulate toggle event with closed state
-    const toggleEvent = new Event('toggle') as ToggleEvent;
-    Object.defineProperty(toggleEvent, 'newState', { value: 'closed' });
-
-    (page.rootInstance as any).handleToggle(toggleEvent);
+    await page.rootInstance.hide();
     await page.waitForChanges();
 
     expect(closeEventSpy).toHaveBeenCalled();
@@ -251,8 +174,7 @@ describe('pds-popover', () => {
       html: '<pds-popover component-id="my-popover" popover-target-action="toggle"></pds-popover>'
     });
 
-    const triggerButton = page.root?.shadowRoot?.querySelector('.pds-popover__trigger') as HTMLButtonElement;
-    expect(triggerButton.getAttribute('popovertargetaction')).toBe('toggle');
+    expect(page.rootInstance.popoverTargetAction).toBe('toggle');
   });
 
   it('should handle different popoverType values', async () => {
@@ -261,7 +183,695 @@ describe('pds-popover', () => {
       html: '<pds-popover component-id="my-popover" popover-type="manual"></pds-popover>'
     });
 
-    const popoverEl = page.root?.shadowRoot?.querySelector('div[popover]') as HTMLElement;
-    expect(popoverEl.getAttribute('popover')).toBe('manual');
+    expect(page.rootInstance.popoverType).toBe('manual');
+  });
+
+  describe('Trigger Slot', () => {
+    it('should render trigger slot wrapper', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="popover-1"></pds-popover>',
+      });
+
+      const triggerWrapper = page.root?.shadowRoot?.querySelector('.pds-popover__trigger-wrapper');
+      expect(triggerWrapper).toBeTruthy();
+    });
+
+    it('should initialize trigger in componentDidLoad as fallback', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover">
+            <button slot="trigger" id="fallback-btn">Fallback</button>
+          </pds-popover>
+        `,
+        supportsShadowDom: false
+      });
+
+      // Manually clear triggerEl to simulate slot change not firing
+      (page.rootInstance as any).triggerEl = null;
+
+      const button = page.root?.querySelector('#fallback-btn') as HTMLElement;
+      const addEventListenerSpy = jest.spyOn(button, 'addEventListener');
+
+      // Mock the shadowRoot and slot
+      const mockSlot = {
+        assignedElements: () => [button]
+      };
+      const mockShadowRoot = {
+        querySelector: jest.fn().mockReturnValue(mockSlot)
+      };
+      Object.defineProperty(page.root, 'shadowRoot', {
+        value: mockShadowRoot,
+        configurable: true
+      });
+
+      // Manually call componentDidLoad
+      await (page.rootInstance as any).componentDidLoad();
+
+      expect((page.rootInstance as any).triggerEl).toBe(button);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('should render with slotted trigger', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="popover-1">
+            <button slot="trigger">Custom Button</button>
+            <p>Content</p>
+          </pds-popover>
+        `,
+      });
+
+      const slottedButton = page.root?.querySelector('button[slot="trigger"]');
+      expect(slottedButton).toBeTruthy();
+      expect(slottedButton?.textContent).toBe('Custom Button');
+    });
+
+    it('should handle slot change with assigned elements', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover" popover-target-action="toggle">
+            <button slot="trigger" id="custom-btn">Custom</button>
+            <p>Content</p>
+          </pds-popover>
+        `,
+      });
+
+      const slot = page.root?.shadowRoot?.querySelector('slot[name="trigger"]') as HTMLSlotElement;
+      const button = page.root?.querySelector('#custom-btn') as HTMLElement;
+
+      // Mock addEventListener to verify it's called
+      const addEventListenerSpy = jest.spyOn(button, 'addEventListener');
+
+      // Mock assignedElements
+      Object.defineProperty(slot, 'assignedElements', {
+        value: () => [button],
+        writable: true
+      });
+
+      // Trigger slot change
+      const slotChangeEvent = new Event('slotchange');
+      Object.defineProperty(slotChangeEvent, 'target', { value: slot, enumerable: true });
+      (page.rootInstance as any).handleTriggerSlotChange(slotChangeEvent);
+      await page.waitForChanges();
+
+      expect((page.rootInstance as any).triggerEl).toBe(button);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('should handle slot change with no assigned elements', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>',
+      });
+
+      const slot = page.root?.shadowRoot?.querySelector('slot[name="trigger"]') as HTMLSlotElement;
+
+      // Mock assignedElements to return empty array
+      Object.defineProperty(slot, 'assignedElements', {
+        value: () => [],
+        writable: true
+      });
+
+      // Trigger slot change
+      const slotChangeEvent = new Event('slotchange');
+      Object.defineProperty(slotChangeEvent, 'target', { value: slot, enumerable: true });
+      (page.rootInstance as any).handleTriggerSlotChange(slotChangeEvent);
+      await page.waitForChanges();
+
+      expect((page.rootInstance as any).triggerEl).toBeNull();
+    });
+
+    it('should clean up trigger event listener on slot change', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover">
+            <button slot="trigger" id="old-btn">Old</button>
+          </pds-popover>
+        `,
+      });
+
+      const slot = page.root?.shadowRoot?.querySelector('slot[name="trigger"]') as HTMLSlotElement;
+      const oldButton = page.root?.querySelector('#old-btn') as HTMLElement;
+      const removeEventListenerSpy = jest.spyOn(oldButton, 'removeEventListener');
+
+      // Mock first slot change with old button
+      Object.defineProperty(slot, 'assignedElements', {
+        value: () => [oldButton],
+        writable: true,
+        configurable: true
+      });
+
+      let slotChangeEvent = new Event('slotchange');
+      Object.defineProperty(slotChangeEvent, 'target', { value: slot, enumerable: true });
+      (page.rootInstance as any).handleTriggerSlotChange(slotChangeEvent);
+      await page.waitForChanges();
+
+      // Mock second slot change with no elements (trigger removed)
+      Object.defineProperty(slot, 'assignedElements', {
+        value: () => [],
+        writable: true,
+        configurable: true
+      });
+
+      slotChangeEvent = new Event('slotchange');
+      Object.defineProperty(slotChangeEvent, 'target', { value: slot, enumerable: true });
+      (page.rootInstance as any).handleTriggerSlotChange(slotChangeEvent);
+      await page.waitForChanges();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+  });
+
+  describe('Performance Optimizations', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should debounce scroll events', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="my-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      // Trigger multiple scroll events
+      (page.rootInstance as any).handleScroll();
+      (page.rootInstance as any).handleScroll();
+      (page.rootInstance as any).handleScroll();
+
+      // Should not call positioning immediately
+      expect(positioningSpy).not.toHaveBeenCalled();
+
+      // Advance timers past debounce delay
+      jest.advanceTimersByTime(50);
+
+      // Should have been called once after debounce
+      expect(positioningSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should debounce resize events', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="my-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      // Trigger multiple resize events
+      (page.rootInstance as any).handleResize();
+      (page.rootInstance as any).handleResize();
+      (page.rootInstance as any).handleResize();
+
+      // Should not call positioning immediately
+      expect(positioningSpy).not.toHaveBeenCalled();
+
+      // Advance timers past debounce delay (100ms for resize)
+      jest.advanceTimersByTime(150);
+
+      // Should have been called once after debounce
+      expect(positioningSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not trigger scroll handler when popover is not active', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="my-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = false;
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      (page.rootInstance as any).handleScroll();
+      jest.advanceTimersByTime(50);
+
+      expect(positioningSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger resize handler when popover is not active', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="my-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = false;
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      (page.rootInstance as any).handleResize();
+      jest.advanceTimersByTime(150);
+
+      expect(positioningSpy).not.toHaveBeenCalled();
+    });
+
+    it('should clear timers on hide', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="my-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      (page.rootInstance as any).scrollDebounceTimer = setTimeout(() => {}, 1000);
+      (page.rootInstance as any).resizeDebounceTimer = setTimeout(() => {}, 1000);
+
+      await page.rootInstance.hide();
+      await page.waitForChanges();
+
+      expect((page.rootInstance as any).scrollDebounceTimer).toBeNull();
+      expect((page.rootInstance as any).resizeDebounceTimer).toBeNull();
+    });
+  });
+
+  describe('Trigger Click Handling', () => {
+    it('should call show() when popoverTargetAction is "show"', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover" popover-target-action="show">
+            <button slot="trigger">Trigger</button>
+          </pds-popover>
+        `
+      });
+
+      const showSpy = jest.spyOn(page.rootInstance, 'show');
+      const mockEvent = new Event('click');
+      jest.spyOn(mockEvent, 'preventDefault');
+
+      (page.rootInstance as any).handleTriggerClick(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(showSpy).toHaveBeenCalled();
+    });
+
+    it('should call hide() when popoverTargetAction is "hide"', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover" popover-target-action="hide">
+            <button slot="trigger">Trigger</button>
+          </pds-popover>
+        `
+      });
+
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+      const mockEvent = new Event('click');
+      jest.spyOn(mockEvent, 'preventDefault');
+
+      (page.rootInstance as any).handleTriggerClick(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(hideSpy).toHaveBeenCalled();
+    });
+
+    it('should call toggle() when popoverTargetAction is "toggle"', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover" popover-target-action="toggle">
+            <button slot="trigger">Trigger</button>
+          </pds-popover>
+        `
+      });
+
+      const toggleSpy = jest.spyOn(page.rootInstance, 'toggle');
+      const mockEvent = new Event('click');
+      jest.spyOn(mockEvent, 'preventDefault');
+
+      (page.rootInstance as any).handleTriggerClick(mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(toggleSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Toggle Method', () => {
+    it('should call hide() when active is true', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      await page.rootInstance.toggle();
+
+      expect(hideSpy).toHaveBeenCalled();
+    });
+
+    it('should call show() when active is false', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      page.rootInstance.active = false;
+      const showSpy = jest.spyOn(page.rootInstance, 'show');
+
+      await page.rootInstance.toggle();
+
+      expect(showSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Light Dismiss', () => {
+    it('should hide popover when clicking outside for auto type', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      // Mock elements
+      (page.rootInstance as any).triggerEl = document.createElement('button');
+      (page.rootInstance as any).portalEl = document.createElement('div');
+
+      // Mock event with target outside popover and trigger
+      const outsideElement = document.createElement('div');
+      const mockEvent = { target: outsideElement } as unknown as MouseEvent;
+
+      (page.rootInstance as any).handleClickOutside(mockEvent);
+
+      expect(hideSpy).toHaveBeenCalled();
+    });
+
+    it('should not hide popover when clicking inside portal', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      // Mock portal element
+      const portalEl = document.createElement('div');
+      const insideElement = document.createElement('span');
+      portalEl.appendChild(insideElement);
+      (page.rootInstance as any).portalEl = portalEl;
+      (page.rootInstance as any).triggerEl = document.createElement('button');
+
+      const mockEvent = { target: insideElement } as unknown as MouseEvent;
+
+      (page.rootInstance as any).handleClickOutside(mockEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not hide popover when clicking trigger', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      // Mock trigger element
+      const triggerEl = document.createElement('button');
+      (page.rootInstance as any).triggerEl = triggerEl;
+      (page.rootInstance as any).portalEl = document.createElement('div');
+
+      const mockEvent = { target: triggerEl } as unknown as MouseEvent;
+
+      (page.rootInstance as any).handleClickOutside(mockEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it('should hide popover when Escape key is pressed', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      const mockEvent = { key: 'Escape' } as KeyboardEvent;
+
+      (page.rootInstance as any).handleEscapeKey(mockEvent);
+
+      expect(hideSpy).toHaveBeenCalled();
+    });
+
+    it('should not hide popover when other keys are pressed', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      const mockEvent = { key: 'Enter' } as KeyboardEvent;
+
+      (page.rootInstance as any).handleEscapeKey(mockEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Positioning Edge Cases', () => {
+    it('should not position when isRepositioning is true', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set up mocks
+      const mockTriggerEl = {
+        getBoundingClientRect: () => ({ top: 100, left: 100, width: 50, height: 30, right: 150, bottom: 130 })
+      } as HTMLElement;
+      (page.rootInstance as any).triggerEl = mockTriggerEl;
+
+      const portalEl = (page.rootInstance as any).portalEl as HTMLElement;
+      Object.defineProperty(portalEl, 'getBoundingClientRect', {
+        value: () => ({ width: 100, height: 50 })
+      });
+
+      // Set isRepositioning to true
+      (page.rootInstance as any).isRepositioning = true;
+
+      // Store initial style
+      const initialTop = portalEl.style.top;
+
+      (page.rootInstance as any).handlePopoverPositioning();
+
+      // Styles should not have changed
+      expect(portalEl.style.top).toBe(initialTop);
+    });
+
+    it('should not position when trigger has zero dimensions', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set up trigger with zero dimensions
+      const mockTriggerEl = {
+        getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0 })
+      } as HTMLElement;
+      (page.rootInstance as any).triggerEl = mockTriggerEl;
+
+      const portalEl = (page.rootInstance as any).portalEl as HTMLElement;
+      Object.defineProperty(portalEl, 'getBoundingClientRect', {
+        value: () => ({ width: 100, height: 50 })
+      });
+
+      // Store initial style
+      const initialTop = portalEl.style.top;
+
+      (page.rootInstance as any).isRepositioning = false;
+      (page.rootInstance as any).handlePopoverPositioning();
+
+      // Styles should not have changed
+      expect(portalEl.style.top).toBe(initialTop);
+    });
+
+    it('should not position when component is not mounted in show()', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set up mocks
+      (page.rootInstance as any).triggerEl = {
+        getBoundingClientRect: () => ({ top: 100, left: 100, width: 50, height: 30, right: 150, bottom: 130 })
+      };
+
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      // Mark component as not mounted
+      (page.rootInstance as any).isComponentMounted = false;
+
+      await page.rootInstance.show();
+
+      // Wait for requestAnimationFrame
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Positioning should not have been called due to early return
+      expect(positioningSpy).not.toHaveBeenCalled();
+    });
+
+    it('should position when component is mounted in show()', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set up mocks
+      (page.rootInstance as any).triggerEl = {
+        getBoundingClientRect: () => ({ top: 100, left: 100, width: 50, height: 30, right: 150, bottom: 130 })
+      };
+
+      const portalEl = (page.rootInstance as any).portalEl as HTMLElement;
+      Object.defineProperty(portalEl, 'getBoundingClientRect', {
+        value: () => ({ width: 100, height: 50 })
+      });
+
+      const positioningSpy = jest.spyOn(page.rootInstance as any, 'handlePopoverPositioning');
+
+      // Ensure component is marked as mounted
+      (page.rootInstance as any).isComponentMounted = true;
+      (page.rootInstance as any).isRepositioning = false;
+
+      await page.rootInstance.show();
+
+      // Wait for requestAnimationFrame to complete
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Positioning should have been called
+      expect(positioningSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Portal Creation', () => {
+    it('should auto-generate portal ID when componentId is not provided', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover></pds-popover>'
+      });
+
+      const portalEl = (page.rootInstance as any).portalEl;
+      expect(portalEl).toBeTruthy();
+      expect(portalEl.id).toMatch(/^pds-popover-portal-\d+$/);
+    });
+
+    it('should handle createPortal with slot content', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: `
+          <pds-popover component-id="test-popover">
+            <button slot="trigger">Trigger</button>
+            <div>Popover content</div>
+          </pds-popover>
+        `
+      });
+
+      // Test that createPortal creates the portal element
+      const portalEl = (page.rootInstance as any).portalEl;
+      expect(portalEl).toBeTruthy();
+      expect(portalEl.id).toBe('test-popover-portal');
+
+      // Verify portal has proper styles applied
+      expect(portalEl.style.position).toBe('fixed');
+      expect(portalEl.style.display).toBe('none');
+      expect(portalEl.style.opacity).toBe('0');
+      expect(portalEl.style.visibility).toBe('hidden');
+    });
+
+    it('should not create portal if one already exists', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      const originalPortal = (page.rootInstance as any).portalEl;
+      const createPortalSpy = jest.spyOn(document, 'createElement');
+
+      // Call createPortal again - it should return early
+      (page.rootInstance as any).createPortal();
+
+      // Should still have the same portal
+      expect((page.rootInstance as any).portalEl).toBe(originalPortal);
+      // createElement should not have been called again for portal creation
+      expect(createPortalSpy).not.toHaveBeenCalledWith('div');
+
+      createPortalSpy.mockRestore();
+    });
+  });
+
+  describe('Show Method Edge Cases', () => {
+    it('should not show if already active', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Set active to true
+      page.rootInstance.active = true;
+
+      const updateContentSpy = jest.spyOn(page.rootInstance as any, 'updatePortalContent');
+
+      await page.rootInstance.show();
+
+      // updatePortalContent should not have been called since already active
+      expect(updateContentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not show if portal does not exist', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover"></pds-popover>'
+      });
+
+      // Remove portal
+      (page.rootInstance as any).portalEl = null;
+
+      const updateContentSpy = jest.spyOn(page.rootInstance as any, 'updatePortalContent');
+
+      await page.rootInstance.show();
+
+      // updatePortalContent should not have been called since no portal
+      expect(updateContentSpy).not.toHaveBeenCalled();
+      expect(page.rootInstance.active).toBe(false);
+    });
+  });
+
+  describe('Light Dismiss Edge Cases', () => {
+    it('should handle click outside when portalEl or triggerEl are null', async () => {
+      const page = await newSpecPage({
+        components: [PdsPopover],
+        html: '<pds-popover component-id="test-popover" popover-type="auto"></pds-popover>'
+      });
+
+      page.rootInstance.active = true;
+      const hideSpy = jest.spyOn(page.rootInstance, 'hide');
+
+      // Set portalEl to null
+      (page.rootInstance as any).portalEl = null;
+      (page.rootInstance as any).triggerEl = null;
+
+      const outsideElement = document.createElement('div');
+      const mockEvent = { target: outsideElement } as unknown as MouseEvent;
+
+      (page.rootInstance as any).handleClickOutside(mockEvent);
+
+      // Should call hide since both are null (nothing to check contains on)
+      expect(hideSpy).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Description

Refactors `pds-popover` to use a slot-based approach for the trigger element, improving flexibility and developer experience. The trigger is now passed via a `slot="trigger"` instead of using `popover-target`, allowing any element (buttons, links, custom components) to activate the popover.

**Key changes:**
- Implement slot-based trigger pattern with `<slot name="trigger">` for better flexibility
- Add portal rendering to `document.body` for correct positioning in all CSS contexts
- Add debounced scroll/resize listeners to keep popover positioned with trigger
- Add new "WithContent" story showcasing rich content using Pine components

**Motivation:** The slot-based approach provides more flexibility for consumers and aligns with modern web component patterns. The portal implementation ensures the component works correctly in all usage contexts, regardless of parent container styles.

Fixes https://kajabi.atlassian.net/browse/DSS-1567

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests - Comprehensive spec tests with fake timers for portal lifecycle, node movement, focus management, debouncing, and edge cases
- [x] e2e tests - Updated E2E tests to query portal elements and validate visibility/positioning
- [x] tested manually - Verified in Storybook across all placement options, scroll/resize behavior, and light dismiss functionality

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
