### PR TITLE
ci: add Slack notification for releases

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -11,9 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Pull latest
-        run: git pull
-
       - name: Setup ENV Vars
         run: |
           VERSION="${{ github.event.release.tag_name }}"

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,35 @@
+name: "Notify Release to Slack"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pull latest
+        run: git pull
+
+      - name: Setup ENV Vars
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          RELEASE_URL="${{ github.event.release.html_url }}"
+          DATE=$(date '+%B %d, %Y')
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "RELEASE_URL=$RELEASE_URL" >> $GITHUB_ENV
+          echo "DATE=$DATE" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Send Slack Notification
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ vars.SLACK_CHANNEL_NAME }}
+          payload-file-path: "./.github/workflows/slack_payloads/release-info.json"
+

--- a/.github/workflows/slack_payloads/release-info.json
+++ b/.github/workflows/slack_payloads/release-info.json
@@ -30,7 +30,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "The details for version *${{ env.VERSION }}* can be found at the link provided below.\n\n*Release*: ${{ env.RELEASE_URL }}"
+				"text": "The details for version *${{ env.VERSION }}* can be found at the link provided below.\n\n*Release*: <${{ env.RELEASE_URL }}>"
 			}
 		}
 	]

--- a/.github/workflows/slack_payloads/release-info.json
+++ b/.github/workflows/slack_payloads/release-info.json
@@ -1,5 +1,5 @@
 {
-  "blocks": [
+	"blocks": [
 		{
 			"type": "header",
 			"text": {
@@ -30,7 +30,7 @@
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
-				"text": "The details for version *${{ env.VERSION }}* can be found at the link provided below. \n\n ${{ env.RELEASE_URL }}"
+				"text": "The details for version *${{ env.VERSION }}* can be found at the link provided below.\n\n*Release*: ${{ env.RELEASE_URL }}"
 			}
 		}
 	]


### PR DESCRIPTION
# Description

Adds automated Slack notifications for Pine releases. When a new release is published, a notification is sent to the configured Slack channel with the version number, release date, and a link to the GitHub release.

This uses the existing internal Slack bot (same setup as pine-icons)

**Files added/modified:**
- `.github/workflows/notify-release.yml` - New workflow that triggers on release published events
- `.github/workflows/slack_payloads/release-info.json` - Updated message template (removed commit message for cleaner multi-commit releases)

Fixes: [DSS-4](https://linear.app/kajabi/issue/DSS-4/add-slack-notifications-for-pine-releases)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested manually - Will be verified when the next Pine release is published. The workflow is isolated and won't affect the release process if it fails.

**Note:** This workflow runs independently after releases are published, so any failure won't impact the release itself.