### PR TITLE
fix(deps): update @pine-ds/icons to 9.12.0 with Stencil 4.38.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,29 +90,6 @@
         "webpack": "^5.74.0"
       }
     },
-    "libs/core/node_modules/@stencil/core": {
-      "version": "4.38.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.38.3.tgz",
-      "integrity": "sha512-rSDzGUfi58X8K79ySjlM6KlY+mq7D+ittzgNAdYHcsXHc70sBpdatFhnbOg25uVDiMf7xRAH9slP38pPdXnZOQ==",
-      "license": "MIT",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.10.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-darwin-arm64": "4.34.9",
-        "@rollup/rollup-darwin-x64": "4.34.9",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
-        "@rollup/rollup-linux-arm64-musl": "4.34.9",
-        "@rollup/rollup-linux-x64-gnu": "4.34.9",
-        "@rollup/rollup-linux-x64-musl": "4.34.9",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
-        "@rollup/rollup-win32-x64-msvc": "4.34.9"
-      }
-    },
     "libs/core/node_modules/vite": {
       "version": "4.5.13",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.13.tgz",
@@ -5694,15 +5671,15 @@
       "link": true
     },
     "node_modules/@pine-ds/icons": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/@pine-ds/icons/-/icons-9.11.0.tgz",
-      "integrity": "sha512-IzvJZI/cnuFgaAkXNm32xxb9UTDoYgzXeqHhtPi2MJkYf9BpZJkW+rQlQSV5ca2CNuPs9ov3AmYb8rGHwfyapQ==",
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@pine-ds/icons/-/icons-9.12.0.tgz",
+      "integrity": "sha512-m0xQYFrxFQ+ycffZvwyv2L0goSULkGInqI8+xhZgSQTPC7J1zROrTfNJC/gAdx07HMqn1h4QUVlPu7dyqr9cGg==",
       "license": "MIT",
       "workspaces": [
         "./"
       ],
       "dependencies": {
-        "@stencil/core": "4.28.2"
+        "@stencil/core": "4.38.3"
       }
     },
     "node_modules/@pine-ds/react": {
@@ -6405,9 +6382,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.28.2.tgz",
-      "integrity": "sha512-sHwBNionxzHfmjQ93ffaQOBNvd5HrSn8e5KSsiBBaODgC/g9squZoARYHHJ0VFfUpOXkEoZQ+ASixpUBafG9bA==",
+      "version": "4.38.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.38.3.tgz",
+      "integrity": "sha512-rSDzGUfi58X8K79ySjlM6KlY+mq7D+ittzgNAdYHcsXHc70sBpdatFhnbOg25uVDiMf7xRAH9slP38pPdXnZOQ==",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"


### PR DESCRIPTION
# Description

Updates @pine-ds/icons from 9.11.0 to 9.12.0, which includes the updated Stencil dependency (4.28.2 → 4.38.3). This ensures version consistency across the Pine ecosystem and resolves Stencil version mismatches that were causing dependency conflicts in consuming applications.

**Dependencies updated:**
- @pine-ds/icons: 9.11.0 → 9.12.0
- @stencil/core (transitive): 4.28.2 → 4.38.3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:
- Pine versions: 3.10.0 → 3.11.0 (after release)
- OS: macOS
- Browsers: N/A (dependency update only)
- Screen readers: N/A
- Misc: Verified package-lock.json reflects correct versions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes