### PR TITLE
fix(): update code connect mappings to match latest component updates

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.figma.ts
+++ b/libs/core/src/components/pds-avatar/pds-avatar.figma.ts
@@ -2,13 +2,13 @@ import figma, { html } from '@figma/code-connect/html';
 
 figma.connect('<FIGMA_AVATAR>', {
   props: {
-    badge: figma.boolean('Member'),
+    badge: figma.boolean('Badge'),
     size: figma.enum('Size', {
-      "xsm": "xs",
-      "sm": "sm",
-      "md": "md",
-      "lg": "lg",
-      "xl": "xl",
+      "xsm - 24px": "xs",
+      "sm - 32px": "sm",
+      "md - 40px": "md",
+      "lg - 56px": "lg",
+      "xl - 64px": "xl",
     }),
     type: figma.enum('Type', {
       "user": "ASSET_URL",

--- a/libs/core/src/components/pds-button/pds-button.figma.ts
+++ b/libs/core/src/components/pds-button/pds-button.figma.ts
@@ -3,11 +3,11 @@ import figma, { html } from '@figma/code-connect/html';
 const sharedProps = {
   label: figma.string('Label'),
   iconStart: figma.boolean("Leading icon", {
-    true: html`<pds-icon name="home" slot="start"></pds-icon>`,
+    true: html`<pds-icon name="home" slot="start" aria-hidden="true"></pds-icon>`,
     false: undefined,
   }),
   iconEnd: figma.boolean("Trailing icon", {
-    true: html`<pds-icon name="home" slot="end"></pds-icon>`,
+    true: html`<pds-icon name="home" slot="end" aria-hidden="true"></pds-icon>`,
     false: undefined,
   }),
   isDisabled: figma.enum("State",{
@@ -33,15 +33,25 @@ figma.connect('<FIGMA_BUTTON_PRIMARY>', {
       "destructive": "destructive",
       "accent": "accent",
     }),
+    iconOnlyAttr: figma.boolean('Icon only', {
+      true: "true",
+      false: undefined,
+    }),
+    iconOnlyIcon: figma.boolean('Icon only', {
+      true: html`<pds-icon slot="start" aria-hidden="true" name="gear"></pds-icon>`,
+      false: undefined,
+    }),
     label: figma.string('Label'),
   },
   example: (props) => html`\
   <pds-button
     disabled=${props.isDisabled}
     loading=${props.isLoading}
+    icon-only=${props.iconOnlyAttr}
     size=${props.size}
     variant=${props.variant}
   >
+    ${props.iconOnlyIcon}
     ${props.iconStart}
     ${props.label}
     ${props.iconEnd}

--- a/libs/core/src/components/pds-button/pds-button.figma.ts
+++ b/libs/core/src/components/pds-button/pds-button.figma.ts
@@ -16,6 +16,11 @@ const sharedProps = {
   isLoading: figma.enum("State",{
     loading: true
   }),
+  size: figma.enum("Size", {
+    "default - 36px": undefined,
+    "small - 32px": "small",
+    "micro - 24px": "micro",
+  }),
 }
 
 figma.connect('<FIGMA_BUTTON_PRIMARY>', {
@@ -24,6 +29,7 @@ figma.connect('<FIGMA_BUTTON_PRIMARY>', {
     variant: figma.enum('Variant', {
       "primary": "primary",
       "secondary": "secondary",
+      "tertiary": "tertiary",
       "destructive": "destructive",
       "accent": "accent",
     }),
@@ -33,6 +39,7 @@ figma.connect('<FIGMA_BUTTON_PRIMARY>', {
   <pds-button
     disabled=${props.isDisabled}
     loading=${props.isLoading}
+    size=${props.size}
     variant=${props.variant}
   >
     ${props.iconStart}

--- a/libs/core/src/components/pds-checkbox/pds-checkbox.figma.ts
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.figma.ts
@@ -9,8 +9,8 @@ figma.connect('<FIGMA_CHECKBOX>', {
     disabled: figma.enum("State", {
       disabled: "true",
     }),
-    helperMessage: figma.boolean("Supporting text", {
-      true: figma.string("↪️ Message"),
+    helperMessage: figma.boolean("Helper message", {
+      true: figma.string("↳ ✏️Message"),
       false: undefined,
     }),
     indeterminate: figma.boolean('Indeterminate', {
@@ -18,7 +18,7 @@ figma.connect('<FIGMA_CHECKBOX>', {
       false: undefined,
     }),
     label: figma.boolean("Label", {
-      true: figma.string("↪️ Message"),
+      true: figma.string("↳ ✏️Message"),
       false: undefined,
     }),
   },


### PR DESCRIPTION
# Description

Updated Figma Code Connect files to align with recent component changes in Figma.

> [!NOTE]  
> Updates have already been published to the Figma library.

**Button Component:**
- Added `tertiary` variant support
- Added `size` prop mapping (`default`, `small`, `micro`)
- Default size returns `undefined` to omit the attribute when not needed

**Checkbox Component:**
- Fixed property reference from `"Supporting text"` to `"Helper message"`

**Avatar Component:**
- Fixed property reference from `"Member"` to `"Badge"`
- Updated size enum values to match Figma naming convention (e.g., `"xsm - 24px"`)

These updates ensure Code Connect validation passes and generated code matches the latest Figma component definitions.

Fixes [DSS-5](https://linear.app/kajabi/issue/DSS-5/update-figma-code-connect-mappings)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Figma Code Connect validation passes without errors
- [x] tested manually

**Test Configuration**:

- Pine versions: current
- OS: macOS
- Browsers: N/A (Figma Code Connect configuration only)
- Screen readers: N/A
- Misc: Verified against Figma component definitions using Figma Desktop MCP

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-5]: https://kajabi.atlassian.net/browse/DSS-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ