### PR TITLE
fix(pds-dropdown-menu) add part for sizing and adjust positioning

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
+++ b/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
@@ -76,6 +76,8 @@ import { components } from '../../../../dist/docs.json';
 
 <DocArgsTable componentName="pds-dropdown-menu-item" docSource={components} />
 
+## Examples
+
 ### Default
 
 The default dropdown menu displays a list of options that can be selected by the user.
@@ -243,6 +245,86 @@ The dropdown menu can be positioned relative to the trigger using the placement 
    <pds-chip slot="trigger" sentiment="success" variant="dropdown">Trigger</pds-chip>
    <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
    <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
+  </pds-dropdown-menu>
+</div>
+</DocCanvas>
+
+### Scrollable Menu
+
+The `menu-panel` CSS part can be used to customize the menu container's dimensions and enable scrolling for long lists as needed.
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+<style>
+{\`
+  .scrollable-menu::part(menu-panel) {
+    max-height: 200px;
+    overflow-y: auto;
+    min-width: 250px;
+  }
+\`}
+</style>
+<PdsDropdownMenu className="scrollable-menu">
+  <PdsButton slot="trigger">Options</PdsButton>
+  <PdsDropdownMenuItem>Item 1</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 2</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 3</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 4</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 5</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 6</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 7</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 8</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 9</PdsDropdownMenuItem>
+  <PdsDropdownMenuItem>Item 10</PdsDropdownMenuItem>
+</PdsDropdownMenu>
+`,
+    webComponent:`
+<style>
+  .scrollable-menu::part(menu-panel) {
+    max-height: 200px;
+    overflow-y: auto;
+    min-width: 250px;
+  }
+</style>
+<pds-dropdown-menu class="scrollable-menu">
+  <pds-button slot="trigger">Options</pds-button>
+  <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 3</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 4</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 5</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 6</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 7</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 8</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 9</pds-dropdown-menu-item>
+  <pds-dropdown-menu-item>Item 10</pds-dropdown-menu-item>
+</pds-dropdown-menu>
+`
+  }}
+>
+<style>
+{`
+  .scrollable-menu::part(menu-panel) {
+    max-height: 200px;
+    overflow-y: auto;
+    min-width: 250px;
+  }
+`}
+</style>
+<div style={{ height: '300px', width: '100%', textAlign: 'center'}}>
+  <pds-dropdown-menu class="scrollable-menu">
+    <pds-button slot="trigger">Options</pds-button>
+    <pds-dropdown-menu-item>Item 1</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 2</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 3</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 4</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 5</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 6</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 7</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 8</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 9</pds-dropdown-menu-item>
+    <pds-dropdown-menu-item>Item 10</pds-dropdown-menu-item>
   </pds-dropdown-menu>
 </div>
 </DocCanvas>

--- a/libs/core/src/components/pds-dropdown-menu/readme.md
+++ b/libs/core/src/components/pds-dropdown-menu/readme.md
@@ -13,6 +13,13 @@
 | `placement`   | `placement`    | The placement of the dropdown panel relative to the trigger.          | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
 
 
+## Shadow Parts
+
+| Part           | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `"menu-panel"` | Exposes the dropdown menu container for styling. |
+
+
 ## Dependencies
 
 ### Depends on


### PR DESCRIPTION
# Description

This PR adds styling customization capabilities to the `pds-dropdown-menu` component and fixes a positioning bug.

Fixes: [DSS-6](https://linear.app/kajabi/issue/DSS-6/add-css-part-to-dropdown-menu-to-allow-styling-of-panel)

## Changes

1. **New CSS Part**: Added `menu-panel` CSS part to expose the dropdown menu container for external styling. Developers can now customize the menu's dimensions, scrolling behavior, and other container styles using `::part(menu-panel)`.

2. **Positioning Fix**: Fixed an issue where the dropdown menu would not maintain its position relative to the trigger when the browser window was resized or scrolled. Implemented `autoUpdate` from Floating UI to automatically reposition the dropdown on viewport changes.

## Motivation

Developers needed a way to control the dropdown menu's size and add scroll behavior for long lists without modifying the component internals. The CSS part pattern provides a clean, standards-based approach for shadow DOM styling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually
  - Verified dropdown repositions correctly on window resize
  - Verified dropdown repositions correctly on scroll
  - Tested CSS part styling with custom dimensions and overflow
  - Tested across different placement options (bottom-start, bottom-end, etc.)
  - Verified cleanup on component unmount and dropdown close

## Test Configuration

- **Browser**: Chrome, Safari
- **Documentation**: Added interactive example demonstrating scrollable menu with custom sizing


# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
