### PR TITLE
fix(input-interface): correct typo in event detail property name

### DIFF
--- a/libs/core/src/components/pds-input/input-interface.ts
+++ b/libs/core/src/components/pds-input/input-interface.ts
@@ -9,6 +9,6 @@ export interface InputInputEventDetail {
 }
 
 export interface InputEvent <T = InputChangeEventDetail> extends CustomEvent {
-  detai: T;
+  detail: T;
   target: HTMLPdsInputElement;
 }


### PR DESCRIPTION
# Description

Fixed a typo in the `InputEvent` interface where the property was incorrectly named `detai` instead of `detail`. This corrects the TypeScript type definitions to match the standard CustomEvent interface.

**File changed:** `libs/core/src/components/pds-input/input-interface.ts`

This addresses developer feedback about improving TypeScript type definitions for components.

Fixes [DSS-9](https://linear.app/kajabi/issue/DSS-9/fix-typo-in-inputevent-interface-detai-→-detail)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests

**Test Results:**
- 165 tests passed (event and input-related tests)
- pds-input component: 85.34% coverage maintained
- All event-related components (checkbox, radio, switch, textarea) continue to pass

**Test Configuration**:
- Pine versions: 3.11.0
- Node: 22.7.0
- Stencil: 4.38.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

[DSS-9]: https://kajabi.atlassian.net/browse/DSS-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ