### PR TITLE
fix(): replace any types with proper types in component events

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -6,18 +6,22 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { BoxColumnType, BoxShadowSizeType, BoxSpacingType } from "./utils/types";
+import { Event } from "@stencil/core";
 import { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-interface";
 import { ChipSentimentType, ChipVariantType, PlacementType } from "./utils/types";
 import { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 import { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
 import { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
+import { SortableEvent } from "sortablejs";
 import { TextareaChangeEventDetail, TextareaInputEventDetail } from "./components/pds-textarea/textarea-interface";
 export { BoxColumnType, BoxShadowSizeType, BoxSpacingType } from "./utils/types";
+export { Event } from "@stencil/core";
 export { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-interface";
 export { ChipSentimentType, ChipVariantType, PlacementType } from "./utils/types";
 export { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 export { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
 export { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
+export { SortableEvent } from "sortablejs";
 export { TextareaChangeEventDetail, TextareaInputEventDetail } from "./components/pds-textarea/textarea-interface";
 export namespace Components {
     /**
@@ -2051,9 +2055,9 @@ export interface PdsToastCustomEvent<T> extends CustomEvent<T> {
 }
 declare global {
     interface HTMLMockPdsModalElementEventMap {
-        "pdsModalOpen": any;
-        "pdsModalClose": any;
-        "pdsModalBackdropClick": any;
+        "pdsModalOpen": void;
+        "pdsModalClose": void;
+        "pdsModalBackdropClick": void;
     }
     /**
      * Mock PdsModal component for testing purposes
@@ -2109,7 +2113,7 @@ declare global {
         new (): HTMLPdsBoxElement;
     };
     interface HTMLPdsButtonElementEventMap {
-        "pdsClick": any;
+        "pdsClick": Event;
     }
     interface HTMLPdsButtonElement extends Components.PdsButton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsButtonElementEventMap>(type: K, listener: (this: HTMLPdsButtonElement, ev: PdsButtonCustomEvent<HTMLPdsButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2144,7 +2148,7 @@ declare global {
         new (): HTMLPdsCheckboxElement;
     };
     interface HTMLPdsChipElementEventMap {
-        "pdsTagCloseClick": any;
+        "pdsTagCloseClick": void;
     }
     interface HTMLPdsChipElement extends Components.PdsChip, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsChipElementEventMap>(type: K, listener: (this: HTMLPdsChipElement, ev: PdsChipCustomEvent<HTMLPdsChipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2178,7 +2182,7 @@ declare global {
         new (): HTMLPdsComboboxElement;
     };
     interface HTMLPdsCopytextElementEventMap {
-        "pdsCopyTextClick": any;
+        "pdsCopyTextClick": string;
     }
     interface HTMLPdsCopytextElement extends Components.PdsCopytext, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsCopytextElementEventMap>(type: K, listener: (this: HTMLPdsCopytextElement, ev: PdsCopytextCustomEvent<HTMLPdsCopytextElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2405,7 +2409,7 @@ declare global {
         new (): HTMLPdsSelectElement;
     };
     interface HTMLPdsSortableElementEventMap {
-        "pdsSortableItemMoved": any;
+        "pdsSortableItemMoved": SortableEvent;
     }
     interface HTMLPdsSortableElement extends Components.PdsSortable, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsSortableElementEventMap>(type: K, listener: (this: HTMLPdsSortableElement, ev: PdsSortableCustomEvent<HTMLPdsSortableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2670,15 +2674,15 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the backdrop is clicked
          */
-        "onPdsModalBackdropClick"?: (event: MockPdsModalCustomEvent<any>) => void;
+        "onPdsModalBackdropClick"?: (event: MockPdsModalCustomEvent<void>) => void;
         /**
           * Event emitted when the modal is closed
          */
-        "onPdsModalClose"?: (event: MockPdsModalCustomEvent<any>) => void;
+        "onPdsModalClose"?: (event: MockPdsModalCustomEvent<void>) => void;
         /**
           * Event emitted when the modal is opened
          */
-        "onPdsModalOpen"?: (event: MockPdsModalCustomEvent<any>) => void;
+        "onPdsModalOpen"?: (event: MockPdsModalCustomEvent<void>) => void;
         /**
           * Whether the modal is open
           * @default false
@@ -3375,7 +3379,7 @@ declare namespace LocalJSX {
           * Provides the button with a submittable name.
          */
         "name"?: string;
-        "onPdsClick"?: (event: PdsButtonCustomEvent<any>) => void;
+        "onPdsClick"?: (event: PdsButtonCustomEvent<Event>) => void;
         /**
           * Sets the size of the button.
           * @defaultValue default
@@ -3478,7 +3482,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the close button is clicked on a tag variant chip.
          */
-        "onPdsTagCloseClick"?: (event: PdsChipCustomEvent<any>) => void;
+        "onPdsTagCloseClick"?: (event: PdsChipCustomEvent<void>) => void;
         /**
           * Defines the color scheme of the chip.
           * @defaultValue 'neutral'
@@ -3608,7 +3612,7 @@ declare namespace LocalJSX {
         /**
           * Event fired when copyText button is clicked.
          */
-        "onPdsCopyTextClick"?: (event: PdsCopytextCustomEvent<any>) => void;
+        "onPdsCopyTextClick"?: (event: PdsCopytextCustomEvent<string>) => void;
         /**
           * Determines whether the `value` should truncate and display with an ellipsis.
           * @defaultValue false
@@ -4232,7 +4236,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a sortable item is moved.
          */
-        "onPdsSortableItemMoved"?: (event: PdsSortableCustomEvent<any>) => void;
+        "onPdsSortableItemMoved"?: (event: PdsSortableCustomEvent<SortableEvent>) => void;
     }
     interface PdsSortableItem {
         /**

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -99,7 +99,7 @@ export class PdsButton {
    */
   @Prop() variant: 'primary' | 'secondary' | 'tertiary' | 'accent' | 'disclosure' | 'destructive' | 'unstyled' | 'filter' = 'primary';
 
-  @Event() pdsClick: EventEmitter;
+  @Event() pdsClick: EventEmitter<Event>;
 
   /**
    * Listen for Enter key presses on form inputs to trigger submit

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -26,9 +26,9 @@
 
 ## Events
 
-| Event      | Description | Type               |
-| ---------- | ----------- | ------------------ |
-| `pdsClick` |             | `CustomEvent<any>` |
+| Event      | Description | Type                 |
+| ---------- | ----------- | -------------------- |
+| `pdsClick` |             | `CustomEvent<Event>` |
 
 
 ## Slots

--- a/libs/core/src/components/pds-chip/pds-chip.tsx
+++ b/libs/core/src/components/pds-chip/pds-chip.tsx
@@ -51,7 +51,7 @@ export class PdsChip {
   /**
    * Event emitted when the close button is clicked on a tag variant chip.
    */
-  @Event() pdsTagCloseClick: EventEmitter;
+  @Event() pdsTagCloseClick: EventEmitter<void>;
 
   private handleCloseClick = () => {
     this.pdsTagCloseClick.emit();

--- a/libs/core/src/components/pds-chip/readme.md
+++ b/libs/core/src/components/pds-chip/readme.md
@@ -19,9 +19,9 @@
 
 ## Events
 
-| Event              | Description                                                           | Type               |
-| ------------------ | --------------------------------------------------------------------- | ------------------ |
-| `pdsTagCloseClick` | Event emitted when the close button is clicked on a tag variant chip. | `CustomEvent<any>` |
+| Event              | Description                                                           | Type                |
+| ------------------ | --------------------------------------------------------------------- | ------------------- |
+| `pdsTagCloseClick` | Event emitted when the close button is clicked on a tag variant chip. | `CustomEvent<void>` |
 
 
 ## Slots

--- a/libs/core/src/components/pds-copytext/pds-copytext.tsx
+++ b/libs/core/src/components/pds-copytext/pds-copytext.tsx
@@ -39,7 +39,7 @@ export class PdsCopytext {
   /**
    * Event fired when copyText button is clicked.
    */
-  @Event() pdsCopyTextClick: EventEmitter;
+  @Event() pdsCopyTextClick: EventEmitter<string>;
 
   private copyToClipboard = async (value: string) => {
     try {

--- a/libs/core/src/components/pds-copytext/readme.md
+++ b/libs/core/src/components/pds-copytext/readme.md
@@ -18,9 +18,9 @@
 
 ## Events
 
-| Event              | Description                                  | Type               |
-| ------------------ | -------------------------------------------- | ------------------ |
-| `pdsCopyTextClick` | Event fired when copyText button is clicked. | `CustomEvent<any>` |
+| Event              | Description                                  | Type                  |
+| ------------------ | -------------------------------------------- | --------------------- |
+| `pdsCopyTextClick` | Event fired when copyText button is clicked. | `CustomEvent<string>` |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
@@ -54,17 +54,17 @@ export class MockPdsModal {
   /**
    * Event emitted when the modal is opened
    */
-  @Event() pdsModalOpen: EventEmitter;
+  @Event() pdsModalOpen: EventEmitter<void>;
 
   /**
    * Event emitted when the modal is closed
    */
-  @Event() pdsModalClose: EventEmitter;
+  @Event() pdsModalClose: EventEmitter<void>;
 
   /**
    * Event emitted when the backdrop is clicked
    */
-  @Event() pdsModalBackdropClick: EventEmitter;
+  @Event() pdsModalBackdropClick: EventEmitter<void>;
 
   /**
    * Shows the modal

--- a/libs/core/src/components/pds-modal/test/readme.md
+++ b/libs/core/src/components/pds-modal/test/readme.md
@@ -23,11 +23,11 @@ This component mimics the real PdsModal but without using the Popover API
 
 ## Events
 
-| Event                   | Description                                | Type               |
-| ----------------------- | ------------------------------------------ | ------------------ |
-| `pdsModalBackdropClick` | Event emitted when the backdrop is clicked | `CustomEvent<any>` |
-| `pdsModalClose`         | Event emitted when the modal is closed     | `CustomEvent<any>` |
-| `pdsModalOpen`          | Event emitted when the modal is opened     | `CustomEvent<any>` |
+| Event                   | Description                                | Type                |
+| ----------------------- | ------------------------------------------ | ------------------- |
+| `pdsModalBackdropClick` | Event emitted when the backdrop is clicked | `CustomEvent<void>` |
+| `pdsModalClose`         | Event emitted when the modal is closed     | `CustomEvent<void>` |
+| `pdsModalOpen`          | Event emitted when the modal is opened     | `CustomEvent<void>` |
 
 
 ## Methods

--- a/libs/core/src/components/pds-sortable/pds-sortable.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import type { SortableEvent } from 'sortablejs';
 import { SortableType } from './sortable-interface';
 import Sortable from 'sortablejs';
 
@@ -13,7 +14,7 @@ export class PdsSortable {
   /**
    * Event emitted when a sortable item is moved.
    */
-  @Event() pdsSortableItemMoved: EventEmitter;
+  @Event() pdsSortableItemMoved: EventEmitter<SortableEvent>;
 
   /**
    * Determines whether `sortable` should have a border.

--- a/libs/core/src/components/pds-sortable/readme.md
+++ b/libs/core/src/components/pds-sortable/readme.md
@@ -17,9 +17,9 @@
 
 ## Events
 
-| Event                  | Description                                  | Type               |
-| ---------------------- | -------------------------------------------- | ------------------ |
-| `pdsSortableItemMoved` | Event emitted when a sortable item is moved. | `CustomEvent<any>` |
+| Event                  | Description                                  | Type                         |
+| ---------------------- | -------------------------------------------- | ---------------------------- |
+| `pdsSortableItemMoved` | Event emitted when a sortable item is moved. | `CustomEvent<SortableEvent>` |
 
 
 ----------------------------------------------

--- a/libs/core/src/components/pds-sortable/sortable-interface.ts
+++ b/libs/core/src/components/pds-sortable/sortable-interface.ts
@@ -1,7 +1,10 @@
+import type { SortableEvent } from 'sortablejs';
+
 export interface SortableType {
   animation: number;
   ghostClass: string;
   dragClass: string;
-  onEnd: (evt: Event) => void;
+  onEnd: (evt: SortableEvent) => void;
   handle?: string;
 }
+


### PR DESCRIPTION
# Description

Component events were using `any` type for event details, causing developers to lose autocomplete and type safety. This addresses developer feedback on improving TypeScript definitions.

## Fix Details

Added proper types to `EventEmitter<T>` for 7 events across 5 components:
- `pds-button.pdsClick` → `EventEmitter<Event>`
- `pds-chip.pdsTagCloseClick` → `EventEmitter<void>`
- `pds-copytext.pdsCopyTextClick` → `EventEmitter<string>`
- `pds-sortable.pdsSortableItemMoved` → `EventEmitter<SortableEvent>`
- `mock-pds-modal` events → `EventEmitter<void>` (pdsModalOpen, pdsModalClose, pdsModalBackdropClick)

This is a non-breaking type refinement. Developers now get full autocomplete and compile-time type checking.

Fixes [DSS-10](https://linear.app/kajabi/issue/DSS-10/fix-typescript-event-type-definitions-remove-any-types-from-component)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.11.0
- OS: macOS
- Browsers: N/A (type-only change)
- Screen readers: N/A
- Misc: TypeScript compilation verified, existing tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR


[DSS-10]: https://kajabi.atlassian.net/browse/DSS-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ