### PR TITLE
fix(core): export component types for TypeScript resolution

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -16,6 +16,19 @@
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/index.cjs.js"
+    },
+    "./components/*": "./components/*",
+    "./loader": {
+      "types": "./loader/index.d.ts",
+      "import": "./loader/index.js",
+      "require": "./loader/index.cjs.js"
+    }
+  },
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/pine-core/pine-core.esm.js",

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -1,1 +1,2 @@
+export * from './components';
 import '@pine-ds/icons';


### PR DESCRIPTION
# Description

Fixes TypeScript type resolution for Pine components. Previously, component types weren't properly exported from `@pine-ds/core`, causing IDE issues and requiring developers to navigate type definitions manually.

**Changes:**
- Export component types from main entry point (`src/index.ts`)
- Add `exports` field to `package.json` for modern bundler/TypeScript support

This improves IDE intellisense and type inference when using Pine components.

Fixes: DSS-13

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Tested in consuming application (`kajabi-products`) to verify:
  - Component prop autocomplete works
  - Type imports resolve correctly
  - No TypeScript errors

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
