### PR TITLE
fix(release): update Slack notification workflow to use environment var

### DIFF
--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -246,6 +246,10 @@ jobs:
         run: git pull
         shell: bash
 
+      - name: Fetch latest tags
+        run: git fetch --tags
+        shell: bash
+
       - name: Setup ENV Vars
         run: |
           # Get the latest git tag (which is the version just released)

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -248,18 +248,22 @@ jobs:
 
       - name: Setup ENV Vars
         run: |
-          echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
-          cat ./package.json >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-          echo "CURRENT_DATE=$(date +'%B %d, %Y')" >> $GITHUB_ENV
+          # Get the latest git tag (which is the version just released)
+          VERSION=$(git describe --tags --abbrev=0)
+          CURRENT_DATE=$(date +'%B %d, %Y')
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "CURRENT_DATE=$CURRENT_DATE" >> $GITHUB_ENV
+          echo "RELEASE_URL=https://github.com/${{ github.repository }}/releases/tag/$VERSION" >> $GITHUB_ENV
+        shell: bash
 
       - name: Send Slack Notification
         uses: slackapi/slack-github-action@v1.26.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           DATE: ${{ env.CURRENT_DATE }}
-          RELEASE_URL: "${{ format('https://github.com/{0}/releases/tag/v{1}', github.repository, fromJSON(env.PACKAGE_JSON).version) }}"
-          VERSION: ${{ fromJson(env.PACKAGE_JSON).version }}
+          RELEASE_URL: ${{ env.RELEASE_URL }}
+          VERSION: ${{ env.VERSION }}
         with:
           channel-id: ${{ vars.SLACK_CHANNEL_NAME }}
           payload-file-path: "./.github/workflows/slack_payloads/release-info.json"


### PR DESCRIPTION
# Description

Fixes the Slack release notification to display the correct version number. Previously, the notification was showing `**` (empty) for the version because it attempted to read from the root `package.json`, which doesn't contain a version field in this monorepo setup.

**Changes:**
- Extract version from the git tag created by Nx release using `git describe --tags --abbrev=0`
- Simplify environment variable setup by removing unnecessary `package.json` parsing
- Construct release URL directly from the git tag

Next release should show the actual version instead of it missing in the most recent release.

<img width="796" height="225" alt="Screenshot 2025-11-20 at 8 28 55 AM" src="https://github.com/user-attachments/assets/58fce3bc-0218-4430-aeff-29f7020ae268" />

Fixes [DSS-14](https://linear.app/kajabi/issue/DSS-14/fix-empty-version-numbers-in-slack-release-notifications)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Will be verified on the next Pine release. The fix uses the git tag that Nx release creates, which is a reliable source for the version number.

**Test Configuration**:

- The previous release showed empty versions (`**`) in the Slack notification
- This fix ensures the version is extracted from the git tag instead

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings