### PR TITLE
docs: standardize docs sections and add form integration section to form components

### DIFF
--- a/libs/core/src/components/pds-accordion/docs/pds-accordion.mdx
+++ b/libs/core/src/components/pds-accordion/docs/pds-accordion.mdx
@@ -33,7 +33,8 @@ Though similar, tabs and accordions both offer different user experiences. Consi
 
 <DocArgsTable componentName="pds-accordion" docSource={components} />
 
-## Default
+## Examples
+### Default
 
 With neither slot set, the accordion will render with a default trigger label and no panel content.
 
@@ -45,7 +46,8 @@ With neither slot set, the accordion will render with a default trigger label an
   <pds-accordion></pds-accordion>
 </DocCanvas>
 
-## Content Slots Set
+
+### Content Slots Set
 
 When the slots are set, the accordion will render with the provided trigger label and panel content. HTML markup or Pine components can be used inside the panel slot.
 
@@ -82,7 +84,7 @@ When the slots are set, the accordion will render with the provided trigger labe
   </pds-accordion>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [NNGroup: Accordions on Desktop: When and How to Use](https://www.nngroup.com/articles/accordions-on-desktop/)
 

--- a/libs/core/src/components/pds-alert/docs/pds-alert.mdx
+++ b/libs/core/src/components/pds-alert/docs/pds-alert.mdx
@@ -29,7 +29,8 @@ The alert component is used to display a message to the user. It can be used to 
 
 <DocArgsTable componentName="pds-alert" docSource={components} />
 
-## Variants
+## Examples
+### Variants
 
 The alert component supports multiple style variants to indicate different types of messages:
 
@@ -71,7 +72,8 @@ Text in small alerts is truncated when it becomes too long for the alert descrip
   <pds-alert heading="Alert heading text" small="true" variant="info">Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.</pds-alert>
 </DocCanvas>
 
-## Actions
+
+### Actions
 
 Action items such as buttons and links should be added to alerts using the `actions` slot.
 
@@ -116,7 +118,8 @@ When using the small variant, actions are displayed on the same line as the desc
   <pds-alert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
 </DocCanvas>
 
-## Dismissible
+
+### Dismissible
 
 Alerts can be set to be dismissible using the `dismissible` property. This will add a close button to the alert.
 

--- a/libs/core/src/components/pds-avatar/docs/pds-avatar.mdx
+++ b/libs/core/src/components/pds-avatar/docs/pds-avatar.mdx
@@ -24,6 +24,8 @@ The avatar component is used to display a thumbnail representation of an admin, 
 
 <DocArgsTable componentName="pds-avatar" docSource={components} />
 
+## Examples
+
 ### Default
 
 The default avatar style, typically used to represent a generic user or business.

--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -51,6 +51,8 @@ The `start` and `end` slots allow icons to be placed before and after the button
 
 <DocArgsTable componentName="pds-button" docSource={components}/>
 
+## Examples
+
 ### Primary
 
 The default button, intended to be used with affirmative actions such as submitting, continuing, and saving.

--- a/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
+++ b/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
@@ -22,6 +22,8 @@ Checkboxes provide users with selectable options like toggling a single setting 
 
 <DocArgsTable componentName="pds-checkbox" docSource={components} />
 
+## Examples
+
 ### Default
 
 <DocCanvas client:only
@@ -100,6 +102,12 @@ An optional error message can be displayed for additional instructions, shown in
 
 ### pdsCheckboxChange
 Used when you want to perform an action when the checkbox state changes. The returned structure is a `CheckboxChangeEventDetail` that contains `checked` and `value`.
+
+## Form Integration
+
+- Set the `name` attribute so each checked box contributes its `value` to `FormData`; unchecked boxes are omitted automatically.
+- Give every checkbox in a group a distinct `value` so the server can differentiate selections.
+- Pair `required`, `invalid`, and `errorMessage` when you need inline validation.
 
 ## Additional Resources
 

--- a/libs/core/src/components/pds-chip/docs/pds-chip.mdx
+++ b/libs/core/src/components/pds-chip/docs/pds-chip.mdx
@@ -24,6 +24,8 @@ The `dropdown` variant and the icon within the `tag` variant of the chip compone
 
 <DocArgsTable componentName="pds-chip" docSource={components} />
 
+## Examples
+
 ### Default
 
 <DocCanvas client:only
@@ -187,7 +189,7 @@ If the `variant` property is set to `"dropdown"`, the chip will be rendered in a
   <pds-chip sentiment="warning" variant="dropdown">Warning</pds-chip>
 </DocCanvas>
 
-## Tag
+### Tag
 
 If the `variant` property is set to `"tag"`, the chip will be rendered in a tag style, altering its appearance and behavior accordingly.
 

--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -1107,3 +1107,14 @@ Both `<optgroup>` and `<pds-text>` group labels are rendered as presentational i
 - **`<pds-text>` elements**: Serve as visual group headers but are purely presentational. They do not provide semantic grouping information to screen readers.
 
 **Recommendation**: Use `<optgroup>` when semantic grouping is important for accessibility and screen reader users. Use `<pds-text>` when you only need visual organization without semantic meaning.
+
+## Form Integration
+
+`pds-combobox` is a <pds-link href="https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/formAssociated" external>form-associated custom element</pds-link>. This means the component participates in `<form>` submission just like native `<select>` / `<input>` controls.
+
+- Provide a `name` attribute so the selected value is included in `FormData`. Without `name`, the control is ignored during submission.
+- The submitted value always matches the option's `value` attribute, even when a custom layout/chip trigger is used.
+- `mode="filter"` behaves like an `<input>` plus `<datalist>`: users can type new text, but the submitted value will still be one of the predefined options.
+- `mode="select-only"` works closer to a `<select>`: typing is disabled for button/chip triggers, and only explicit option values can be submitted.
+- Update the `value` prop to control the selection from a parent component (React state, framework store, etc.). The component automatically syncs the input text/trigger label to match the selected option.
+

--- a/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
+++ b/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
@@ -19,6 +19,8 @@ The Copy Text component is a button that enables users to copy text to their cli
 
 <DocArgsTable componentName="pds-copytext" docSource={components} />
 
+## Examples
+
 ### Default
 
 The default copy text button.

--- a/libs/core/src/components/pds-divider/docs/pds-divider.mdx
+++ b/libs/core/src/components/pds-divider/docs/pds-divider.mdx
@@ -24,6 +24,8 @@ A divider is used to create a clear visual separation between sections of conten
 
 <DocArgsTable componentName="pds-divider" docSource={components} />
 
+## Examples
+
 ### Default
 
 The default divider displays a horizontal line.

--- a/libs/core/src/components/pds-filters/docs/pds-filters.mdx
+++ b/libs/core/src/components/pds-filters/docs/pds-filters.mdx
@@ -37,9 +37,7 @@ The filters component provides a flexible system for creating filter interfaces 
 
 <DocArgsTable componentName="pds-filter" docSource={components} />
 
-## Variants
-
-The `pds-filter` component supports four variants:
+## Examples
 
 ### Default
 
@@ -160,7 +158,8 @@ Emitted when a filter popover is closed. Clear variant does not emit this event.
 
 Emitted when a clear variant is clicked. Use this event to clear/reset other filters.
 
-## Methods
+## Technical Notes
+### Methods
 
 ### showFilter()
 

--- a/libs/core/src/components/pds-icon/docs/pds-icon.mdx
+++ b/libs/core/src/components/pds-icon/docs/pds-icon.mdx
@@ -22,6 +22,8 @@ The icon component is used to display scalable, customizable icons that represen
 
 <DocArgsTable componentName="pds-icon" docSource={pdsDocsJson} />
 
+## Examples
+
 ### Color
 
 The `color` property allows the icon to be displayed in a specified color. Accepted formats include:
@@ -84,7 +86,7 @@ The `size` property allows the icon to be displayed at a specified size. Accepte
   </>
 </DocCanvas>
 
-## How to Use Icons
+### How to Use Icons
 
 ### React Usage
 
@@ -110,7 +112,8 @@ For web components, use the `name` property with the icon name as a string:
 <pds-icon name="launch" size="large"></pds-icon>
 ```
 
-## Common Patterns
+
+### Common Patterns
 
 ### Individual Icon Imports
 
@@ -128,11 +131,11 @@ import { danger, bulb } from '@pine-ds/icons/icons';
 For components that use several icons, import multiple icons in a single statement:
 
 ```jsx
-import { 
-  danger, 
-  bulb, 
-  launch, 
-  downSmall 
+import {
+  danger,
+  bulb,
+  launch,
+  downSmall
 } from '@pine-ds/icons/icons';
 ```
 
@@ -142,7 +145,8 @@ import {
 - **Avoid wildcard imports**: Don't use `import * from '@pine-ds/icons/icons'` as this imports all icons
 - **Bundle size**: Each icon adds approximately 1-2KB to your bundle
 
-## Troubleshooting
+
+### Troubleshooting
 
 ### Console Warning About Name Property
 

--- a/libs/core/src/components/pds-image/docs/pds-image.mdx
+++ b/libs/core/src/components/pds-image/docs/pds-image.mdx
@@ -23,6 +23,8 @@ While images can provide useful information to convey to the user, when not care
 
 <DocArgsTable componentName="pds-image" docSource={components} />
 
+## Examples
+
 ### Default
 
 A default image with a `src` and `alt`.
@@ -66,7 +68,7 @@ An image with `srcset` and `sizes` props set. Refresh the browser at `400px` and
   ></pds-image>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [MDN: Image](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
 

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -35,6 +35,8 @@ When analyzing designs or screenshots, text that appears above an input field is
 
 <DocArgsTable componentName="pds-input" docSource={components} />
 
+## Examples
+
 ### Default
 
 The type of input used varies based on the type of information you look to capture. The `text` default type allows for any type of single line data. For more information on the types this component supports, please see the MDN article on the [input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types).
@@ -445,7 +447,13 @@ Best practice: Use for form submission and final value processing
 
 Example: `<pds-input onPdsChange={handleFormChange}>`
 
-## References
+## Form Integration
+
+- Provide a `name` so the field participates in `FormData` submissions whenever it holds a non-empty value (empty strings are skipped, matching the built-in ElementInternals behavior).
+- Use the `value` prop with `onPdsInputChange` when you need a controlled field; omit `value` for uncontrolled forms.
+- Pair `required`, `pattern`, `errorMessage`, and `invalid` to surface validation rules inline with native form semantics.
+
+## Additional Resources
 
 For more information about using inputs, refer to:
 - [MDN Web Docs: HTML autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

--- a/libs/core/src/components/pds-link/docs/pds-link.mdx
+++ b/libs/core/src/components/pds-link/docs/pds-link.mdx
@@ -15,6 +15,8 @@ In many current web design patterns, buttons and links have evolved to look visu
 
 <DocArgsTable componentName="pds-link" docSource={components} />
 
+## Examples
+
 ### Default
 
 The default `inline` link. Visually, it maintains the underlined appearance of a hyperlink.
@@ -114,7 +116,7 @@ When no custom text is provided, the link will use the `href` as the link text.
   <pds-link href="#some-anchor"></pds-link>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [CSS Tricks: Buttons vs. Links](https://css-tricks.com/buttons-vs-links/)
 

--- a/libs/core/src/components/pds-loader/docs/pds-loader.mdx
+++ b/libs/core/src/components/pds-loader/docs/pds-loader.mdx
@@ -18,13 +18,21 @@ The Loader component is a visual indicator that informs users an operation is in
 - Avoid using the Loader for actions that complete quickly, as it may cause unnecessary distraction.
 - Do not use the Loader for background tasks that do not require user interaction.
 
-## Accessibility
+
+### Accessibility
 
 Dynamic content on a page that does not require a page load is considered a live region. A loader can be used to convey to the user that the live region will be updated. The appropriate aria role, `aria-live`, is already set on the loader component when `is-loading` is set to `true`. When `is-loading` is set to `false`, `aria-hidden` is added to the component to hide it from the accessibility tree. For more information about live regions, please refer to [MDN's article.](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
+
+### Technical Details
+
+- `<pds-loader>` toggles `aria-live="polite"`, `aria-hidden`, and `aria-busy` as `is-loading` changes. Add `role="status"` yourself when you want the loader to be announced as the primary status region. Provide specific copy (“Saving profile…”) instead of generic text when possible.
+- The default “Loading…” string is injected through the unnamed slot even when `show-label="false"`. This keeps the label available to screen readers. Supply a `<span slot="label">` to customise the announcement.
 
 ## Properties
 
 <DocArgsTable componentName="pds-loader" docSource={components} />
+
+## Examples
 
 ### Default
 
@@ -75,7 +83,7 @@ The default loader's size can be changed to a either a preset value or a custom 
 </DocCanvas>
 
 
-## Typing
+### Typing
 
 Setting the `variant` prop to `typing` will display a typing loader. This loader is not affected by any changes to the `size` prop.
 
@@ -87,6 +95,6 @@ Setting the `variant` prop to `typing` will display a typing loader. This loader
   <pds-loader is-loading="true" variant="typing"></pds-loader>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [MDN: Live Regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -44,173 +44,8 @@ The `pds-modal-footer` component provides a consistent footer area for the modal
 
 {/* <DocArgsTable componentName="pds-modal-footer" docSource={components} /> */}
 
-## Opening and Closing Modals
-
-There are several ways to control a modal's visibility:
-
-### Using Buttons
-
-Modals can be opened and closed programmatically using the `open` property:
-
-<DocCanvas client:only
-  mdxSource={{
-    react: `
-    function ModalControl() {
-      return (
-        <div>
-          <PdsButton onClick={() => {
-            const modal = document.querySelector('#control-modal');
-            if (modal) modal.open = true;
-          }}>Open Modal</PdsButton>
-
-          <PdsModal id="control-modal" componentId="control-modal">
-            <PdsModalHeader>
-              <PdsBox direction="column" fit padding="md">
-                <PdsBox alignItems="center" fit justifyContent="space-between">
-                  <PdsText tag="h2" size="h3">Controlled Modal</PdsText>
-                  <PdsButton
-                    class="pds-modal__close"
-                    variant="unstyled"
-                    iconOnly
-                    onclick="document.querySelector('#control-modal').open = false"
-                    aria-label="Close modal"
-                  >
-                    <PdsIcon slot="start" name="remove" aria-hidden="true"></PdsIcon>
-                  </PdsButton>
-                </PdsBox>
-              </PdsBox>
-            </PdsModalHeader>
-            <PdsModalContent>
-              <PdsBox fit direction="column" paddingInlineStart="md" paddingInlineEnd="md">
-                <p>This modal is controlled by external buttons.</p>
-              </PdsBox>
-            </PdsModalContent>
-            <PdsModalFooter>
-              <PdsBox fit justifyContent="end" padding="md" gap="sm">
-                <PdsButton onClick={() => {
-                  const modal = document.querySelector('#control-modal');
-                  if (modal) modal.open = false;
-                }}>Close</PdsButton>
-              </PdsBox>
-            </PdsModalFooter>
-          </PdsModal>
-        </div>
-      );
-    }
-    `,
-    webComponent: `
-    <div>
-      <pds-button onClick={() => {
-        const modal = document.querySelector('#control-modal');
-        if (modal) modal.open = true;
-      }}>Open Modal</pds-button>
-
-      <pds-modal id="control-modal" component-id="control-modal">
-        <pds-modal-header>
-          <pds-box direction="column" fit padding="md">
-            <pds-box align-items="center" fit justify-content="space-between">
-              <pds-text tag="h2" size="h3">Controlled Modal</pds-text>
-              <pds-button
-                class="pds-modal__close"
-                variant="unstyled"
-                icon-only="true"
-                onclick="document.querySelector('#control-modal').open = false"
-                aria-label="Close modal"
-              >
-                <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
-              </pds-button>
-            </pds-box>
-          </pds-box>
-        </pds-modal-header>
-        <pds-modal-content>
-          <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
-            <p>This modal is controlled by external buttons.</p>
-          </pds-box>
-        </pds-modal-content>
-        <pds-modal-footer>
-          <pds-box fit justify-content="end" padding="md" gap="sm">
-            <pds-button onClick={() => {
-              const modal = document.querySelector('#control-modal');
-              if (modal) modal.open = false;
-            }}>Close</pds-button>
-          </pds-box>
-        </pds-modal-footer>
-      </pds-modal>
-    </div>
-    `
-  }}
->
-  <div>
-    <pds-button onClick={() => {
-      const modal = document.querySelector('#control-modal');
-      if (modal) modal.open = true;
-    }}>Open Modal</pds-button>
-
-    <pds-modal id="control-modal" component-id="control-modal">
-      <pds-modal-header>
-        <pds-box direction="column" fit padding="md">
-          <pds-box align-items="center" fit justify-content="space-between">
-            <pds-text tag="h2" size="h3">Controlled Modal</pds-text>
-            <pds-button
-              class="pds-modal__close"
-              variant="unstyled"
-              icon-only="true"
-              onclick="document.querySelector('#control-modal').open = false"
-              aria-label="Close modal"
-            >
-              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
-            </pds-button>
-          </pds-box>
-        </pds-box>
-      </pds-modal-header>
-      <pds-modal-content>
-        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
-          <p>This modal is controlled by external buttons.</p>
-        </pds-box>
-      </pds-modal-content>
-      <pds-modal-footer>
-        <pds-box fit justify-content="end" padding="md" gap="sm">
-          <pds-button onClick={() => {
-            const modal = document.querySelector('#control-modal');
-            if (modal) modal.open = false;
-          }}>Close</pds-button>
-        </pds-box>
-      </pds-modal-footer>
-    </pds-modal>
-  </div>
-</DocCanvas>
-
-### Using Events
-
-Modals emit events that you can listen to:
-
-```javascript
-// Listen for when the modal opens
-const modal = document.querySelector('#my-modal');
-modal.addEventListener('pds-modal-open', () => {
-  console.log('Modal opened');
-});
-
-// Listen for when the modal closes
-modal.addEventListener('pds-modal-close', () => {
-  console.log('Modal closed');
-});
-```
-
-### Auto-Close Behaviors
-
-Modals can be configured to close automatically in response to user actions:
-
-- Escape key - Always closes the modal (per accessibility guidelines)
-- `backdropDismiss` (default: `true`) - Allow closing when clicking outside the modal
-
-```html
-<pds-modal backdropDismiss={false}>
-  <!-- Modal content that can only be closed via explicit button clicks -->
-</pds-modal>
-```
-
-## Variants
+## Examples
+### Variants
 
 ### Default
 
@@ -1463,3 +1298,176 @@ Modals can be nested, with only the topmost modal responding to escape key and b
     </pds-modal>
   </div>
 </DocCanvas>
+## Technical Notes
+
+- The component renders a native `<dialog>` with `aria-modal="true"` and automatically sets `aria-labelledby` based on the slotted heading content (`${componentId}-heading`). Ensure your modal header contains a semantic heading (`<pds-text tag="h2">`) so assistive technologies announce it.
+- Focus trapping is managed internally. When `open` becomes `true`, the component stores the previously focused element, queries for focusable nodes inside the modal, and moves focus to the first match. When `hideModal()` is called (directly or indirectly), focus is restored to the element that opened the modal.
+- Nested modals respect z-index order: backdrop clicks and Escape close only the top-most modal. Use this when stacking wizard dialogs or confirm prompts.
+
+
+### Opening and Closing Modals
+
+There are several ways to control a modal's visibility:
+
+### Using Buttons
+
+Modals can be opened and closed programmatically using the `open` property:
+
+<DocCanvas client:only
+  mdxSource={{
+    react: `
+    function ModalControl() {
+      return (
+        <div>
+          <PdsButton onClick={() => {
+            const modal = document.querySelector('#control-modal');
+            if (modal) modal.open = true;
+          }}>Open Modal</PdsButton>
+
+          <PdsModal id="control-modal" componentId="control-modal">
+            <PdsModalHeader>
+              <PdsBox direction="column" fit padding="md">
+                <PdsBox alignItems="center" fit justifyContent="space-between">
+                  <PdsText tag="h2" size="h3">Controlled Modal</PdsText>
+                  <PdsButton
+                    class="pds-modal__close"
+                    variant="unstyled"
+                    iconOnly
+                    onclick="document.querySelector('#control-modal').open = false"
+                    aria-label="Close modal"
+                  >
+                    <PdsIcon slot="start" name="remove" aria-hidden="true"></PdsIcon>
+                  </PdsButton>
+                </PdsBox>
+              </PdsBox>
+            </PdsModalHeader>
+            <PdsModalContent>
+              <PdsBox fit direction="column" paddingInlineStart="md" paddingInlineEnd="md">
+                <p>This modal is controlled by external buttons.</p>
+              </PdsBox>
+            </PdsModalContent>
+            <PdsModalFooter>
+              <PdsBox fit justifyContent="end" padding="md" gap="sm">
+                <PdsButton onClick={() => {
+                  const modal = document.querySelector('#control-modal');
+                  if (modal) modal.open = false;
+                }}>Close</PdsButton>
+              </PdsBox>
+            </PdsModalFooter>
+          </PdsModal>
+        </div>
+      );
+    }
+    `,
+    webComponent: `
+    <div>
+      <pds-button onClick={() => {
+        const modal = document.querySelector('#control-modal');
+        if (modal) modal.open = true;
+      }}>Open Modal</pds-button>
+
+      <pds-modal id="control-modal" component-id="control-modal">
+        <pds-modal-header>
+          <pds-box direction="column" fit padding="md">
+            <pds-box align-items="center" fit justify-content="space-between">
+              <pds-text tag="h2" size="h3">Controlled Modal</pds-text>
+              <pds-button
+                class="pds-modal__close"
+                variant="unstyled"
+                icon-only="true"
+                onclick="document.querySelector('#control-modal').open = false"
+                aria-label="Close modal"
+              >
+                <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+              </pds-button>
+            </pds-box>
+          </pds-box>
+        </pds-modal-header>
+        <pds-modal-content>
+          <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+            <p>This modal is controlled by external buttons.</p>
+          </pds-box>
+        </pds-modal-content>
+        <pds-modal-footer>
+          <pds-box fit justify-content="end" padding="md" gap="sm">
+            <pds-button onClick={() => {
+              const modal = document.querySelector('#control-modal');
+              if (modal) modal.open = false;
+            }}>Close</pds-button>
+          </pds-box>
+        </pds-modal-footer>
+      </pds-modal>
+    </div>
+    `
+  }}
+>
+  <div>
+    <pds-button onClick={() => {
+      const modal = document.querySelector('#control-modal');
+      if (modal) modal.open = true;
+    }}>Open Modal</pds-button>
+
+    <pds-modal id="control-modal" component-id="control-modal">
+      <pds-modal-header>
+        <pds-box direction="column" fit padding="md">
+          <pds-box align-items="center" fit justify-content="space-between">
+            <pds-text tag="h2" size="h3">Controlled Modal</pds-text>
+            <pds-button
+              class="pds-modal__close"
+              variant="unstyled"
+              icon-only="true"
+              onclick="document.querySelector('#control-modal').open = false"
+              aria-label="Close modal"
+            >
+              <pds-icon slot="start" name="remove" aria-hidden="true"></pds-icon>
+            </pds-button>
+          </pds-box>
+        </pds-box>
+      </pds-modal-header>
+      <pds-modal-content>
+        <pds-box fit direction="column" padding-inline-start="md" padding-inline-end="md">
+          <p>This modal is controlled by external buttons.</p>
+        </pds-box>
+      </pds-modal-content>
+      <pds-modal-footer>
+        <pds-box fit justify-content="end" padding="md" gap="sm">
+          <pds-button onClick={() => {
+            const modal = document.querySelector('#control-modal');
+            if (modal) modal.open = false;
+          }}>Close</pds-button>
+        </pds-box>
+      </pds-modal-footer>
+    </pds-modal>
+  </div>
+</DocCanvas>
+
+### Using Events
+
+Modals emit events that you can listen to:
+
+```javascript
+// Listen for when the modal opens
+const modal = document.querySelector('#my-modal');
+modal.addEventListener('pds-modal-open', () => {
+  console.log('Modal opened');
+});
+
+// Listen for when the modal closes
+modal.addEventListener('pds-modal-close', () => {
+  console.log('Modal closed');
+});
+```
+
+### Auto-Close Behaviors
+
+Modals can be configured to close automatically in response to user actions:
+
+- Escape key - Always closes the modal (per accessibility guidelines)
+- `backdropDismiss` (default: `true`) - Allow closing when clicking outside the modal
+
+```html
+<pds-modal backdropDismiss={false}>
+  <!-- Modal content that can only be closed via explicit button clicks -->
+</pds-modal>
+```
+

--- a/libs/core/src/components/pds-popover/docs/pds-popover.mdx
+++ b/libs/core/src/components/pds-popover/docs/pds-popover.mdx
@@ -18,11 +18,15 @@ Popovers display contextual information when users click or initiates a keyboard
 - Avoid using for simple text-only tooltips
 - Don't nest popovers within other popovers
 
+## Usage Notes
+
+Keep popover content concise and ensure every trigger element is focusable so keyboard users can open and dismiss the overlay reliably.
+
 ## Properties
 
 <DocArgsTable componentName="pds-popover" docSource={components} />
 
-## Usage
+## Examples
 
 ### Trigger Slot
 
@@ -239,3 +243,9 @@ The `max-width` prop allows adjusting the maximum width of the popover content. 
     <p>This is a wider popover with more content space available.</p>
   </pds-popover>
 </DocCanvas>
+
+## Technical Notes
+
+- The trigger slot automatically receives `aria-expanded` and `aria-controls` attributes when the component is hydrated. Use focusable elements (buttons, chips, avatar with `dropdown="true"`, etc.) so that keyboard users can open the popover with Enter or Space.
+- Content is teleported to `document.body` via a portal to ensure it is correctly layered above other UI. Because the markup is outside the component's DOM tree, associate it with the trigger via `aria-labelledby` or `aria-describedby` when the content needs more context (for example, referencing the trigger text).
+- Auto popovers (`popover-type="auto"`) listen for outside clicks and Escape to close the overlay. Manual popovers must expose their own dismissal affordance—include a close button in the content and wire it to `popover.hide()`.

--- a/libs/core/src/components/pds-progress/docs/pds-progress.mdx
+++ b/libs/core/src/components/pds-progress/docs/pds-progress.mdx
@@ -18,11 +18,16 @@ The Progress component shows the progress of a task or process. It's great for h
 - Avoid using for actions that complete quickly, like opening a modal or changing a setting.
 - Not suitable for tasks that don't follow a linear path, like live updates.
 
-## Accessibility
+
+### Accessibility
 
 - Make sure to provide a clear and descriptive label for the progress indicator, like "Uploading file" or "Creating account".
 
+## Properties
+
 <DocArgsTable componentName='pds-progress' docSource={components} />
+
+## Examples
 
 ### Default
 _`percent` value used in source is only for demonstration purposes, otherwise progress bar would not appear_

--- a/libs/core/src/components/pds-property/docs/pds-property.mdx
+++ b/libs/core/src/components/pds-property/docs/pds-property.mdx
@@ -31,6 +31,8 @@ The Property component is designed with accessibility in mind:
 
 <DocArgsTable componentName="pds-property" docSource={components} />
 
+## Examples
+
 ### Default
 
 Basic property with default star icon when no icon is specified.

--- a/libs/core/src/components/pds-radio/docs/pds-radio.mdx
+++ b/libs/core/src/components/pds-radio/docs/pds-radio.mdx
@@ -27,6 +27,8 @@ Radio components allow users to select one option from a group of two or more ch
 
 <DocArgsTable componentName='pds-radio' docSource={components} />
 
+## Examples
+
 ### Default
 
 <DocCanvas client:only mdxSource={{
@@ -286,6 +288,12 @@ Image-based radios work seamlessly in groups with the same bordered card layout,
     </pds-radio>
   </pds-box>
 </DocCanvas>
+
+## Form Integration
+
+- Assign the same `name` to each radio in a group so only one option submits with the form.
+- Set a unique `value` on every radio to identify the selected option inside `FormData`.
+- Apply `required` (typically on the first radio in the group) plus `invalid`/`errorMessage` to surface validation feedback when no choice is selected.
 
 ## Additional Resources
 

--- a/libs/core/src/components/pds-select/docs/pds-select.mdx
+++ b/libs/core/src/components/pds-select/docs/pds-select.mdx
@@ -28,15 +28,11 @@ The select component provides a dropdown list of options, allowing users to make
 
 When analyzing designs or screenshots, text that appears above a select dropdown is the select's label, not a separate `pds-text` component. The `label` prop creates text that appears above the select field and integrates properly with the component's styling and accessibility features.
 
-### Form Integration Features
-
-- Full ARIA support with proper labeling and descriptions
-- Supports single and multiple option selection
-- Uses slot-based option content for flexibility
-
 ## Properties
 
 <DocArgsTable componentName="pds-select" docSource={components} />
+
+## Examples
 
 ### Default
 
@@ -418,6 +414,15 @@ The action slot allows you to add helpful content next to the select label, such
     <option value="au">Australia</option>
   </pds-select>
 </DocCanvas>
+
+## Form Integration
+
+- Provide a `name` so the chosen option is included in `FormData` (disabled selects are skipped automatically).
+- Manage selection via the `value` prop plus `onPdsSelectChange` for controlled React usage; rely on native selection/default values for uncontrolled forms.
+- Combine `required`, `errorMessage`, and `invalid` to mirror native validation flows, especially when the first option is a disabled placeholder.
+- Labels are wired automatically through the native `<label>` element, and helper/error props render standardized messaging so you don’t need duplicate markup.
+- Use slot-based option content for flexible layouts (icons, descriptions) without breaking form submission.
+- Supports both single and (where applicable) multiple-option scenarios; ensure each option has a unique `value`.
 
 ## Additional Resources
 

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -22,11 +22,13 @@ Sortable is for creating containers of items that can be sorted via drag and dro
 
 <DocArgsTable componentName='pds-sortable' docSource={components} />
 
-## Sortable Items
+### Sortable Items
 
 The `pds-sortable-item` sub-component are the items that can be sorted within a sortable container `pds-sortable`.
 
 <DocArgsTable componentName='pds-sortable-item' docSource={components} />
+
+## Examples
 
 ### Default
 

--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -22,6 +22,7 @@ A styled checkbox component that functions as a toggle.
 
 <DocArgsTable componentName="pds-switch" docSource={components} />
 
+## Examples
 
 ### Default
 
@@ -95,3 +96,9 @@ Displays an error message with additional instructions, separate from the helper
     required="true"
   ></pds-switch>
 </DocCanvas>
+## Form Integration
+
+- Provide a `name` so the switch contributes a value to `FormData` when checked; unchecked switches are omitted like native checkboxes.
+- Use `value` (default `"on"`) to differentiate multiple switches that share the same `name`.
+- Combine `checked`, `onPdsSwitchChange`, and state management for controlled React usage, and pair `required`/`invalid` to enforce acknowledgements such as terms of service.
+

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -42,7 +42,8 @@ The table body cell. Equivalent to the `<td>` element.
 
 <DocArgsTable componentName="pds-table-cell" docSource={components} />
 
-## Default
+## Examples
+### Default
 
 The default table, properly using all subcomponents.
 
@@ -123,7 +124,8 @@ The default table, properly using all subcomponents.
   </pds-table>
 </DocCanvas>
 
-## Compact
+
+### Compact
 
 A compact table is a table with a reduced row spacing. This is useful for tables with a large number of rows.
 
@@ -204,7 +206,8 @@ A compact table is a table with a reduced row spacing. This is useful for tables
   </pds-table>
 </DocCanvas>
 
-## Selectable
+
+### Selectable
 
 When the `selectable` prop is set to `true`, the table will render a checkbox in the first column of each row.
 
@@ -285,7 +288,8 @@ When the `selectable` prop is set to `true`, the table will render a checkbox in
   </pds-table>
 </DocCanvas>
 
-## Responsive
+
+### Responsive
 
 When the `responsive` prop is set to `true`, the table will render a horizontal scrollbar when the table width exceeds the width of the container.
 
@@ -474,7 +478,8 @@ When the `responsive` prop is set to `true`, the table will render a horizontal 
 </DocCanvas>
 
 
-## Fixed Column
+
+### Fixed Column
 
 When the `fixed-column` prop is set to `true`, the first column of the table will be fixed in place while the rest of the table scrolls horizontally.
 
@@ -852,7 +857,8 @@ webComponent: `<pds-table component-id="fixedcb" responsive fixed-column selecta
   </pds-table>
 </DocCanvas>
 
-## Cell Truncation
+
+### Cell Truncation
 
 When the `truncate` prop is set to `true` on a `pds-table-cell` element, the cell will visually truncate the text and add an ellipsis when the text exceeds the max-width (100px) of the cell.
 
@@ -932,7 +938,8 @@ When the `truncate` prop is set to `true` on a `pds-table-cell` element, the cel
   </pds-table>
 </DocCanvas>
 
-## Cell Alignment
+
+### Cell Alignment
 
 Text alignment can be controlled using the `cell-align` prop on both `pds-table-head-cell` and `pds-table-cell` elements. The available alignment options are `start`, `center`, `end`, and `justify`.
 
@@ -1024,11 +1031,20 @@ Text alignment can be controlled using the `cell-align` prop on both `pds-table-
   </pds-table>
 </DocCanvas>
 
-## Sorting
+
+### Sorting
 
 Basic sorting can be enabled by adding the `sortable` attribute to a `pds-table-head-cell` element. The table will automatically sort in ascending or descending order when the cell is clicked.
 
 In cases where the default sorting functionality is not suitable, it is possible to use a custom sorting function by listening to the `pdsTableSort` event.
+
+### Event payload
+
+`pdsTableSort` dispatches from the clicked `<pds-table-head-cell>` and bubbles up to `<pds-table>`.
+
+### Preventing built-in sorting
+
+If you need full control over the rendered rows (for example, remote sorting), prevent the table from mutating the DOM by intercepting the event during the capture phase.
 
 <DocCanvas mdxSource={{
   react: `<PdsTable componentId="sortable" selectable={true}>
@@ -1211,6 +1227,6 @@ In cases where the default sorting functionality is not suitable, it is possible
 </pds-table>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [MDN: Table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)

--- a/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
+++ b/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
@@ -19,7 +19,8 @@ Though similar, tabs and accordions both offer different user experiences to kee
 
 - If a longer label is desired. Consider using an accordion instead.
 
-## Accessibility
+
+### Accessibility
 
 For best practices in accessibility, be sure to provide a `tablist-label` and a unique `component-id`. The `tabslist-label` will provide context to screen readers about what kind of tabslist information is being presented.
 
@@ -35,7 +36,8 @@ For best practices in accessibility, be sure to provide a `tablist-label` and a 
 
 <DocArgsTable componentName='pds-tabpanel' docSource={components} />
 
-## Variant
+## Examples
+### Variant
 
 ### Primary
 

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -33,6 +33,8 @@ Use this component for general text content, headings, paragraphs, and other sem
 
 <DocArgsTable componentName="pds-text" docSource={components} />
 
+## Examples
+
 ### Default
 
 Each semantic tag provided comes with default styling. If no `tag` prop is provided, the default tag will be set to `p`.
@@ -199,7 +201,7 @@ To truncate text, add the `truncate` attribute to the component. Text truncation
   <pds-text style={{maxWidth: '40ch'}} tag="p" truncate>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</pds-text>
 </DocCanvas>
 
-## References
+## Additional Resources
 
 [MDN: Semantics](https://developer.mozilla.org/en-US/docs/Glossary/Semantics)
 

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -29,16 +29,11 @@ For accessibility, it is strongly encouraged to follow these best practices:
 
 When analyzing designs or screenshots, text that appears above a textarea is the textarea's label, not a separate `pds-text` component. The `label` prop creates text that appears above the textarea field and integrates properly with the component's styling and accessibility features.
 
-### Form Integration Features
-
-- Supports error messages and invalid states
-- Full ARIA support with proper labeling and descriptions
-- Debounced input events and change detection
-- Users can resize the textarea vertically
-
 ## Properties
 
 <DocArgsTable componentName="pds-textarea" docSource={components} />
+
+## Examples
 
 ### Default
 
@@ -227,6 +222,12 @@ The action slot allows you to add helpful content next to the textarea label, su
   </pds-textarea>
 </DocCanvas>
 
-## References
+## Form Integration
+
+- Provide a `name` so the textarea's value is included in `FormData` and server submissions.
+- Use the `value` prop with `onPdsTextareaChange` for controlled frameworks; omit `value` for native, uncontrolled forms.
+- Combine `required`, `maxLength`, and `errorMessage` to show limits and inline guidance before submit.
+
+## Additional Resources
 
 [MDN: Autocomplete Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

--- a/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
+++ b/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
@@ -18,6 +18,8 @@ Tooltips display helpful popup text when users hover over or keyboard focus on a
 
 <DocArgsTable componentName="pds-tooltip" docSource={components} />
 
+## Examples
+
 ### Trigger
 Whether your trigger is text or an HTML element, it will be placed in the default slot between the opening and closing tags.
 
@@ -264,6 +266,51 @@ The `max-width` prop lets you adjust the maximum width of the tooltip content. T
 }}>
   <pds-tooltip content="This is long tooltip content to demonstrate how the max-width can be used to expand or narrow the width of the tooltip content to fit one's use case and content needs. This example uses 520px to create a bit more width for this amount of content." max-width="520px" placement="right">text</pds-tooltip>
 </DocCanvas>
+
+## Technical Notes
+
+- The trigger element receives `aria-describedby` referencing an ID that the component creates. Provide meaningful button/link labels so the tooltip content is read *after* the control name. When combining multiple tooltips on the same control, set `aria-describedby` manually to avoid duplication.
+- Tooltips do not announce themselves automatically because they use `aria-live="off"`. Reserve tooltips for purely supplemental information and display critical validation or blocking instructions inline.
+- Use the `opened` property when the tooltip should persist for longer than a hover/focus interaction (for example, guided tours). Because `opened` reflects as an attribute, you can also toggle it declaratively via frameworks or CSS selectors.
+- Call the public methods `showTooltip()` and `hideTooltip()` for advanced interactions (focus trapping, commanded display, or analytics). These methods return a promise that resolves once the visibility state changes.
+- When `html-content="true"`, avoid placing focusable elements inside the `content` slot. Tooltips are not intended for interactive elements. If you require buttons or links, switch to `<pds-popover>`, which manages focus and dismissal affordances.
+
+```tsx
+// React example showing imperative control
+const FieldWithTooltip = () => {
+  const tooltipRef = useRef<HTMLPdsTooltipElement>(null);
+
+  return (
+    <PdsTooltip
+      ref={tooltipRef}
+      content="Passwords must be at least 16 characters."
+      placement="right"
+    >
+      <PdsButton
+        variant="secondary"
+        onFocus={() => tooltipRef.current?.showTooltip()}
+        onBlur={() => tooltipRef.current?.hideTooltip()}
+      >
+        Password help
+      </PdsButton>
+    </PdsTooltip>
+  );
+};
+```
+
+```html
+<!-- Vanilla JS -->
+<pds-tooltip id="status-tooltip" opened="false" content="Synced 2 minutes ago">
+  <pds-icon-button icon="info" aria-label="Sync status"></pds-icon-button>
+</pds-tooltip>
+
+<script type="module">
+  const tooltip = document.getElementById('status-tooltip');
+  const icon = tooltip.querySelector('pds-icon-button');
+  icon.addEventListener('mouseenter', () => tooltip.showTooltip());
+  icon.addEventListener('mouseleave', () => tooltip.hideTooltip());
+</script>
+```
 
 ## Additional Resources
 

--- a/libs/core/src/stories/guides/events.docs.mdx
+++ b/libs/core/src/stories/guides/events.docs.mdx
@@ -18,6 +18,12 @@ Due to that, our components dispatch custom events that are named like the nativ
 like `pds-checkbox`, for example, dispatch an `pdsCheckboxChange` event. Which custom events are available can be found in the "Events" section of each component's
 properties table.
 
+## Event Patterns
+
+- **Composition**: All Pine custom events are composed and bubble so you can listen on ancestor elements or `document`.
+- **Detail payload**: Events include a `detail` object containing the component's value/state. Check the component docs for the exact payload.
+- **Preventing defaults**: Certain custom events support interruption using `event.preventDefault()` or `stopImmediatePropagation()` to implement custom behaviors.
+
 ## Examples
 
 These examples show you how to use the custom "pds"-prefixed events with Vanilla JS and React.

--- a/libs/core/src/stories/guides/forms.docs.mdx
+++ b/libs/core/src/stories/guides/forms.docs.mdx
@@ -33,6 +33,12 @@ The web component example utilizes vanilla JavaScript to access values directly 
 
 > **💡 Open your browser's developer console before submitting the form to see detailed debugging output!**
 
+## Validation Patterns
+
+- **Inline validation**: Most Pine inputs support the `invalid` attribute and an `error` message prop. Toggle these in response to the component's event and display contextual feedback beneath the field.
+- **Summary validation**: Combine multiple messages into a `<pds-alert>` after form submission fails. Remember to move focus to the first invalid control.
+- **Async validation**: Use the `loading` state (e.g., `pds-button` with a loader) while waiting for server-side responses and apply `aria-busy="true"` to the container so assistive technologies know updates are pending.
+
 <DocCanvas client:only
   mdxSource={{
     react: `


### PR DESCRIPTION
# Description

Standardized Pine component documentation structure to improve developer experience and consistency across all components.

This PR implements a unified documentation structure with consistent section ordering, adds missing content sections, and ensures all technical details are properly documented.

**Key changes:**
- Enforced consistent section ordering: Guidelines → Usage Notes → Properties → Examples → Events → Form Integration → Technical Notes → Additional Resources
- Added Form Integration sections to all form-associated components explaining `name`/`value` submission, FormData behavior, and validation patterns
- Added Technical Notes sections documenting accessibility implementation details, programmatic APIs, and component behavior
- Added missing Examples headings to group usage demonstrations consistently
- Enhanced forms and events guides with additional patterns and examples

Fixes [DSS-15](https://linear.app/kajabi/issue/DSS-15/standardize-pine-component-doc-sections)

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Verified all MDX files render correctly in Storybook
- Confirmed section ordering adheres to approved structure across all components
- Validated form integration documentation against component source code
- Reviewed technical notes for accuracy

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

[DSS-15]: https://kajabi.atlassian.net/browse/DSS-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ