### PR TITLE
fix(pds-divider, pds-link, pds-progress): update code connect properties and examples

### DIFF
--- a/libs/core/src/components/pds-divider/pds-divider.figma.ts
+++ b/libs/core/src/components/pds-divider/pds-divider.figma.ts
@@ -2,10 +2,14 @@ import figma, { html } from '@figma/code-connect/html';
 
 figma.connect('<FIGMA_DIVIDER>', {
   props: {
-    offset: figma.enum('Bleed', {
-      "16px bleed": "sm",
-      "24px bleed": "md",
+    offset: figma.enum('Offset', {
+      "xxs - 4px": "xxs",
+      "xs - 8px bleed": "xs",
+      "sm - 16px bleed": "sm",
+      "md - 24px bleed": "md",
+      "lg - 32px bleed": "lg",
+      "xl - 48px": "xl",
     }),
   },
-  example: (props) => html`<pds-divider bleed=${props.offset}></pds-divider>`,
+  example: (props) => html`<pds-divider offset=${props.offset}></pds-divider>`,
 });

--- a/libs/core/src/components/pds-link/pds-link.figma.ts
+++ b/libs/core/src/components/pds-link/pds-link.figma.ts
@@ -22,6 +22,7 @@ figma.connect('<FIGMA_LINK>', {
   },
   example: (props) => html`\
   <pds-link
+    href="#"
     color=${props.color}
     external=${props.external}
     font-size=${props.fontSize}

--- a/libs/core/src/components/pds-link/pds-link.figma.ts
+++ b/libs/core/src/components/pds-link/pds-link.figma.ts
@@ -3,27 +3,30 @@ import figma, { html } from '@figma/code-connect/html';
 figma.connect('<FIGMA_LINK>', {
   props: {
     color: figma.enum('Variant', {
-      'destructive': 'destructive',
+      'destructive': 'danger',
       'accent': 'accent',
+      'inverted': 'secondary',
     }),
     external: figma.enum('Variant', {
       'external': true,
     }),
     fontSize: figma.enum('Size', {
       'md': 'md',
-      'lg': 'lg',
+      'sm': 'sm',
     }),
     label: figma.string('Label'),
     variant: figma.enum('Variant', {
       'plain': 'plain',
+      'inline': 'inline',
     }),
   },
-  example: (props) => html`
+  example: (props) => html`\
   <pds-link
     color=${props.color}
     external=${props.external}
     font-size=${props.fontSize}
     variant=${props.variant}
-    >${props.label}
+  >
+    ${props.label}
   </pds-link>`,
 });

--- a/libs/core/src/components/pds-link/pds-link.figma.ts
+++ b/libs/core/src/components/pds-link/pds-link.figma.ts
@@ -11,7 +11,7 @@ figma.connect('<FIGMA_LINK>', {
       'external': true,
     }),
     fontSize: figma.enum('Size', {
-      'md': 'md',
+      'md': undefined,
       'sm': 'sm',
     }),
     label: figma.string('Label'),

--- a/libs/core/src/components/pds-progress/pds-progress.figma.ts
+++ b/libs/core/src/components/pds-progress/pds-progress.figma.ts
@@ -1,27 +1,66 @@
 import figma, { html } from '@figma/code-connect/html';
 
 figma.connect('<FIGMA_PROGRESS_BAR>', {
-    props: {
-      percent: figma.string("Progress"),
-      showPercent: figma.enum("Label", {
-        "false": true,
-      }),
-    },
-    example: (props) => html`\
-      <pds-progress
-        percent=${props.percent}
-        show-percent=${props.showPercent}
-      ></pds-progress>
-    `,
-  });
+  props: {
+    percent: figma.string("Progress"),
+    showPercent: figma.enum("Label", {
+      "Right": true,
+    }),
+  },
+  example: (props) => html`\
+<pds-progress
+  percent=${props.percent}
+  show-percent=${props.showPercent}
+></pds-progress>
+  `,
+  variant: { "Label": "False" },
+});
+
+figma.connect('<FIGMA_PROGRESS_BAR>', {
+  props: {
+    percent: figma.string("Progress"),
+    showPercent: figma.enum("Label", {
+      "Right": true,
+    }),
+  },
+  example: (props) => html`\
+<pds-progress
+  percent=${props.percent}
+  show-percent=${props.showPercent}
+></pds-progress>
+  `,
+  variant: { "Label": "Right" },
+});
+
+figma.connect('<FIGMA_PROGRESS_BAR>', {
+  props: {
+    percent: figma.string("Progress"),
+  },
+  example: (props) => html`\
+<pds-tooltip content=${props.percent} has-arrow="false" placement="top" style="width: 100%">
+  <pds-progress percent=${props.percent}></pds-progress>
+</pds-tooltip>
+  `,
+  variant: { "Label": "Top floating" },
+});
+
+figma.connect('<FIGMA_PROGRESS_BAR>', {
+  props: {
+    percent: figma.string("Progress"),
+  },
+  example: (props) => html`\
+<pds-tooltip content=${props.percent} has-arrow="false" placement="bottom" style="width: 100%">
+  <pds-progress percent=${props.percent}></pds-progress>
+</pds-tooltip>
+  `,
+  variant: { "Label": "Bottom floating" },
+});
 
 figma.connect('<FIGMA_PROGRESS_CIRCLE>', {
   props: {
     percent: figma.string("Completion"),
   },
   example: (props) => html`\
-    <pds-progress
-      percent=${props.percent}
-    ></pds-progress>
+<pds-progress percent=${props.percent}></pds-progress>
   `,
 });


### PR DESCRIPTION
# Description

Updated Figma Code Connect files for `pds-link`, `pds-divider`, and `pds-progress` components to match recent Figma component updates by the design team.

> [!NOTE]  
> The updates are already published to [Figma](https://www.figma.com/design/CC1YmaGKHnsvB28yLY9mEH/%E2%9D%96-Pine-components?m=auto&node-id=4553-21314) and can be verified there.

**Changes:**
- **pds-link**: Added missing variants (`inline`, `inverted`), fixed color mapping (`destructive` → `danger`), and added `sm` size option
- **pds-divider**: Fixed property name from `Bleed` → `Offset` (capitalized) and added all new size options (`xxs`, `xs`, `sm`, `md`, `lg`, `xl`)
- **pds-progress**: Fixed property name capitalization (`Progress`, `Label`, `Completion`) and properly mapped "Top floating" and "Bottom floating" variants to use `pds-tooltip` composition pattern

These updates resolve validation errors that prevented publishing Code Connect mappings to Figma.

Fixes: 

- DSS-16
- DSS-17
- DSS-18

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: Validated and published to Figma Code Connect successfully

**Test Configuration**:

- Pine versions: Current
- OS: macOS
- Browsers: N/A (Figma Code Connect validation)
- Screen readers: N/A
- Misc: Tested via Figma Code Connect CLI publish command

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR