### PR TITLE
docs(pds-icon): add technical notes on icon usage

### DIFF
--- a/libs/core/src/components/pds-icon/docs/pds-icon.mdx
+++ b/libs/core/src/components/pds-icon/docs/pds-icon.mdx
@@ -176,3 +176,10 @@ import { danger } from '@pine-ds/icons/icons';
 - Import only the icons you need
 - Avoid importing icons in shared utility files unless necessary
 - Consider lazy loading for icons used in less common user flows
+
+## Technical Notes
+
+- React uses the `icon` property while web components use `name`. This difference is intentional and optimized for each framework's strengths.
+- In React, icons are imported as objects from `@pine-ds/icons/icons` and passed to the `icon` property. This provides type safety, editor autocomplete, and tree-shaking—only imported icons are bundled.
+- In web components, the `name` property accepts string values for simpler HTML-like syntax, following standard web component attribute patterns.
+- Setting the `name` property in React has no effect and will trigger a console warning directing developers to use the `icon` property instead.


### PR DESCRIPTION
# Description

This PR adds a "Technical Notes" section to the `pds-icon` documentation to clarify the intentional differences in icon usage between React and web components.

**Motivation**: Developers may be confused about why React components use the `icon` property while web components use the `name` attribute. This documentation update explains the reasoning behind this design decision and helps developers understand the framework-specific optimizations.

**Changes**:
- Added a new "Technical Notes" section to `pds-icon.mdx`
- Documented that React uses `icon` property with imported icon objects for type safety, autocomplete, and tree-shaking
- Documented that web components use `name` attribute with string values for HTML-like syntax
- Clarified that using `name` in React triggers a warning and has no effect

No new dependencies are required for this change.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (documentation-only change)

# How Has This Been Tested?

- [x] tested manually - Reviewed documentation rendering in Storybook
- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] other:

**Test Configuration**:

- Pine versions: Current development version
- OS: macOS
- Browsers: N/A (documentation change)
- Screen readers: N/A
- Misc: Verified MDX syntax and formatting

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
