### PR TITLE
fix(pds-alert): update padding of alert to 20px

### DIFF
--- a/libs/core/src/components/pds-alert/pds-alert.scss
+++ b/libs/core/src/components/pds-alert/pds-alert.scss
@@ -14,6 +14,8 @@
   --pds-alert-color-text: var(--pine-alert-color-text);
   --pds-alert-color-dismiss: var(--pine-alert-color-dismiss);
   --pds-alert-background-dismiss-hover: var(--pine-alert-color-dismiss-hover);
+
+  padding: var(--pine-dimension-250);
 }
 
 .pds-alert__container--danger {

--- a/libs/core/src/components/pds-alert/pds-alert.tsx
+++ b/libs/core/src/components/pds-alert/pds-alert.tsx
@@ -114,7 +114,6 @@ export class PdsAlert {
           border-radius="md"
           border
           display="block"
-          padding="md"
         >
           <pds-box gap="sm" display="flex">
             <pds-icon

--- a/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
+++ b/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
@@ -10,7 +10,7 @@ describe('pds-alert', () => {
     expect(page.root).toEqualHtml(`
       <pds-alert class="pds-alert" variant="default">
         <mock:shadow-root>
-          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
+          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
@@ -35,7 +35,7 @@ describe('pds-alert', () => {
     expect(page.root).toEqualHtml(`
       <pds-alert class="pds-alert" heading="Test Alert Heading" variant="default">
         <mock:shadow-root>
-          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
+          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
@@ -61,7 +61,7 @@ describe('pds-alert', () => {
     expect(page.root).toEqualHtml(`
       <pds-alert class="pds-alert" variant="default">
         <mock:shadow-root>
-          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
+          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
@@ -87,7 +87,7 @@ describe('pds-alert', () => {
     expect(page.root).toEqualHtml(`
       <pds-alert class="pds-alert" heading="This heading should not show" small="true" variant="default">
         <mock:shadow-root>
-          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
+          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon pds-alert__icon--small" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
@@ -113,7 +113,7 @@ describe('pds-alert', () => {
     expect(page.root).toEqualHtml(`
       <pds-alert class="pds-alert" dismissible="true" variant="default">
         <mock:shadow-root>
-          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block" padding="md">
+          <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
             <pds-box display="flex" gap="sm">
               <pds-icon class="pds-alert__icon" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">


### PR DESCRIPTION
# Description

This PR updates the `pds-alert` component to use a direct CSS token for padding instead of relying on the `pds-box` padding prop. The padding is now set to `--pine-dimension-250` (20px) directly in the component's stylesheet, ensuring consistent padding across all alert variants.

**Changes:**
- Removed `padding="md"` prop from the `pds-box` wrapper in `pds-alert.tsx`
- Added `padding: var(--pine-dimension-250)` directly to `.pds-alert__container` in `pds-alert.scss`

This change improves maintainability by using design tokens directly and removes the dependency on the `pds-box` component's padding prop, making the styling more explicit and easier to maintain.

No new dependencies or updates are required for this change.

Fixes DSS-28

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.

Provide instructions so that we can reproduce.

Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration:**

- Pine versions: Latest
- OS: macOS
- Browsers: Chrome, Safari, Firefox
- Screen readers: N/A
- Misc: Verified alert padding visually matches design specifications (20px)

**Manual Testing:**
- Verified all alert variants (danger, info, success, warning) display with correct 20px padding
- Confirmed alert content, icons, and dismiss buttons are properly positioned
- Tested with and without dismiss functionality
- Verified responsive behavior remains unchanged

# Checklist:

If not applicable, leave options unchecked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
