### PR TITLE
fix(storybook): update Vite watch config for HMR live reload

### DIFF
--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -82,16 +82,33 @@ const config = {
     config.optimizeDeps.exclude = config.optimizeDeps.exclude || [];
     config.optimizeDeps.exclude.push('@mdx-js/react');
 
-    // Force Vite to not watch the loader/dist directories during HMR
-    // This prevents Storybook from breaking when tests rebuild these files
+    // Configure Vite watch settings for HMR
+    // The key issue: Storybook loads from dist/, so we need Vite to watch dist/ files
+    // But we also need to watch source files so changes trigger reloads
     config.server.watch = config.server.watch || {};
     config.server.watch.ignored = config.server.watch.ignored || [];
+
+    // Only ignore specific build artifacts that shouldn't trigger reloads
+    // Don't ignore dist/ entirely - we need to watch dist/docs.json and dist/collection for changes
     config.server.watch.ignored.push(
-      '**/loader/**',
-      '**/dist/**',
-      '**/www/**',
-      '**/components/**'
+      '**/loader/**',  // Ignore loader to prevent test rebuild issues
+      '**/www/**',     // Ignore www build output
+      '**/node_modules/**',
+      '**/coverage/**',
+      // Ignore specific dist subdirectories that aren't used by Storybook
+      '**/dist/cjs/**',
+      '**/dist/esm-es5/**',
+      '**/dist/pine-core/**',
+      '**/dist/types/**',
+      // Note: We DO want to watch dist/docs.json and dist/collection/** for component changes
     );
+
+    // Enable HMR for better live reload experience
+    config.server.hmr = config.server.hmr || {};
+    config.server.hmr.overlay = true;
+
+    // Configure Vite to use native file system events (faster than polling)
+    config.server.watch.usePolling = false;
 
     // Dedupe lit to avoid "Multiple versions of Lit loaded" warning
     config.resolve.dedupe = config.resolve.dedupe || [];


### PR DESCRIPTION
# Description

After upgrading Storybook from version 8 to 10, the live reload (HMR) feature stopped working correctly for component code changes. Style changes would reload, but changes to `.tsx` and `.ts` files required manually restarting the Storybook server.

The root cause was the Vite watch configuration in `.storybook/main.js`. The previous config ignored `**/components/**` and `**/dist/**` which prevented Vite from detecting changes in source files and built output.

**Changes:**
- Remove `**/components/**` from ignored to watch `src/components/**`
- Remove blanket `**/dist/**` ignore, only ignore unused subdirectories
- Keep watching `dist/docs.json` and `dist/collection/**` for Stencil rebuilds
- Enable HMR overlay for better developer feedback

This restores the expected live reload behavior when making component code changes.

Fixes DSS-31

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Steps to reproduce:**
1. Run `npm run start` to start both Stencil and Storybook
2. Navigate to any component story (e.g., Alert)
3. Make a code change to the component's `.tsx` file
4. Verify that Storybook reloads and reflects the change without manual restart

**Test Configuration**:

- Pine versions: 3.11.1
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR