### PR TITLE
docs(storybook): update changelog page with actual list from changelog.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ loader/
 www/
 
 storybook-static
+libs/core/.storybook/static/
 
 # IDEs and editors
 .idea/

--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 
 // Get directory paths
 const currentDir = dirname(fileURLToPath(import.meta.url));
-const changelogSource = join(currentDir, '../../../../CHANGELOG.md');
+const changelogSource = join(currentDir, '../../../CHANGELOG.md');
 const staticDir = join(currentDir, 'static');
 const changelogDest = join(staticDir, 'CHANGELOG.md');
 

--- a/libs/core/src/stories/_helpers/ChangelogLoader.tsx
+++ b/libs/core/src/stories/_helpers/ChangelogLoader.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { ChangelogRenderer } from './ChangelogRenderer';
+
+/**
+ * Component that loads and displays the changelog from the static directory
+ * Tries to fetch from /CHANGELOG.md (served from staticDirs) or falls back to GitHub
+ */
+export const ChangelogLoader: React.FC = () => {
+  const [content, setContent] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadChangelog = async () => {
+      try {
+        setLoading(true);
+        // Try to fetch from static directory (configured in Storybook main.js)
+        // The file should be accessible at /CHANGELOG.md when served from staticDirs
+        const response = await fetch('/CHANGELOG.md');
+        if (!response.ok) {
+          throw new Error(`Failed to load changelog: ${response.statusText}`);
+        }
+        const text = await response.text();
+        setContent(text);
+        setError(null);
+      } catch (err) {
+        // If loading fails, show error with link to GitHub
+        setError(err instanceof Error ? err.message : 'Failed to load changelog');
+        console.error('Error loading changelog:', err);
+        console.log('Changelog file should be accessible at /CHANGELOG.md from staticDirs');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadChangelog();
+  }, []);
+
+  if (loading) {
+    return <div>Loading changelog...</div>;
+  }
+
+  if (error !== null) {
+    return (
+      <div>
+        <p>Unable to load changelog from local file. {error}</p>
+        <p>
+          <a href="https://github.com/Kajabi/pine/releases" target="_blank" rel="noopener noreferrer">
+            View releases on GitHub
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  return <ChangelogRenderer changelogContent={content} />;
+};
+

--- a/libs/core/src/stories/_helpers/ChangelogRenderer.tsx
+++ b/libs/core/src/stories/_helpers/ChangelogRenderer.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import Markdown from 'markdown-to-jsx';
+
+interface ChangelogRendererProps {
+  changelogContent: string;
+}
+
+/**
+ * Component to render changelog markdown content using Pine design tokens
+ * Renders the provided markdown content as formatted HTML with Pine styling
+ */
+export const ChangelogRenderer: React.FC<ChangelogRendererProps> = ({ changelogContent }) => {
+  return (
+    <div style={{
+      maxWidth: '100%',
+      lineHeight: 'var(--pine-line-height-body)',
+      color: 'var(--pine-color-text)',
+    }}>
+      <Markdown
+        options={{
+          overrides: {
+            h2: {
+              component: 'h2',
+              props: {
+                style: {
+                  marginBlockStart: 'var(--pine-dimension-2xl)',
+                  marginBlockEnd: 'var(--pine-dimension-md)',
+                  paddingBlockEnd: 'var(--pine-dimension-xs)',
+                  borderBlockEnd: 'var(--pine-border)',
+                  fontSize: 'var(--pine-font-size-heading-2)',
+                  fontWeight: 'var(--pine-font-weight-semi-bold)',
+                  color: 'var(--pine-color-text)',
+                  lineHeight: 'var(--pine-line-height-heading)',
+                },
+              },
+            },
+            h3: {
+              component: 'h3',
+              props: {
+                style: {
+                  marginBlockStart: 'var(--pine-dimension-xl)',
+                  marginBlockEnd: 'var(--pine-dimension-sm)',
+                  fontSize: 'var(--pine-font-size-heading-3)',
+                  fontWeight: 'var(--pine-font-weight-semi-bold)',
+                  color: 'var(--pine-color-text)',
+                  lineHeight: 'var(--pine-line-height-heading)',
+                },
+              },
+            },
+            ul: {
+              component: 'ul',
+              props: {
+                style: {
+                  marginInlineStart: 'var(--pine-dimension-lg)',
+                  marginBlockEnd: 'var(--pine-dimension-md)',
+                  paddingInlineStart: 'var(--pine-dimension-sm)',
+                },
+              },
+            },
+            li: {
+              component: 'li',
+              props: {
+                style: {
+                  marginBlockEnd: 'var(--pine-dimension-xs)',
+                  fontSize: 'var(--pine-font-size-body-md)',
+                  lineHeight: 'var(--pine-line-height-body)',
+                  color: 'var(--pine-color-text)',
+                },
+              },
+            },
+            p: {
+              component: 'p',
+              props: {
+                style: {
+                  marginBlockEnd: 'var(--pine-dimension-md)',
+                  fontSize: 'var(--pine-font-size-body-md)',
+                  lineHeight: 'var(--pine-line-height-body)',
+                  color: 'var(--pine-color-text)',
+                },
+              },
+            },
+            a: {
+              component: 'a',
+              props: {
+                style: {
+                  color: 'var(--pine-color-text-accent)',
+                  textDecoration: 'none',
+                },
+              },
+            },
+            code: {
+              component: 'code',
+              props: {
+                style: {
+                  backgroundColor: 'var(--pine-color-background-container-hover)',
+                  paddingBlock: 'var(--pine-dimension-2xs)',
+                  paddingInline: 'var(--pine-dimension-xs)',
+                  borderRadius: 'var(--pine-dimension-2xs)',
+                  fontSize: 'var(--pine-font-size-body-sm)',
+                  fontFamily: 'monospace',
+                  color: 'var(--pine-color-text)',
+                },
+              },
+            },
+          },
+        }}
+      >
+        {changelogContent}
+      </Markdown>
+    </div>
+  );
+};
+

--- a/libs/core/src/stories/_helpers/ChangelogRenderer.tsx
+++ b/libs/core/src/stories/_helpers/ChangelogRenderer.tsx
@@ -83,8 +83,9 @@ export const ChangelogRenderer: React.FC<ChangelogRendererProps> = ({ changelogC
               component: 'a',
               props: {
                 style: {
-                  color: 'var(--pine-color-text-accent)',
-                  textDecoration: 'none',
+                  color: 'var(--pine-color-text)',
+                  textDecoration: 'underline',
+                  fontWeight: 'var(--pine-font-weight-semi-bold)',
                 },
               },
             },

--- a/libs/core/src/stories/_helpers/index.ts
+++ b/libs/core/src/stories/_helpers/index.ts
@@ -30,3 +30,6 @@ export const customArgsWithIconControl = ({property}: Omit<IconControlArgs, 'com
   };
 }
 
+export { ChangelogLoader } from './ChangelogLoader';
+export { ChangelogRenderer } from './ChangelogRenderer';
+

--- a/libs/core/src/stories/resources/changelogs.docs.mdx
+++ b/libs/core/src/stories/resources/changelogs.docs.mdx
@@ -1,22 +1,22 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { ChangelogLoader } from '../_helpers/ChangelogLoader';
 
-<Meta title="Resources/Changelogs" parameters={{ previewTabs: { canvas: { hidden: true }, } }} />
+<Meta title="Resources/Changelog" parameters={{ previewTabs: { canvas: { hidden: true }, } }} />
 
-# Changelogs
+# Changelog
 
-Stay up to date with the latest releases and updates across the Pine Design System:
+Stay up to date with the latest releases, new features, bug fixes, and improvements for the Pine Design System.
 
-## Pine
-View the latest releases, new features, bug fixes, and improvements for the Pine component library.
+<ChangelogLoader />
 
-<pds-link href="https://github.com/Kajabi/pine/releases" external>View Pine Releases</pds-link>
+## Other Resources
 
-## Pine Icons
+### Pine Icons
 Track updates to the Pine icon library, including new icons, modifications, and deprecations.
 
 <pds-link href="https://github.com/Kajabi/pine-icons/releases" external>View Pine Icons Releases</pds-link>
 
-## Design Tokens
+### Design Tokens
 Follow changes to design tokens including colors, spacing, typography, and other foundational design values.
 
 <pds-link href="https://github.com/Kajabi/ds-tokens/releases" external>View Design Tokens Releases</pds-link>

--- a/libs/core/src/stories/tsconfig.json
+++ b/libs/core/src/stories/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "baseUrl": "../..",
+    "declaration": false,
+    "lib": ["dom", "es2015", "es2017"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "moduleResolution": "node",
+    "module": "esnext",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "es2017"
+  },
+  "include": ["**/*.tsx", "**/*.ts"],
+  "exclude": ["node_modules"]
+}
+

--- a/libs/core/src/stories/tsconfig.json
+++ b/libs/core/src/stories/tsconfig.json
@@ -11,6 +11,9 @@
     "module": "esnext",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "paths": {
+      "@utils/*": ["src/utils/*"]
+    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "target": "es2017"

--- a/libs/core/tsconfig.json
+++ b/libs/core/tsconfig.json
@@ -31,6 +31,7 @@
     "**/*.stories.ts",
     "**/*.stories.tsx",
     "**/*.figma.ts",
-    "scripts/custom-elements"
+    "scripts/custom-elements",
+    "**/stories/_helpers/**/*"
   ]
 }


### PR DESCRIPTION
# Description

Updates changelog page in Storybook documentation to display the repository's `CHANGELOG.md` content directly in the docs.

- Renders changelog with Pine design tokens for consistent styling
- Auto-syncs from root `CHANGELOG.md` during dev and build
- Isolated from Stencil compilation via dedicated tsconfig

No new runtime dependencies. Uses existing `markdown-to-jsx` and `react` dev dependencies.

Fixes DSS-32

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions: 3.x
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
