### PR TITLE
fix(storybook): use pine-core ESM bundle to fix HMR reload errors

### DIFF
--- a/libs/core/.storybook/main.js
+++ b/libs/core/.storybook/main.js
@@ -82,6 +82,10 @@ const config = {
     config.optimizeDeps.exclude = config.optimizeDeps.exclude || [];
     config.optimizeDeps.exclude.push('@mdx-js/react');
 
+    // Exclude Stencil loader from Vite analysis to prevent "dist/esm" resolution errors
+    // The loader references dist/esm which only exists in production builds
+    config.optimizeDeps.exclude.push('@pine-ds/core/loader');
+
     // Configure Vite watch settings for HMR
     // The key issue: Storybook loads from dist/, so we need Vite to watch dist/ files
     // But we also need to watch source files so changes trigger reloads

--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -3,11 +3,11 @@ import { useEffect } from 'storybook/preview-api';
 import { action } from 'storybook/actions';
 import stencilDocs from '../dist/docs.json';
 
-// Import defineCustomElements from loader (prestart runs build first to generate polyfills)
-import { defineCustomElements } from '../loader';
-
-// Register Stencil custom elements
-defineCustomElements();
+// Import pine-core ESM bundle which auto-registers all custom elements on import
+// Note: We use dist/pine-core instead of loader because:
+// - loader/index.js references dist/esm which only exists in production builds (buildEs5: 'prod')
+// - dist/pine-core is always built, even in dev mode
+import '../dist/pine-core/pine-core.esm.js';
 
 // Get all custom event names from Stencil docs
 const allEventNames = stencilDocs.components


### PR DESCRIPTION
# Description

Fixes Storybook failing to load content during HMR reload when Vite optimizes new dependencies.

**Root cause:** `loader/index.js` imports from `dist/esm/` which only exists in production builds (`buildEs5: 'prod'`), causing Vite to fail when re-analyzing imports during dependency optimization.

Fixes DSS-33

**Solution:** 
- Use `dist/pine-core/pine-core.esm.js` which auto-registers components and is always built
- Exclude loader from Vite's `optimizeDeps` as a safety net

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:
- Pine versions: 3.11.1
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings