### PR TITLE
style: address transform minification warnings 

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -257,7 +257,7 @@
   .has-error &:hover:not(:disabled) {
     border-color: var(--pds-input-error-border-hover);
 
-    [data-theme="dark"] & {
+    :host-context([data-theme="dark"]) & {
       border-color: var(--pine-color-red-950);
     }
   }

--- a/libs/doc-components/src/components/docCanvas/docCanvas.css
+++ b/libs/doc-components/src/components/docCanvas/docCanvas.css
@@ -98,10 +98,10 @@
   padding: var(--doc-canvas-spacing-sm);
   text-align: center;
   text-transform: uppercase;
+}
 
-  [data-theme="dark"] &:hover {
-    color: #ffffff;
-  }
+[data-theme="dark"] .doc-canvas-action:hover {
+  color: #ffffff;
 }
 
 .doc-canvas-action:first-child {
@@ -147,10 +147,10 @@
   border-radius: var(--doc-canvas-radius-sm);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
   overflow: hidden;
+}
 
-  [data-theme="dark"] & {
-    background-color: #2d2d2d;
-  }
+[data-theme="dark"] .doc-cavas-actions-toggle {
+  background-color: #2d2d2d;
 }
 
 .doc-canvas-code-wrapper {

--- a/libs/doc-components/src/components/docTokenTable/docTokenTable.css
+++ b/libs/doc-components/src/components/docTokenTable/docTokenTable.css
@@ -1,7 +1,7 @@
 .doc-token-table {
 	border-collapse: collapse;
-  table-layout: fixed;
-  width: 100%;
+	table-layout: fixed;
+	width: 100%;
 
 	thead {
 		tr {
@@ -18,12 +18,6 @@
 	tbody {
 		tr {
 			background-color: #ffffff !important;
-
-			/* stylelint-disable selector-max-compound-selectors */
-			[data-theme="dark"] & {
-				background-color: #2d2d2d !important;
-			}
-			/* stylelint-enable selector-max-compound-selectors */
 		}
 
 		td {
@@ -35,3 +29,9 @@
 		}
 	}
 }
+
+/* stylelint-disable selector-max-compound-selectors */
+[data-theme="dark"] .doc-token-table tbody tr {
+	background-color: #2d2d2d !important;
+}
+/* stylelint-enable selector-max-compound-selectors */


### PR DESCRIPTION
# Description

Fix CSS nesting warnings that appear when running Storybook. The `[data-theme="dark"] &` nesting syntax requires the `:is()` pseudo-class transformation, which is not supported in the configured target browsers (chrome87, edge88, firefox78, safari14).

|  Screenshot  |
|--------|
|<img width="1046" height="296" alt="Screenshot 2025-12-15 at 9 54 58 AM" src="https://github.com/user-attachments/assets/31e70f71-a190-43fe-97e8-5571f4f32f1b" />|

Fixes DSS-40

Updated selectors to use compatible patterns:
- Web components: Use `:host-context([data-theme="dark"]) &` (consistent with existing patterns)
- Doc components: Un-nest to flat selectors like `[data-theme="dark"] .class`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

1. Run storybook locally, verify warnings no longer appear.

**Test Configuration**:

- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
