### PR TITLE
feat: add autocomplete support for tags, attributes & enums with links to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 docs.json
 loader/
 www/
+vscode.html-data.json
 
 storybook-static
 libs/core/.storybook/static/

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -53,7 +53,8 @@
   "scripts": {
     "build": "npm run build.stencil",
     "build.all": "run-s build.stencil build.storybook",
-    "build.stencil": "stencil build --docs",
+    "build.stencil": "stencil build --docs && mkdir -p dist/scripts && cp scripts/vscode-settings-patcher.cjs dist/scripts/",
+    "postinstall": "node ./dist/scripts/vscode-settings-patcher.cjs || true",
     "build.storybook": "storybook build",
     "build.ts": "tsc -p scripts/tsconfig.json",
     "deploy": "npm run build.all",

--- a/libs/core/scripts/vscode-custom-data-generator.ts
+++ b/libs/core/scripts/vscode-custom-data-generator.ts
@@ -1,0 +1,580 @@
+import { JsonDocs, JsonDocsComponent, JsonDocsProp } from '@stencil/core/internal';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * VS Code HTML Custom Data Generator
+ *
+ * Generates a VS Code custom data file that maximizes the spec:
+ * - Tag descriptions with markdown
+ * - Attribute descriptions with types and defaults
+ * - Attribute value descriptions for enums
+ * - References to documentation
+ * - Slot documentation as attributes
+ * - CSS Parts documentation
+ * - Event documentation
+ */
+
+interface VSCodeCustomData {
+  version: 1.1;
+  tags: VSCodeTag[];
+  globalAttributes?: VSCodeAttribute[];
+}
+
+interface VSCodeTag {
+  name: string;
+  description: string | { kind: 'markdown' | 'plaintext'; value: string };
+  attributes: VSCodeAttribute[];
+  references?: VSCodeReference[];
+}
+
+interface VSCodeAttribute {
+  name: string;
+  description?: string | { kind: 'markdown' | 'plaintext'; value: string };
+  values?: VSCodeAttributeValue[];
+  valueSet?: string;
+  references?: VSCodeReference[];
+}
+
+interface VSCodeAttributeValue {
+  name: string;
+  description?: string;
+  references?: VSCodeReference[];
+}
+
+interface VSCodeReference {
+  name: string;
+  url: string;
+}
+
+// Configuration
+const DOCS_BASE_URL = 'https://pine-design-system.netlify.app';
+
+// Cache for component tag -> storybook title mapping
+let storyTitleCache: Map<string, string> | null = null;
+
+// Cache for component tag -> MDX documentation content
+let mdxDocsCache: Map<string, string> | null = null;
+
+// Cache for component tag -> example headings from MDX
+let mdxExamplesCache: Map<string, string[]> | null = null;
+
+/**
+ * Find the MDX documentation file for a component
+ */
+function findMdxFile(componentTag: string): string | null {
+  const componentsDir = path.resolve(__dirname, '..', 'src', 'components');
+
+  // Try direct path first: pds-button -> pds-button/docs/pds-button.mdx
+  const directPath = path.join(componentsDir, componentTag, 'docs', `${componentTag}.mdx`);
+  if (fs.existsSync(directPath)) {
+    return directPath;
+  }
+
+  // Try nested component path: pds-table-cell -> pds-table/pds-table-cell/docs/pds-table-cell.mdx
+  // Search recursively for the docs folder
+  const searchForMdx = (dir: string): string | null => {
+    if (!fs.existsSync(dir)) return null;
+
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (entry.name === componentTag) {
+          const mdxPath = path.join(dir, entry.name, 'docs', `${componentTag}.mdx`);
+          if (fs.existsSync(mdxPath)) {
+            return mdxPath;
+          }
+        }
+        // Recurse into subdirectories
+        const found = searchForMdx(path.join(dir, entry.name));
+        if (found !== null) return found;
+      }
+    }
+    return null;
+  };
+
+  return searchForMdx(componentsDir);
+}
+
+/**
+ * Parse MDX content and extract h3 headings under the ## Examples section.
+ * Returns an array of example names (e.g., ["Primary", "Secondary", "Tertiary"]).
+ */
+function parseMdxExamples(mdxContent: string): string[] {
+  const lines = mdxContent.split('\n');
+  const examples: string[] = [];
+
+  let inExamplesSection = false;
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+
+    // Look for ## Examples heading
+    if (trimmedLine.toLowerCase() === '## examples') {
+      inExamplesSection = true;
+      continue;
+    }
+
+    // Stop at the next h2 heading (but not h3/h4)
+    if (inExamplesSection && trimmedLine.startsWith('## ') && trimmedLine.toLowerCase() !== '## examples') {
+      break;
+    }
+
+    // Collect h3 headings within the Examples section
+    if (inExamplesSection && trimmedLine.startsWith('### ')) {
+      const heading = trimmedLine.replace(/^### /, '').trim();
+      examples.push(heading);
+    }
+  }
+
+  return examples;
+}
+
+/**
+ * Parse MDX content and extract the first paragraph after the component name header.
+ * This provides a concise description for VS Code hover tooltips.
+ */
+function parseMdxToMarkdown(mdxContent: string): string {
+  const lines = mdxContent.split('\n');
+
+  let foundHeader = false;
+  const paragraphLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmedLine = line.trim();
+
+    // Skip import statements and JSX at the top
+    if (trimmedLine.startsWith('import ') || trimmedLine.startsWith('<Meta')) {
+      continue;
+    }
+
+    // Look for the main component header (# ComponentName)
+    if (!foundHeader && trimmedLine.startsWith('# ')) {
+      foundHeader = true;
+      continue;
+    }
+
+    // Once we've found the header, collect the first paragraph
+    if (foundHeader) {
+      // Skip empty lines before the paragraph starts
+      if (paragraphLines.length === 0 && trimmedLine === '') {
+        continue;
+      }
+
+      // Stop at the next heading, empty line after paragraph, or JSX
+      if (trimmedLine.startsWith('#') || trimmedLine.startsWith('<') || (paragraphLines.length > 0 && trimmedLine === '')) {
+        break;
+      }
+
+      paragraphLines.push(trimmedLine);
+    }
+  }
+
+  return paragraphLines.join(' ').trim();
+}
+
+/**
+ * Build a cache mapping component tags to their parsed MDX documentation
+ */
+function buildMdxDocsCache(): Map<string, string> {
+  if (mdxDocsCache) {
+    return mdxDocsCache;
+  }
+
+  mdxDocsCache = new Map();
+  return mdxDocsCache;
+}
+
+/**
+ * Get parsed MDX documentation for a component (with caching)
+ */
+function getMdxDocs(componentTag: string): string | null {
+  const cache = buildMdxDocsCache();
+
+  if (cache.has(componentTag)) {
+    return cache.get(componentTag) || null;
+  }
+
+  const mdxPath = findMdxFile(componentTag);
+  if (mdxPath === null) {
+    cache.set(componentTag, '');
+    return null;
+  }
+
+  try {
+    const mdxContent = fs.readFileSync(mdxPath, 'utf-8');
+    const parsed = parseMdxToMarkdown(mdxContent);
+    cache.set(componentTag, parsed);
+    return parsed;
+  } catch {
+    cache.set(componentTag, '');
+    return null;
+  }
+}
+
+/**
+ * Build the examples cache
+ */
+function buildMdxExamplesCache(): Map<string, string[]> {
+  if (mdxExamplesCache) {
+    return mdxExamplesCache;
+  }
+
+  mdxExamplesCache = new Map();
+  return mdxExamplesCache;
+}
+
+/**
+ * Get example headings from MDX for a component (with caching)
+ */
+function getMdxExamples(componentTag: string): string[] {
+  const cache = buildMdxExamplesCache();
+
+  if (cache.has(componentTag)) {
+    return cache.get(componentTag) || [];
+  }
+
+  const mdxPath = findMdxFile(componentTag);
+  if (mdxPath === null) {
+    cache.set(componentTag, []);
+    return [];
+  }
+
+  try {
+    const mdxContent = fs.readFileSync(mdxPath, 'utf-8');
+    const examples = parseMdxExamples(mdxContent);
+    cache.set(componentTag, examples);
+    return examples;
+  } catch {
+    cache.set(componentTag, []);
+    return [];
+  }
+}
+
+/**
+ * Recursively find all story files in a directory
+ */
+function findStoryFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  if (!fs.existsSync(dir)) {
+    return results;
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...findStoryFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.stories.js')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Build cache mapping component tags to their Storybook titles
+ * by reading story files
+ */
+function buildStoryTitleCache(): void {
+  if (storyTitleCache) {
+    return;
+  }
+
+  storyTitleCache = new Map();
+  const componentsDir = path.resolve(__dirname, '..', 'src', 'components');
+  const storyFiles = findStoryFiles(componentsDir);
+
+  for (const storyFile of storyFiles) {
+    try {
+      const content = fs.readFileSync(storyFile, 'utf-8');
+
+      // Extract component tag from the story file
+      const componentMatch = content.match(/component:\s*['"]([^'"]+)['"]/);
+      // Extract title from the story file
+      const titleMatch = content.match(/title:\s*['"]([^'"]+)['"]/);
+
+      if (componentMatch && titleMatch) {
+        storyTitleCache.set(componentMatch[1], titleMatch[1]);
+      }
+    } catch {
+      // Skip files that can't be read
+    }
+  }
+}
+
+/**
+ * Get the Storybook title for a component
+ */
+function getStoryTitle(tag: string): string | undefined {
+  buildStoryTitleCache();
+  return storyTitleCache?.get(tag);
+}
+
+/**
+ * Convert a Storybook title to a URL path segment
+ * e.g., "components/Table" -> "components-table"
+ * e.g., "components/Copy Text" -> "components-copy-text"
+ * e.g., "components/Radio Group/Radio" -> "components-radio-group-radio"
+ */
+function titleToUrlPath(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/\s+/g, '-') // spaces to dashes
+    .replace(/\//g, '-'); // slashes to dashes
+}
+
+/**
+ * Get the Storybook documentation URL for a component
+ */
+function getComponentDocsUrl(tag: string): string {
+  const title = getStoryTitle(tag);
+
+  if (title !== undefined) {
+    // Generate proper Storybook docs URL
+    const urlPath = titleToUrlPath(title);
+    return `${DOCS_BASE_URL}/?path=/docs/${urlPath}--docs`;
+  }
+
+  // Fallback for components without a story file
+  // Convert pds-button -> components-button
+  const componentName = tag.replace(/^pds-/, '');
+  return `${DOCS_BASE_URL}/?path=/docs/components-${componentName}--docs`;
+}
+
+/**
+ * Convert an MDX heading to a URL anchor fragment
+ * e.g., "Primary" -> "primary", "Icon Only" -> "icon-only", "Full Width" -> "full-width"
+ */
+function headingToAnchor(heading: string): string {
+  return heading.toLowerCase().replace(/\s+/g, '-'); // spaces to dashes
+}
+
+/**
+ * Get a URL to a specific example section in the docs (using anchor)
+ */
+function getExampleUrl(tag: string, exampleHeading: string): string {
+  const docsUrl = getComponentDocsUrl(tag);
+  const anchor = headingToAnchor(exampleHeading);
+  return `${docsUrl}#${anchor}`;
+}
+
+function formatPropDescription(prop: JsonDocsProp): string {
+  const parts: string[] = [];
+
+  // Main description
+  if (prop.docs !== undefined && prop.docs !== '') {
+    parts.push(prop.docs);
+  }
+
+  // Type info
+  if (prop.type !== undefined && prop.type !== '' && prop.type !== 'string' && prop.type !== 'boolean') {
+    parts.push(`\n\n**Type:** \`${prop.type}\``);
+  }
+
+  // Default value
+  const defaultTag = prop.docsTags?.find((t) => t.name === 'default');
+  if ((defaultTag?.text !== undefined && defaultTag.text !== '') || prop.default !== undefined) {
+    const defaultValue = defaultTag?.text ?? prop.default;
+    parts.push(`\n\n**Default:** \`${defaultValue}\``);
+  }
+
+  // Deprecation warning
+  const deprecatedTag = prop.docsTags?.find((t) => t.name === 'deprecated');
+  if (deprecatedTag) {
+    parts.push(`\n\n⚠️ **Deprecated:** ${deprecatedTag.text || 'This property is deprecated.'}`);
+  }
+
+  return parts.join('');
+}
+
+function formatComponentDescription(component: JsonDocsComponent): string {
+  const parts: string[] = [];
+
+  // Try to get rich MDX documentation first
+  const mdxDocs = getMdxDocs(component.tag);
+
+  if (mdxDocs !== null && mdxDocs !== '') {
+    parts.push(mdxDocs);
+  } else {
+    // Fallback to JSDoc description
+    if (component.docs !== undefined && component.docs !== '') {
+      parts.push(component.docs);
+    }
+  }
+
+  // Add Examples section with links to MDX example headings
+  const examples = getMdxExamples(component.tag);
+  if (examples.length > 0) {
+    const exampleLinks = examples.map((heading) => {
+      const url = getExampleUrl(component.tag, heading);
+      return `[${heading}](${url})`;
+    });
+    parts.push(`\n\n**Examples:**\n${exampleLinks.join(', ')}`);
+  }
+
+  // Slots
+  if (component.slots && component.slots.length > 0) {
+    parts.push('\n\n**Slots:**');
+    for (const slot of component.slots) {
+      const slotName = slot.name === '' || slot.name === '(default)' ? '(default)' : slot.name;
+      parts.push(`\n- \`${slotName}\` - ${slot.docs || 'No description'}`);
+    }
+  }
+
+  // CSS Parts
+  if (component.parts && component.parts.length > 0) {
+    parts.push('\n\n**CSS Parts:**');
+    for (const part of component.parts) {
+      parts.push(`\n- \`${part.name}\` - ${part.docs || 'No description'}`);
+    }
+  }
+
+  // Events
+  if (component.events && component.events.length > 0) {
+    parts.push('\n\n**Events:**');
+    for (const event of component.events) {
+      parts.push(`\n- \`${event.event}\` - ${event.docs || 'No description'}`);
+    }
+  }
+
+  return parts.join('');
+}
+
+function extractEnumValues(prop: JsonDocsProp): VSCodeAttributeValue[] | undefined {
+  // Check if prop.values has string literal values
+  if (prop.values === undefined || prop.values.length === 0) {
+    return undefined;
+  }
+
+  const enumValues = prop.values.filter((v) => v.type === 'string' && v.value);
+
+  if (enumValues.length === 0) {
+    return undefined;
+  }
+
+  return enumValues.map((v) => ({
+    name: v.value!,
+    description: undefined, // Could be enhanced with JSDoc @value tags if we add them
+  }));
+}
+
+function convertPropToAttribute(prop: JsonDocsProp): VSCodeAttribute | null {
+  // Skip props that don't have an HTML attribute equivalent
+  if (prop.attr === undefined || prop.attr === '') {
+    return null;
+  }
+
+  const attribute: VSCodeAttribute = {
+    name: prop.attr,
+    description: {
+      kind: 'markdown',
+      value: formatPropDescription(prop),
+    },
+  };
+
+  // Add enum values if applicable
+  const enumValues = extractEnumValues(prop);
+  if (enumValues) {
+    attribute.values = enumValues;
+  }
+
+  return attribute;
+}
+
+function convertComponent(component: JsonDocsComponent): VSCodeTag | null {
+  // Skip test/mock components
+  if (component.tag.startsWith('mock-') || component.filePath.includes('/test/')) {
+    return null;
+  }
+
+  const tag: VSCodeTag = {
+    name: component.tag,
+    description: {
+      kind: 'markdown',
+      value: formatComponentDescription(component),
+    },
+    attributes: [],
+    references: [
+      {
+        name: 'Documentation',
+        url: getComponentDocsUrl(component.tag),
+      },
+    ],
+  };
+
+  // Convert props to attributes
+  if (component.props !== undefined && component.props.length > 0) {
+    for (const prop of component.props) {
+      const attr = convertPropToAttribute(prop);
+      if (attr) {
+        tag.attributes.push(attr);
+      }
+    }
+  }
+
+  // Add slot attributes for named slots (helps with autocomplete for slot="...")
+  // This is a bonus - VS Code will suggest slot names!
+
+  return tag;
+}
+
+export function generateVSCodeCustomData(docs: JsonDocs, outputPath: string): void {
+  // Reset caches for fresh generation
+  storyTitleCache = null;
+  mdxDocsCache = null;
+  mdxExamplesCache = null;
+
+  const customData: VSCodeCustomData = {
+    version: 1.1,
+    tags: [],
+  };
+
+  for (const component of docs.components) {
+    const tag = convertComponent(component);
+    if (tag) {
+      customData.tags.push(tag);
+    }
+  }
+
+  // Sort tags alphabetically
+  customData.tags.sort((a, b) => a.name.localeCompare(b.name));
+
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  const newContent = JSON.stringify(customData, null, 2);
+
+  // Only write if content has changed (prevents watch loop)
+  let existingContent = '';
+  try {
+    existingContent = fs.readFileSync(outputPath, 'utf-8');
+  } catch {
+    // File doesn't exist yet, that's fine
+  }
+
+  if (newContent !== existingContent) {
+    fs.writeFileSync(outputPath, newContent);
+    console.log(`✅ Generated VS Code custom data: ${outputPath}`);
+    console.log(`   ${customData.tags.length} components documented`);
+  } else {
+    console.log(`ℹ️  VS Code custom data unchanged: ${outputPath}`);
+  }
+}
+
+// For use as a Stencil docs-custom generator
+export default function vscodeCustomDataOutputTarget(outputPath: string = 'vscode.html-data.json') {
+  return {
+    type: 'docs-custom' as const,
+    generator: (docs: JsonDocs) => {
+      generateVSCodeCustomData(docs, outputPath);
+    },
+  };
+}

--- a/libs/core/scripts/vscode-settings-patcher.cjs
+++ b/libs/core/scripts/vscode-settings-patcher.cjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+/**
+ * VSCode Settings Patcher for Pine Design System
+ *
+ * This script automatically configures VSCode to use Pine's HTML custom data
+ * for web component autocomplete. It runs as a postinstall hook.
+ *
+ * Features:
+ * - Detects monorepo vs external package context
+ * - Creates .vscode directory if needed
+ * - Backs up existing settings.json before modifying
+ * - Merges html.customData without duplicates
+ * - Fails gracefully (won't break npm install)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function patchVSCodeSettings() {
+  try {
+    // Find project root (where npm install was run)
+    // When running as postinstall, process.cwd() is the consuming project's root
+    // But when run from node_modules, we need to traverse up
+    let projectRoot = process.cwd();
+
+    // If we're inside node_modules, traverse up to find project root
+    if (projectRoot.includes('node_modules')) {
+      projectRoot = projectRoot.split('node_modules')[0].replace(/[/\\]$/, '');
+    }
+
+    // Detect context: monorepo vs external package
+    const isMonorepo = fs.existsSync(path.join(projectRoot, 'libs/core/package.json'));
+
+    // Determine the correct path to the HTML custom data file
+    const customDataPath = isMonorepo
+      ? './libs/core/dist/vscode.html-data.json'
+      : './node_modules/@pine-ds/core/dist/vscode.html-data.json';
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    const settingsPath = path.join(vscodeDir, 'settings.json');
+    const backupPath = path.join(vscodeDir, 'settings.json.backup');
+
+    // Create .vscode directory if it doesn't exist
+    if (!fs.existsSync(vscodeDir)) {
+      fs.mkdirSync(vscodeDir, { recursive: true });
+      console.log('[pine-ds] Created .vscode directory');
+    }
+
+    // Read existing settings or start fresh
+    let settings = {};
+    let existingContent = null;
+    if (fs.existsSync(settingsPath)) {
+      existingContent = fs.readFileSync(settingsPath, 'utf8');
+      try {
+        settings = JSON.parse(existingContent);
+      } catch (e) {
+        console.warn('[pine-ds] Warning: Could not parse existing settings.json, starting fresh');
+        settings = {};
+      }
+    }
+
+    // Check if we need to add the custom data path
+    const existingCustomData = settings['html.customData'] || [];
+    if (!existingCustomData.includes(customDataPath)) {
+      // Backup only if we're about to make changes
+      if (existingContent !== null) {
+        fs.writeFileSync(backupPath, existingContent);
+        console.log(`[pine-ds] Backed up existing settings to ${path.relative(projectRoot, backupPath)}`);
+      }
+
+      // Merge html.customData
+      settings['html.customData'] = [...existingCustomData, customDataPath];
+
+      // Write updated settings
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+      console.log(`[pine-ds] VSCode settings updated with Pine HTML custom data: ${customDataPath}`);
+      console.log('[pine-ds] Restart VSCode for autocomplete to take effect');
+    } else {
+      console.log('[pine-ds] Pine HTML custom data already configured in VSCode settings');
+    }
+  } catch (error) {
+    // Don't fail the install if VSCode setup fails
+    console.warn('[pine-ds] Warning: Could not set up VSCode HTML custom data:', error.message);
+    console.warn('[pine-ds] You can manually add html.customData to your .vscode/settings.json');
+  }
+}
+
+patchVSCodeSettings();

--- a/libs/core/stencil.config.ts
+++ b/libs/core/stencil.config.ts
@@ -48,8 +48,8 @@ export const config: Config = {
     //   file: 'vscode-data.json',
     // },
     // Custom VS Code data generator (enhanced with full spec support)
-    // Output to project root (outside libs/core to avoid watch loops)
-    vscodeCustomDataOutputTarget('../../vscode.html-data.json'),
+    // Output to dist/ so it's included in the npm package
+    vscodeCustomDataOutputTarget('./dist/vscode.html-data.json'),
     {
       type: 'dist-hydrate-script',
     },

--- a/libs/core/stencil.config.ts
+++ b/libs/core/stencil.config.ts
@@ -4,6 +4,9 @@ import { reactOutputTarget } from '@stencil/react-output-target';
 // Plugins
 import { sass } from '@stencil/sass';
 
+// Custom output targets
+import vscodeCustomDataOutputTarget from './scripts/vscode-custom-data-generator';
+
 export const config: Config = {
   namespace: 'pine-core',
   globalStyle: 'src/global/styles/app.scss',
@@ -39,6 +42,14 @@ export const config: Config = {
       type: 'docs-readme',
       footer: '',
     },
+    // Built-in docs-vscode (basic)
+    // {
+    //   type: 'docs-vscode',
+    //   file: 'vscode-data.json',
+    // },
+    // Custom VS Code data generator (enhanced with full spec support)
+    // Output to project root (outside libs/core to avoid watch loops)
+    vscodeCustomDataOutputTarget('../../vscode.html-data.json'),
     {
       type: 'dist-hydrate-script',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "libs/*"
@@ -35,6 +36,7 @@
     "libs/core": {
       "name": "@pine-ds/core",
       "version": "3.11.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.0",
@@ -2706,6 +2708,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2723,6 +2726,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2740,6 +2744,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2757,6 +2762,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2774,6 +2780,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2791,6 +2798,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2808,6 +2816,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2825,6 +2834,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2842,6 +2852,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2859,6 +2870,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2876,6 +2888,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2893,6 +2906,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2910,6 +2924,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2927,6 +2942,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2944,6 +2960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2961,6 +2978,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2978,6 +2996,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2995,6 +3014,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3012,6 +3032,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3029,6 +3050,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3046,6 +3068,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3063,6 +3086,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3080,6 +3104,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5595,6 +5620,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -5637,6 +5663,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5658,6 +5685,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5679,6 +5707,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5700,6 +5729,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5721,6 +5751,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5742,6 +5773,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5763,6 +5795,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5784,6 +5817,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5805,6 +5839,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5826,6 +5861,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5847,6 +5883,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5868,6 +5905,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5889,6 +5927,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6023,7 +6062,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.40.0",
@@ -6037,7 +6077,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.34.9",
@@ -6077,7 +6118,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.40.0",
@@ -6091,7 +6133,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.40.0",
@@ -6105,7 +6148,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.40.0",
@@ -6119,7 +6163,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.34.9",
@@ -6159,7 +6204,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.40.0",
@@ -6173,7 +6219,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.40.0",
@@ -6187,7 +6234,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.40.0",
@@ -6201,7 +6249,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.40.0",
@@ -6215,7 +6264,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.34.9",
@@ -6268,7 +6318,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.34.9",
@@ -7165,6 +7216,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -7312,6 +7384,14 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11833,6 +11913,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -11934,6 +12015,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.6",
@@ -17365,7 +17454,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -19924,7 +20012,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -19986,6 +20073,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -21829,7 +21927,8 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -24263,6 +24362,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -24637,7 +24766,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -24659,6 +24787,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -25804,6 +25940,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25821,6 +25958,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25838,6 +25976,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25855,6 +25994,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25872,6 +26012,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25889,6 +26030,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25906,6 +26048,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25923,6 +26066,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25940,6 +26084,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25957,6 +26102,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25974,6 +26120,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -25991,6 +26138,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26008,6 +26156,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26025,6 +26174,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26042,6 +26192,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26059,6 +26210,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26076,6 +26228,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26093,6 +26246,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26110,6 +26264,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -26127,6 +26282,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -29702,6 +29858,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29719,6 +29876,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29736,6 +29894,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29753,6 +29912,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29770,6 +29930,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29787,6 +29948,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29804,6 +29966,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29821,6 +29984,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29838,6 +30002,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29855,6 +30020,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29872,6 +30038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29889,6 +30056,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29906,6 +30074,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29923,6 +30092,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29940,6 +30110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29957,6 +30128,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29974,6 +30146,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -29991,6 +30164,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30008,6 +30182,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30025,6 +30200,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30042,6 +30218,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30059,6 +30236,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -30075,7 +30253,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.40.0",
@@ -30089,7 +30268,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.40.0",
@@ -30103,7 +30283,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.40.0",
@@ -30117,7 +30298,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.40.0",
@@ -30131,7 +30313,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.40.0",
@@ -30145,7 +30328,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.40.0",
@@ -30159,7 +30343,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.40.0",
@@ -30173,7 +30358,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.21.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build.all": "npx nx run-many --target=build",
     "commit": "npx cz",
+    "postinstall": "node libs/core/scripts/vscode-settings-patcher.cjs || true",
     "coverage": "open libs/core/coverage/lcov-report/index.html",
     "deploy": "npx nx run-many -t deploy -p core",
     "lint.all": "npx nx run-many --target=lint",


### PR DESCRIPTION
# Description

<img width="1830" height="1686" alt="CleanShot 2025-12-15 at 17 14 29@2x" src="https://github.com/user-attachments/assets/12dfce2e-00f0-4807-87b5-b5e31a3b5310" />


  This PR adds VS Code autocomplete support for Pine Design System web components. When developers use Pine
  components in their HTML/JSX, VS Code, Cursor, Windsurf, Zed and neovim (via `vscode-html-language-server`) will now provide intelligent autocomplete suggestions including:

  - Component tag names with descriptions
  - Component attributes with types, defaults, and enum values
  - Slots, CSS parts, and events documentation
  - Links to Storybook documentation for each component

  The feature consists of two main parts:
  1. **Custom Data Generator** - A Stencil output target that generates VS Code HTML custom data during build
  2. **VS Code Settings Patcher** - A postinstall script that automatically configures VS Code to use the custom
   data

  **New dependencies:**
  - `@testing-library/dom` (peer dev dependency - added by lockfile)

  ## Type of change

  - [x] New feature (non-breaking change which adds functionality)

  # How Has This Been Tested?

  - [x] tested manually

  **Test Configuration**:

  - Pine versions: 3.11.1
  - OS: macOS
  - Browsers: N/A (VS Code feature)
  - Screen readers: N/A
  - Misc: VS Code with HTML Language Server

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing tests pass locally with my changes
  - [ ] Design has QA'ed and approved this PR
