### PR TITLE
fix(pds-modal): make border prop mutable and remove debug logging

### DIFF
--- a/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.tsx
+++ b/libs/core/src/components/pds-modal/pds-modal-content/pds-modal-content.tsx
@@ -12,7 +12,7 @@ export class PdsModalContent {
    * The border style for the content area. When not explicitly set, automatically determined based on scroll state.
    * @default 'none'
    */
-  @Prop({ reflect: true }) border: 'none' | 'both' | 'top' | 'bottom' = 'none';
+  @Prop({ reflect: true, mutable: true }) border: 'none' | 'both' | 'top' | 'bottom' = 'none';
 
   @State() contentMaxHeight: string = 'none';
 
@@ -40,7 +40,6 @@ export class PdsModalContent {
     if (!this.userSetBorder) {
       setTimeout(() => {
         // The scroll happens on the component element itself (this.el), not the inner div
-        console.log('Setting up scroll listener on component element:', this.el);
         this.el.addEventListener('scroll', this.handleScroll.bind(this));
         // Initial border update after everything is set up
         setTimeout(() => this.updateBorders(), 100);
@@ -65,7 +64,6 @@ export class PdsModalContent {
    * Handle scroll events
    */
   private handleScroll() {
-    console.log('Scroll event fired!');
     this.updateBorders();
   }
 
@@ -123,33 +121,18 @@ export class PdsModalContent {
     const isAtTop = scrollTop <= tolerance;
     const isAtBottom = scrollBottom >= scrollHeight - tolerance;
 
-    // Debug logging (can be removed later)
-    console.log('Border Debug:', {
-      scrollTop,
-      scrollHeight,
-      clientHeight,
-      scrollBottom,
-      isAtTop,
-      isAtBottom,
-      currentBorder: this.border
-    });
-
     if (isAtTop && isAtBottom) {
       // Content fits exactly, no borders needed
       this.border = 'none';
-      console.log('Content fits exactly, no borders needed');
     } else if (isAtTop && !isAtBottom) {
       // At top, show bottom border only
       this.border = 'bottom';
-      console.log('At top, show bottom border only');
     } else if (!isAtTop && isAtBottom) {
       // At bottom, show top border only
       this.border = 'top';
-      console.log('At bottom, show top border only');
     } else {
       // In middle, show both borders
       this.border = 'both';
-      console.log('In middle, show both borders');
     }
   }
 


### PR DESCRIPTION
# Description

Cleans up the `pds-modal-content` component by removing debug console.log statements and fixing Stencil prop mutability warnings.

**Changes:**
- Removed 7 debug `console.log` statements that were outputting scroll/border state information to the console
- Added `mutable: true` to the `border` prop decorator to fix Stencil warnings about modifying an immutable prop from within the component

The `border` prop is dynamically updated based on scroll position when not explicitly set by the user, which requires the prop to be mutable. Without this flag, Stencil was logging repeated warnings in the console.

Fixes DSS-48

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified that console warnings and debug logs no longer appear when interacting with the modal component. Existing modal tests are unaffected as they do not test the `border` prop or console output.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: N/A
- OS: macOS
- Browsers: Chrome
- Screen readers: N/A
- Misc: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
