### PR TITLE
style(pds-input, pds-checkbox): standardize helper and error message typography

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.scss
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.scss
@@ -152,8 +152,7 @@ label {
 
 .pds-checkbox__message--error {
   display: flex;
-  font-size: var(--pine-font-size-085);
-  gap: var(--pine-dimension-050);
+  gap: var(--pine-dimension-2xs);
 
   pds-icon {
     margin-block-start: var(--pine-dimension-025);

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -300,7 +300,7 @@
 .pds-input__error-message,
 .pds-input__helper-message {
   color: var(--pine-color-text-message);
-  font: var(--pine-typography-body-sm);
+  font: var(--pine-typography-body-sm-medium);
   margin-block-end: var(--pine-dimension-none);
   margin-block-start: var(--pine-dimension-2xs);
 }


### PR DESCRIPTION
# Description

Standardizes helper and error message typography across form components to ensure visual consistency.

**Changes:**
- `pds-input`: Updated helper/error message font from `--pine-typography-body-sm` to `--pine-typography-body-sm-medium`
- `pds-checkbox`: Removed custom `font-size` override on error message (now inherits `--pine-typography-body-sm-medium`)
- `pds-checkbox`: Changed error message gap from `--pine-dimension-050` to `--pine-dimension-2xs`

These components now match the typography used by `pds-textarea`, `pds-select`, and `pds-switch`.

Fixes DSS-49

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR