### PR TITLE
style: update alert dark mode link hover style

### DIFF
--- a/libs/core/src/components/pds-alert/docs/pds-alert.mdx
+++ b/libs/core/src/components/pds-alert/docs/pds-alert.mdx
@@ -49,9 +49,9 @@ The alert component supports multiple style variants to indicate different types
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert heading="Alert heading text" variant="default">
+    react: `<PdsAlert heading="Alert heading text" variant="default">
   Alerts can also have description text that can be used to provide more information about the alert.
-</pdsAlert>`,
+</PdsAlert>`,
     webComponent: `<pds-alert heading="Alert heading text" variant="default">
   Alerts can also have description text that can be used to provide more information about the alert.
 </pds-alert>`
@@ -67,9 +67,9 @@ Text in small alerts is truncated when it becomes too long for the alert descrip
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert heading="Alert heading text" small="true" variant="info">
+    react: `<PdsAlert heading="Alert heading text" small="true" variant="info">
   Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.
-</pdsAlert>`,
+</PdsAlert>`,
     webComponent: `<pds-alert heading="Alert heading text" small="true" variant="info">
   Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.
 </pds-alert>`
@@ -86,21 +86,22 @@ Action items such as buttons and links should be added to alerts using the `acti
 > - In order to adhere to design and UX best practices, only links and buttons should be used in the actions slot.
 > - The `actions` slot uses a flex layout automatically, so the actions will be spaced and aligned properly.
 > - When using the small variant, only links should be used in the actions slot due to the compact inline layout.
+> - Links (`pds-link`) automatically inherit the correct colors from the alert variant - no manual color prop needed.
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert heading="Alert heading text" variant="success">
+    react: `<PdsAlert heading="Alert heading text" variant="success">
   Alerts can also have description text that can be used to provide more information about the alert.
-  <pdsButton slot="actions" variant="primary">Action button</pdsButton>
-  <pdsLink href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pdsLink>
-</pdsAlert>`,
+  <PdsButton slot="actions" variant="primary">Action button</PdsButton>
+  <PdsLink href="#" slot="actions" variant="plain">Action link</PdsLink>
+</PdsAlert>`,
     webComponent: `<pds-alert heading="Alert heading text" variant="success">
   Alerts can also have description text that can be used to provide more information about the alert.
   <pds-button slot="actions" variant="primary">Action button</pds-button>
-  <pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link>
+  <pds-link href="#" slot="actions" variant="plain">Action link</pds-link>
 </pds-alert>`
 }}>
-  <pds-alert heading="Alert heading text" variant="success">Alerts can also have description text that can be used to provide more information about the alert.<pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link></pds-alert>
+  <pds-alert heading="Alert heading text" variant="success">Alerts can also have description text that can be used to provide more information about the alert.<pds-button slot="actions" variant="primary">Action button</pds-button><pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
 </DocCanvas>
 
 ### Small with actions
@@ -109,18 +110,18 @@ When using the small variant, actions are displayed on the same line as the desc
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert heading="Alert heading text" small="true" variant="warning">
+    react: `<PdsAlert heading="Alert heading text" small="true" variant="warning">
   Alerts can also have description text that can be used to provide more information about the alert.
-  <pdsLink href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pdsLink>
-  <pdsLink href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pdsLink>
-</pdsAlert>`,
+  <PdsLink href="#" slot="actions" variant="plain">Action link</PdsLink>
+  <PdsLink href="#" slot="actions" variant="plain">Action link</PdsLink>
+</PdsAlert>`,
     webComponent: `<pds-alert heading="Alert heading text" small="true" variant="warning">
   Alerts can also have description text that can be used to provide more information about the alert.
-  <pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link>
-  <pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link>
+  <pds-link href="#" slot="actions" variant="plain">Action link</pds-link>
+  <pds-link href="#" slot="actions" variant="plain">Action link</pds-link>
 </pds-alert>`
 }}>
-  <pds-alert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain" color="var(--pine-color-grey-900)">Action link</pds-link></pds-alert>
+  <pds-alert heading="Alert heading text" small="true" variant="warning">Alerts can also have description text that can be used to provide more information about the alert.<pds-link href="#" slot="actions" variant="plain">Action link</pds-link> <pds-link href="#" slot="actions" variant="plain">Action link</pds-link></pds-alert>
 </DocCanvas>
 
 
@@ -132,9 +133,9 @@ An event `pdsAlertDismissClick` is emitted when the dismiss button is clicked, w
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert dismissible="true" heading="Alert heading text" variant="danger">
+    react: `<PdsAlert dismissible="true" heading="Alert heading text" variant="danger">
   Alerts can also have description text that can be used to provide more information about the alert.
-</pdsAlert>`,
+</PdsAlert>`,
     webComponent: `<pds-alert dismissible="true" heading="Alert heading text" variant="danger">
   Alerts can also have description text that can be used to provide more information about the alert.
 </pds-alert>`
@@ -146,9 +147,9 @@ An event `pdsAlertDismissClick` is emitted when the dismiss button is clicked, w
 
 <DocCanvas
   mdxSource={{
-    react: `<pdsAlert dismissible="true" heading="Alert heading text" small="true" variant="danger">
+    react: `<PdsAlert dismissible="true" heading="Alert heading text" small="true" variant="danger">
   Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.
-</pdsAlert>`,
+</PdsAlert>`,
     webComponent: `<pds-alert dismissible="true" heading="Alert heading text" small="true" variant="danger">
   Small alerts use the description to provide more information about the alert, but are truncated when the text becomes too long for the alert to fit the screen.
 </pds-alert>`

--- a/libs/core/src/components/pds-alert/pds-alert.scss
+++ b/libs/core/src/components/pds-alert/pds-alert.scss
@@ -1,7 +1,31 @@
 :host {
+  // Context link colors for slotted pds-link components (default variant)
+  --pds-context-link-color: var(--pine-alert-color-link);
+  --pds-context-link-color-hover: var(--pine-alert-color-link-hover);
+
   display: block;
   line-height: 1;
   width: 100%;
+}
+
+:host([variant="danger"]) {
+  --pds-context-link-color: var(--pine-alert-color-danger-link);
+  --pds-context-link-color-hover: var(--pine-alert-color-danger-link-hover);
+}
+
+:host([variant="info"]) {
+  --pds-context-link-color: var(--pine-alert-color-info-link);
+  --pds-context-link-color-hover: var(--pine-alert-color-info-link-hover);
+}
+
+:host([variant="success"]) {
+  --pds-context-link-color: var(--pine-alert-color-success-link);
+  --pds-context-link-color-hover: var(--pine-alert-color-success-link-hover);
+}
+
+:host([variant="warning"]) {
+  --pds-context-link-color: var(--pine-alert-color-warning-link);
+  --pds-context-link-color-hover: var(--pine-alert-color-warning-link-hover);
 }
 
 .pds-alert__container {

--- a/libs/core/src/components/pds-link/pds-link.scss
+++ b/libs/core/src/components/pds-link/pds-link.scss
@@ -8,7 +8,8 @@
 
 .pds-link {
   align-items: center;
-  color: var(--color, var(--pine-color-text));
+  // Priority: 1) explicit --color prop, 2) context variable, 3) default
+  color: var(--color, var(--pds-context-link-color, var(--pine-color-text)));
   display: inline-flex;
   font-weight: var(--pine-font-weight-medium);
 
@@ -20,7 +21,7 @@
   }
 
   &:hover {
-    color: var(--color, var(--pine-color-text-hover));
+    color: var(--color, var(--pds-context-link-color-hover, var(--pine-color-text-hover)));
     text-decoration: none;
   }
 
@@ -83,7 +84,7 @@
   text-decoration: none;
 
   &:hover {
-    color: var(--pine-color-text-hover);
+    color: var(--color, var(--pds-context-link-color-hover, var(--pine-color-text-hover)));
     text-decoration: underline;
   }
 }

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -8,6 +8,10 @@
   --sizing-min-width-desktop: calc(var(--sizing-total-width) - (var(--padding-inline-desktop) * 2));
   --sizing-total-width: 350px;
 
+  // Context link colors for slotted pds-link components (light text on dark backgrounds)
+  --pds-context-link-color: var(--pine-color-text-inverse);
+  --pds-context-link-color-hover: var(--pine-color-text-inverse-emphasis);
+
   box-sizing: border-box;
   display: block;
   font: var(--pine-typography-body-medium);

--- a/libs/core/src/components/pds-toast/pds-toast.scss
+++ b/libs/core/src/components/pds-toast/pds-toast.scss
@@ -8,10 +8,6 @@
   --sizing-min-width-desktop: calc(var(--sizing-total-width) - (var(--padding-inline-desktop) * 2));
   --sizing-total-width: 350px;
 
-  // Context link colors for slotted pds-link components (light text on dark backgrounds)
-  --pds-context-link-color: var(--pine-color-text-inverse);
-  --pds-context-link-color-hover: var(--pine-color-text-inverse-emphasis);
-
   box-sizing: border-box;
   display: block;
   font: var(--pine-typography-body-medium);


### PR DESCRIPTION
# Description

- [x] in dark mode links on items with a colored background are hard to read

Fixes #(issue)

| Before | After |
|--------|--------|
|![alertLinkHoverBefore](https://github.com/user-attachments/assets/1eee675f-71db-48d0-8e21-8bcd4804564b)|![alertLinkHoverAfter](https://github.com/user-attachments/assets/4ce161a2-e204-49f9-a887-ee73936df892)|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Click the dark mode toggle -> Visit the alert page -> Small with actions -> hover link

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
