### PR TITLE
style(pds-copytext): move background color to span element

### DIFF
--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -27,7 +27,6 @@
     }
 
     span {
-      background: var(--pine-color-secondary);
       font-weight: var(--pine-font-weight-medium);
       margin-inline-end: var(--pine-dimension-xs);
       white-space: nowrap;
@@ -57,6 +56,7 @@
     }
 
     span {
+      background: var(--pine-color-secondary);
       border: var(--pine-border);
       border-radius: var(--pine-border-radius-full);
       margin-inline-end: var(--pine-dimension-sm);

--- a/libs/core/src/components/pds-copytext/pds-copytext.scss
+++ b/libs/core/src/components/pds-copytext/pds-copytext.scss
@@ -5,7 +5,6 @@
 
   pds-button {
     align-items: center;
-    background: var(--pine-color-secondary);
     border-radius: var(--pine-border-radius-full);
     border-width: var(--pine-dimension-none);
     display: inline-flex;
@@ -28,6 +27,7 @@
     }
 
     span {
+      background: var(--pine-color-secondary);
       font-weight: var(--pine-font-weight-medium);
       margin-inline-end: var(--pine-dimension-xs);
       white-space: nowrap;


### PR DESCRIPTION
# Description

Moves the background color style from the `pds-button` element to the inner `span` element in `pds-copytext`. This ensures the secondary background color is applied only to the text label rather than the entire button, providing correct visual styling for the component.

Fixes DSS-55

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="218" height="62" alt="Screenshot 2026-01-05 at 12 12 04 PM" src="https://github.com/user-attachments/assets/00d6cd1c-ecf8-40c4-a9bf-984589eed523" />|<img width="228" height="64" alt="Screenshot 2026-01-05 at 12 11 48 PM" src="https://github.com/user-attachments/assets/99d18c74-e75d-43fd-842c-a90b660c3e0f" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions: 3.12.0
- OS: macOS
- Browsers: Chrome
- Screen readers: N/A
- Misc: Visual inspection of pds-copytext component

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR