### PR TITLE
fix(pds-modal) Escape key dismisses modal even when backdropDismiss is false

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -32,7 +32,7 @@ export namespace Components {
      */
     interface MockPdsModal {
         /**
-          * Whether the modal can be dismissed by clicking the backdrop
+          * Whether the modal can be dismissed by clicking the backdrop or pressing Escape
           * @default true
          */
         "backdropDismiss": boolean;
@@ -2734,7 +2734,7 @@ declare namespace LocalJSX {
      */
     interface MockPdsModal {
         /**
-          * Whether the modal can be dismissed by clicking the backdrop
+          * Whether the modal can be dismissed by clicking the backdrop or pressing Escape
           * @default true
          */
         "backdropDismiss"?: boolean;

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -336,7 +336,7 @@ The standard modal with a header, content area, and footer. By default, it can b
       if (modal) modal.open = true;
     }}>Open Modal</pds-button>
 
-    <pds-modal id="default-modal-1" component-id="default-modal-1" closeOnEsc={true}>
+    <pds-modal id="default-modal-1" component-id="default-modal-1">
       <pds-modal-header>
         <pds-box direction="column" fit padding="md">
           <pds-box
@@ -1467,14 +1467,16 @@ modal.addEventListener('pds-modal-close', () => {
 
 Modals can be configured to close automatically in response to user actions:
 
-- Escape key - Always closes the modal (per accessibility guidelines)
-- `backdropDismiss` (default: `true`) - Allow closing when clicking outside the modal
+- `backdropDismiss` (default: `true`) - Controls whether the modal can be dismissed by clicking outside the modal OR pressing the Escape key
 
 ```html
-<pds-modal backdropDismiss={false}>
+<!-- Non-dismissible modal: backdrop clicks and Escape key are both disabled -->
+<pds-modal backdrop-dismiss="false">
   <!-- Modal content that can only be closed via explicit button clicks -->
 </pds-modal>
 ```
+
+> **Note:** While WAI-ARIA guidelines recommend Escape-to-close for standard modals, setting `backdrop-dismiss="false"` disables this for use cases requiring explicit user action (e.g., required onboarding flows, critical confirmations). Ensure users have a clear, accessible path to complete the required action.
 
 ## Playground
 

--- a/libs/core/src/components/pds-modal/pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/pds-modal.tsx
@@ -255,9 +255,10 @@ export class PdsModal {
 
     // Handle Escape key to close the modal
     if (e.key === 'Escape') {
-      // Only close if this is the innermost modal
-      if (this.isInnermostModal()) {
-        e.preventDefault();
+      // Always prevent native dialog close behavior
+      e.preventDefault();
+      // Only close if backdropDismiss is enabled and this is the innermost modal
+      if (this.backdropDismiss && this.isInnermostModal()) {
         this.hideModal();
       }
       return;

--- a/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
+++ b/libs/core/src/components/pds-modal/test/mock-pds-modal.tsx
@@ -38,11 +38,9 @@ export class MockPdsModal {
   @Prop() scrollable = true;
 
   /**
-   * Whether the modal can be dismissed by clicking the backdrop
+   * Whether the modal can be dismissed by clicking the backdrop or pressing Escape
    */
   @Prop() backdropDismiss = true;
-
-  // Native dialog element always closes on Escape key press, so no closeOnEsc property is needed
 
   /**
    * Whether the modal is open
@@ -99,12 +97,17 @@ export class MockPdsModal {
 
   /**
    * Listen for keydown events to handle Escape key
-   * Native dialog element always closes on Escape key press
+   * Should only close on Escape if backdropDismiss is enabled
    */
   // Using direct method instead of @Listen to avoid ESLint warning
   handleKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape' && this.open === true) {
-      this.hideModal();
+      // Always prevent default to mirror native dialog behavior blocking
+      event.preventDefault();
+      // Only close if backdropDismiss is enabled
+      if (this.backdropDismiss === true) {
+        this.hideModal();
+      }
     }
   }
 

--- a/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
+++ b/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
@@ -167,6 +167,8 @@ describe('pds-modal', () => {
     const mockEvent = { key: 'Escape', preventDefault: jest.fn() } as unknown as KeyboardEvent;
     page.rootInstance.handleKeyDown(mockEvent);
 
+    // Should prevent default browser behavior
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
     // Modal should be closed
     expect(page.rootInstance.open).toBe(false);
   });
@@ -185,6 +187,8 @@ describe('pds-modal', () => {
     const mockEvent = { key: 'Escape', preventDefault: jest.fn() } as unknown as KeyboardEvent;
     page.rootInstance.handleKeyDown(mockEvent);
 
+    // Should still prevent default browser behavior even when not closing
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
     // Modal should still be open
     expect(page.rootInstance.open).toBe(true);
   });

--- a/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
+++ b/libs/core/src/components/pds-modal/test/pds-modal.spec.tsx
@@ -69,23 +69,6 @@ describe('pds-modal', () => {
     expect(page.root?.getAttribute('backdrop-dismiss')).toBe('false');
   });
 
-  it('should have the correct closeOnEsc attribute', async () => {
-    // Default value should be true
-    const defaultPage = await newSpecPage({
-      components: [MockPdsModal],
-      html: `<mock-pds-modal></mock-pds-modal>`,
-    });
-    expect(defaultPage.root?.getAttribute('close-on-esc')).toBeNull(); // Default value is not set as attribute
-
-    // Explicit false value
-    const page = await newSpecPage({
-      components: [MockPdsModal],
-      html: `<mock-pds-modal close-on-esc="false"></pds-modal>`,
-    });
-
-    expect(page.root?.getAttribute('close-on-esc')).toBe('false');
-  });
-
   it('should have the correct open attribute', async () => {
     // Default value should be false
     const defaultPage = await newSpecPage({
@@ -170,7 +153,7 @@ describe('pds-modal', () => {
     expect(page.rootInstance.open).toBe(true);
   });
 
-  it('should close on Escape key press (native dialog behavior)', async () => {
+  it('should close on Escape key press when backdropDismiss is true (default)', async () => {
     const page = await newSpecPage({
       components: [MockPdsModal],
       html: `<mock-pds-modal></mock-pds-modal>`,
@@ -181,10 +164,28 @@ describe('pds-modal', () => {
     await page.waitForChanges();
 
     // Directly call the handler method with a mocked event
-    const mockEvent = { key: 'Escape' } as KeyboardEvent;
+    const mockEvent = { key: 'Escape', preventDefault: jest.fn() } as unknown as KeyboardEvent;
     page.rootInstance.handleKeyDown(mockEvent);
 
     // Modal should be closed
     expect(page.rootInstance.open).toBe(false);
+  });
+
+  it('should not close on Escape key press when backdropDismiss is false', async () => {
+    const page = await newSpecPage({
+      components: [MockPdsModal],
+      html: `<mock-pds-modal backdrop-dismiss="false"></mock-pds-modal>`,
+    });
+
+    // Open the modal
+    page.rootInstance.open = true;
+    await page.waitForChanges();
+
+    // Directly call the handler method with a mocked event
+    const mockEvent = { key: 'Escape', preventDefault: jest.fn() } as unknown as KeyboardEvent;
+    page.rootInstance.handleKeyDown(mockEvent);
+
+    // Modal should still be open
+    expect(page.rootInstance.open).toBe(true);
   });
 });

--- a/libs/core/src/components/pds-modal/test/readme.md
+++ b/libs/core/src/components/pds-modal/test/readme.md
@@ -12,13 +12,13 @@ This component mimics the real PdsModal but without using the Popover API
 
 ## Properties
 
-| Property          | Attribute          | Description                                                 | Type                                   | Default     |
-| ----------------- | ------------------ | ----------------------------------------------------------- | -------------------------------------- | ----------- |
-| `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop | `boolean`                              | `true`      |
-| `componentId`     | `component-id`     | The ID of the modal component                               | `string`                               | `undefined` |
-| `open`            | `open`             | Whether the modal is open                                   | `boolean`                              | `false`     |
-| `scrollable`      | `scrollable`       | Whether the modal content should be scrollable              | `boolean`                              | `true`      |
-| `size`            | `size`             | The size of the modal                                       | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
+| Property          | Attribute          | Description                                                                    | Type                                   | Default     |
+| ----------------- | ------------------ | ------------------------------------------------------------------------------ | -------------------------------------- | ----------- |
+| `backdropDismiss` | `backdrop-dismiss` | Whether the modal can be dismissed by clicking the backdrop or pressing Escape | `boolean`                              | `true`      |
+| `componentId`     | `component-id`     | The ID of the modal component                                                  | `string`                               | `undefined` |
+| `open`            | `open`             | Whether the modal is open                                                      | `boolean`                              | `false`     |
+| `scrollable`      | `scrollable`       | Whether the modal content should be scrollable                                 | `boolean`                              | `true`      |
+| `size`            | `size`             | The size of the modal                                                          | `"fullscreen" \| "lg" \| "md" \| "sm"` | `'md'`      |
 
 
 ## Events


### PR DESCRIPTION
# Description

Fixes an issue where the Escape key could still dismiss a `pds-modal` even when `backdropDismiss` was set to `false`.

**Root cause:** The native `<dialog>` element has built-in Escape-to-close behavior. The previous implementation only called `e.preventDefault()` when `backdropDismiss` was `true`, allowing the browser's native behavior to bypass our logic when set to `false`.

**Solution:** Always call `e.preventDefault()` when Escape is pressed on an open modal, then conditionally call `hideModal()` based on the `backdropDismiss` prop.

Fixes DSS-63

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR