### PR TITLE
style(form-inputs): align error icon with top of multi-line messages

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -306,10 +306,13 @@
 }
 
 .pds-input__error-message {
-  align-items: center;
   color: var(--pds-input-error-color);
   display: flex;
   gap: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-025);
+  }
 }
 
 .visually-hidden {

--- a/libs/core/src/components/pds-radio-group/pds-radio-group.scss
+++ b/libs/core/src/components/pds-radio-group/pds-radio-group.scss
@@ -39,8 +39,11 @@
 }
 
 .pds-radio-group__message--error {
-  align-items: center;
   display: flex;
   gap: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-050);
+  }
 }
 

--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -194,9 +194,12 @@ label:has(input:disabled) {
 }
 
 .pds-radio__message--error {
-  align-items: center;
   display: flex;
   gap: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-025);
+  }
 }
 
 // Image-based radio styles - matches bordered layout

--- a/libs/core/src/components/pds-select/pds-select.scss
+++ b/libs/core/src/components/pds-select/pds-select.scss
@@ -148,10 +148,13 @@ select {
 }
 
 .pds-select__error-message {
-  align-items: center;
   color: var(--pine-color-text-message-danger);
   display: flex;
   gap: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-025);
+  }
 }
 
 .pds-select__message {

--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -66,12 +66,15 @@ label {
 }
 
 .pds-textarea__error-message {
-  align-items: center;
   color: var(--pine-color-text-message-danger);
   display: flex;
   font: var(--pine-typography-body-sm-medium);
   gap: var(--pine-dimension-2xs);
   margin-block-start: var(--pine-dimension-2xs);
+
+  pds-icon {
+    margin-block-start: var(--pine-dimension-025);
+  }
 }
 
 .pds-textarea__field-wrapper {


### PR DESCRIPTION
# Description

Fixed vertical alignment of error icons in form input components. When validation error messages span multiple lines, the error icon was vertically centered relative to the entire text block, causing visual misalignment. The icon now aligns with the top/start of the error text for consistent visual layout.

This change follows the existing pattern already established in `pds-checkbox` and `pds-switch` components, where the icon uses a top margin instead of vertical centering.

Fixes DSS-66

**Components updated:**
- `pds-input`
- `pds-textarea`
- `pds-select`
- `pds-radio-group` (uses larger margin due to larger text size)
- `pds-radio`

No new dependencies or updates required.

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="525" height="140" alt="Screenshot 2026-01-08 at 5 07 45 PM" src="https://github.com/user-attachments/assets/14c02f97-8668-4592-beee-9c556ea4be75" />|<img width="474" height="116" alt="Screenshot 2026-01-08 at 5 08 36 PM" src="https://github.com/user-attachments/assets/71d6e33d-2179-4c2f-9454-cb8a4bc6333b" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: Latest
- OS: macOS
- Browsers: Chrome, Safari, Firefox
- Screen readers: N/A
- Misc: Tested with multi-line error messages in Storybook

**Manual Testing:**
- Verified error icon alignment with single-line error messages
- Verified error icon alignment with multi-line error messages
- Confirmed visual consistency across all updated components
- Verified radio-group uses appropriate margin for larger text

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR