### PR TITLE
style(pds-dropdown-menu-item): adjust link styles for improved clickable area

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
@@ -75,7 +75,8 @@ pds-link::part(link):focus-visible {
 
 pds-link::part(link) {
   display: block;
-  margin-inline: calc(var(--pine-dimension-xs) * -1);
-  padding-inline: var(--pine-dimension-xs);
-  width: 100%
+  margin: calc(var(--pine-dimension-xs) * -1);
+  padding: var(--pine-dimension-xs);
+  text-decoration: none;
+  width: calc(100% + var(--pine-dimension-xs) * 2);
 }


### PR DESCRIPTION
# Description

When `pds-dropdown-menu-item` has an `href`, the inner link's clickable area didn't include the item's padding, making the hit target smaller than the visual hover state. This updates the link styling to fill the entire menu item area and removes the default underline to match design spec.

Fixes DSS-68

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

When hovering a menu-item with link, verify the full area is clickable

**Test Configuration**:

- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR