### PR TITLE
fix: update release-info.json to remove template typo for version

### DIFF
--- a/.github/workflows/slack_payloads/release-info.json
+++ b/.github/workflows/slack_payloads/release-info.json
@@ -4,7 +4,7 @@
 			"type": "header",
 			"text": {
 				"type": "plain_text",
-				"text": ":pine:  Pine Release v${{ env.VERSION }} :pine:"
+				"text": ":pine:  Pine Release ${{ env.VERSION }} :pine:"
 			}
 		},
 		{


### PR DESCRIPTION
# Description

Fixes a typo in the Slack release notification that was causing the version to display with a double "v" prefix (e.g., "Pine Release vv3.13.0" instead of "Pine Release v3.13.0").

The issue occurred because:
1. The `VERSION` environment variable is set from `git describe --tags --abbrev=0`, which returns the full tag name including the `v` prefix (e.g., `v3.13.0`)
2. The Slack payload template was adding an additional `v` before the `${{ env.VERSION }}` variable

This PR removes the redundant `v` from the Slack payload template.

Fixes DSS-69

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

Verified by reviewing the template logic and confirming that `git describe --tags --abbrev=0` returns tags with the `v` prefix included.

**Test Configuration**:

- Pine versions: N/A (CI/CD change only)
- OS: N/A
- Browsers: N/A
- Screen readers: N/A
- Misc: GitHub Actions workflow

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
