### PR TITLE
fix(pds-table): add default sorting props

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1706,6 +1706,15 @@ export namespace Components {
          */
         "componentId": string;
         /**
+          * The name of the column to sort by on initial load. Must match the text content of a sortable column header.
+         */
+        "defaultSortColumn"?: string;
+        /**
+          * The direction to sort the default column on initial load. Only applies if `defaultSortColumn` is set.
+          * @defaultValue 'asc'
+         */
+        "defaultSortDirection"?: 'asc' | 'desc';
+        /**
           * Determines if the should display a fixed first column.
          */
         "fixedColumn": boolean;
@@ -1761,6 +1770,11 @@ export namespace Components {
           * Sets the text alignment within the head cell.
          */
         "cellAlign"?: 'start' | 'center' | 'end' | 'justify';
+        /**
+          * Programmatically sets this column as the active sort column with the specified direction. Used by pds-table to apply a default sort on initial load.
+          * @param direction - The sort direction to apply ('asc' or 'desc')
+         */
+        "setActiveSort": (direction: "asc" | "desc") => Promise<void>;
         /**
           * Determines whether the table column is sortable when set to `true`.
          */
@@ -4478,6 +4492,15 @@ declare namespace LocalJSX {
           * A unique identifier used for the table `id` attribute.
          */
         "componentId": string;
+        /**
+          * The name of the column to sort by on initial load. Must match the text content of a sortable column header.
+         */
+        "defaultSortColumn"?: string;
+        /**
+          * The direction to sort the default column on initial load. Only applies if `defaultSortColumn` is set.
+          * @defaultValue 'asc'
+         */
+        "defaultSortDirection"?: 'asc' | 'desc';
         /**
           * Determines if the should display a fixed first column.
          */

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -1136,7 +1136,16 @@ In cases where the default sorting functionality is not suitable, it is possible
 
 ### Preventing built-in sorting
 
-If you need full control over the rendered rows (for example, remote sorting), prevent the table from mutating the DOM by intercepting the event during the capture phase.
+If you need full control over the rendered rows (for example, server-side sorting), call `event.preventDefault()` on the `pdsTableSort` event to prevent the table from reordering the DOM.
+
+```javascript
+document.addEventListener('pdsTableSort', (event) => {
+  event.preventDefault();
+
+  const { column, direction } = event.detail;
+  // Handle sorting via server request, state management, etc.
+});
+```
 
 <DocCanvas mdxSource={{
   react: `<PdsTable componentId="sortable" selectable={true}>

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -1319,6 +1319,116 @@ If you need full control over the rendered rows (for example, remote sorting), p
 </pds-table>
 </DocCanvas>
 
+### Default Sort
+
+To display the table with a pre-sorted column on initial load, use the `defaultSortColumn` and `defaultSortDirection` properties. The `defaultSortColumn` value must match the text content of a sortable column header exactly.
+
+<DocCanvas mdxSource={{
+  react: `<PdsTable componentId="default-sort" defaultSortColumn="Name" defaultSortDirection="desc">
+  <PdsTableHead>
+    <PdsTableHeadCell sortable={true}>Name</PdsTableHeadCell>
+    <PdsTableHeadCell sortable={true}>Email</PdsTableHeadCell>
+    <PdsTableHeadCell sortable={true}>Account</PdsTableHeadCell>
+  </PdsTableHead>
+  <PdsTableBody>
+    <PdsTableRow>
+      <PdsTableCell>John Doe</PdsTableCell>
+      <PdsTableCell>john.doe@example.com</PdsTableCell>
+      <PdsTableCell>47321</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>Jane Smith</PdsTableCell>
+      <PdsTableCell>jane.smith@example.com</PdsTableCell>
+      <PdsTableCell>89654</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>Michael Johnson</PdsTableCell>
+      <PdsTableCell>michael.johnson@example.com</PdsTableCell>
+      <PdsTableCell>21578</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>Susan Brown</PdsTableCell>
+      <PdsTableCell>susan.brown@example.com</PdsTableCell>
+      <PdsTableCell>63920</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>William Davis</PdsTableCell>
+      <PdsTableCell>william.davis@example.com</PdsTableCell>
+      <PdsTableCell>17436</PdsTableCell>
+    </PdsTableRow>
+  </PdsTableBody>
+</PdsTable>`,
+  webComponent: `<pds-table component-id="default-sort" default-sort-column="Name" default-sort-direction="desc">
+  <pds-table-head>
+    <pds-table-head-cell sortable>Name</pds-table-head-cell>
+    <pds-table-head-cell sortable>Email</pds-table-head-cell>
+    <pds-table-head-cell sortable>Account</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell>John Doe</pds-table-cell>
+      <pds-table-cell>john.doe@example.com</pds-table-cell>
+      <pds-table-cell>47321</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Jane Smith</pds-table-cell>
+      <pds-table-cell>jane.smith@example.com</pds-table-cell>
+      <pds-table-cell>89654</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Michael Johnson</pds-table-cell>
+      <pds-table-cell>michael.johnson@example.com</pds-table-cell>
+      <pds-table-cell>21578</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Susan Brown</pds-table-cell>
+      <pds-table-cell>susan.brown@example.com</pds-table-cell>
+      <pds-table-cell>63920</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>William Davis</pds-table-cell>
+      <pds-table-cell>william.davis@example.com</pds-table-cell>
+      <pds-table-cell>17436</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>
+`}}>
+<pds-table component-id="default-sort" default-sort-column="Name" default-sort-direction="desc">
+  <pds-table-head>
+    <pds-table-head-cell sortable>Name</pds-table-head-cell>
+    <pds-table-head-cell sortable>Email</pds-table-head-cell>
+    <pds-table-head-cell sortable>Account</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell>John Doe</pds-table-cell>
+      <pds-table-cell>john.doe@example.com</pds-table-cell>
+      <pds-table-cell>47321</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Jane Smith</pds-table-cell>
+      <pds-table-cell>jane.smith@example.com</pds-table-cell>
+      <pds-table-cell>89654</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Michael Johnson</pds-table-cell>
+      <pds-table-cell>michael.johnson@example.com</pds-table-cell>
+      <pds-table-cell>21578</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Susan Brown</pds-table-cell>
+      <pds-table-cell>susan.brown@example.com</pds-table-cell>
+      <pds-table-cell>63920</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>William Davis</pds-table-cell>
+      <pds-table-cell>william.davis@example.com</pds-table-cell>
+      <pds-table-cell>17436</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>
+</DocCanvas>
+
 ## Additional Resources
 
 [MDN: Table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Host, Prop, h, Event, EventEmitter, State } from '@stencil/core';
+import { Component, Element, Host, Prop, h, Event, EventEmitter, State, Method } from '@stencil/core';
 
 import { downSmall, upSmall } from '@pine-ds/icons/icons';
 
@@ -58,6 +58,17 @@ export class PdsTableHeadCell {
    * @defaultValue false
    */
   @State() private hasHeadBackground: boolean = false;
+
+  /**
+   * Programmatically sets this column as the active sort column with the specified direction.
+   * Used by pds-table to apply a default sort on initial load.
+   * @param direction - The sort direction to apply ('asc' or 'desc')
+   */
+  @Method()
+  async setActiveSort(direction: 'asc' | 'desc') {
+    this.sortingDirection = direction;
+    this.hostElement.classList.add('is-active');
+  }
 
   componentWillLoad() {
     // Set initial references and state before first render

--- a/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/pds-table-head-cell.tsx
@@ -66,6 +66,8 @@ export class PdsTableHeadCell {
    */
   @Method()
   async setActiveSort(direction: 'asc' | 'desc') {
+    if (!this.sortable) return;
+
     this.sortingDirection = direction;
     this.hostElement.classList.add('is-active');
   }

--- a/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
@@ -20,6 +20,26 @@
 | `pdsTableSort` | Event emitted to signal that a table column header has been sorted, providing information about the sorted column's name and sorting direction. | `CustomEvent<{ column: string; direction: string; }>` |
 
 
+## Methods
+
+### `setActiveSort(direction: "asc" | "desc") => Promise<void>`
+
+Programmatically sets this column as the active sort column with the specified direction.
+Used by pds-table to apply a default sort on initial load.
+
+#### Parameters
+
+| Name        | Type              | Description                                     |
+| ----------- | ----------------- | ----------------------------------------------- |
+| `direction` | `"desc" \| "asc"` | - The sort direction to apply ('asc' or 'desc') |
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Shadow Parts
 
 | Part          | Description |

--- a/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
@@ -31,7 +31,7 @@ Used by pds-table to apply a default sort on initial load.
 
 | Name        | Type              | Description                                     |
 | ----------- | ----------------- | ----------------------------------------------- |
-| `direction` | `"asc" \| "desc"` | - The sort direction to apply ('asc' or 'desc') |
+| `direction` | `"desc" \| "asc"` | - The sort direction to apply ('asc' or 'desc') |
 
 #### Returns
 

--- a/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/readme.md
@@ -31,7 +31,7 @@ Used by pds-table to apply a default sort on initial load.
 
 | Name        | Type              | Description                                     |
 | ----------- | ----------------- | ----------------------------------------------- |
-| `direction` | `"desc" \| "asc"` | - The sort direction to apply ('asc' or 'desc') |
+| `direction` | `"asc" \| "desc"` | - The sort direction to apply ('asc' or 'desc') |
 
 #### Returns
 

--- a/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
@@ -437,4 +437,42 @@ describe('pds-table-head-cell', () => {
 
     expect(true).toBe(true);
   });
+
+  it('sets active sort state via setActiveSort method', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell, PdsTable],
+      html: `<pds-table><pds-table-head-cell sortable>Column</pds-table-head-cell></pds-table>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as any;
+
+    // Initially should have sort-asc class (default) and no is-active
+    expect(tableHeadCell).toHaveClass('sort-asc');
+    expect(tableHeadCell).not.toHaveClass('is-active');
+
+    // Call setActiveSort with 'desc'
+    await tableHeadCell.setActiveSort('desc');
+    await page.waitForChanges();
+
+    // Should now have is-active class and sort-desc class
+    expect(tableHeadCell).toHaveClass('is-active');
+    expect(tableHeadCell).toHaveClass('sort-desc');
+  });
+
+  it('sets active sort state to asc via setActiveSort method', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell, PdsTable],
+      html: `<pds-table><pds-table-head-cell sortable>Column</pds-table-head-cell></pds-table>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as any;
+
+    // Call setActiveSort with 'asc'
+    await tableHeadCell.setActiveSort('asc');
+    await page.waitForChanges();
+
+    // Should have is-active class and sort-asc class
+    expect(tableHeadCell).toHaveClass('is-active');
+    expect(tableHeadCell).toHaveClass('sort-asc');
+  });
 });

--- a/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head-cell/test/pds-table-head-cell.spec.tsx
@@ -475,4 +475,20 @@ describe('pds-table-head-cell', () => {
     expect(tableHeadCell).toHaveClass('is-active');
     expect(tableHeadCell).toHaveClass('sort-asc');
   });
+
+  it('does not set active sort state on non-sortable column', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHeadCell, PdsTable],
+      html: `<pds-table><pds-table-head-cell>Column</pds-table-head-cell></pds-table>`,
+    });
+
+    const tableHeadCell = page.body.querySelector('pds-table-head-cell') as any;
+
+    // Call setActiveSort on non-sortable column
+    await tableHeadCell.setActiveSort('desc');
+    await page.waitForChanges();
+
+    // Should not have is-active class
+    expect(tableHeadCell).not.toHaveClass('is-active');
+  });
 });

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -45,6 +45,19 @@ export class PdsTable {
   @Prop({ reflect: true }) rowDividers: boolean = false;
 
   /**
+   * The name of the column to sort by on initial load.
+   * Must match the text content of a sortable column header.
+   */
+  @Prop() defaultSortColumn?: string;
+
+  /**
+   * The direction to sort the default column on initial load.
+   * Only applies if `defaultSortColumn` is set.
+   * @defaultValue 'asc'
+   */
+  @Prop() defaultSortDirection?: 'asc' | 'desc' = 'asc';
+
+  /**
    * The name of the column being sorted.
    * @defaultValue null
    */
@@ -67,13 +80,45 @@ export class PdsTable {
    */
   @Event() pdsTableSelectAll: EventEmitter<{ isSelected: boolean }>;
 
-  componentWillLoad() {
-    this.sortingColumn = null;
-  }
-
   componentDidLoad() {
     if (this.responsive) {
       this.setupResponsiveScrolling();
+    }
+
+    // Apply default sort if specified
+    if (this.defaultSortColumn) {
+      this.applyDefaultSort();
+    }
+  }
+
+  /**
+   * Applies the default sort configuration on initial load.
+   * Finds the matching column header and activates its sort state.
+   * @private
+   */
+  private async applyDefaultSort() {
+    const direction = this.defaultSortDirection || 'asc';
+
+    // Find the matching sortable header cell
+    const columnHeaderCells = Array.from(
+      this.el.querySelectorAll('pds-table-head-cell[sortable]')
+    ) as HTMLElement[];
+
+    const matchingCell = columnHeaderCells.find(
+      (cell) => cell.innerText.trim() === this.defaultSortColumn
+    );
+
+    if (matchingCell) {
+      // Sort the table data
+      this.sortTable(this.defaultSortColumn, direction);
+      this.sortingColumn = this.defaultSortColumn;
+      this.sortingDirection = direction;
+
+      // Activate the visual state on the header cell
+      // Type assertion needed as setActiveSort is added via @Method() decorator
+      await (matchingCell as HTMLPdsTableHeadCellElement & { setActiveSort: (direction: 'asc' | 'desc') => Promise<void> }).setActiveSort(direction);
+    } else {
+      console.warn(`Default sort column "${this.defaultSortColumn}" not found.`);
     }
   }
 

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -97,7 +97,7 @@ export class PdsTable {
    * @private
    */
   private async applyDefaultSort() {
-    const direction = this.defaultSortDirection || 'asc';
+    const direction = this.defaultSortDirection;
 
     // Find the matching sortable header cell
     const columnHeaderCells = Array.from(
@@ -238,6 +238,9 @@ export class PdsTable {
 
   private sortTable(column: string, direction: 'asc' | 'desc') {
     const tableBody = this.el.querySelector('pds-table-body');
+
+    // Return early if no table body exists
+    if (!tableBody) return;
 
     // Get the rows in the table body
     const tableRows = Array.from(tableBody.querySelectorAll('pds-table-row'));

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -112,9 +112,10 @@ export class PdsTable {
     );
 
     if (matchingCell) {
+      const columnName = (matchingCell.textContent ?? '').trim();
       // Sort the table data
-      this.sortTable(this.defaultSortColumn, direction);
-      this.sortingColumn = this.defaultSortColumn;
+      this.sortTable(columnName, direction);
+      this.sortingColumn = columnName;
       this.sortingDirection = direction;
 
       // Activate the visual state on the header cell

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -285,6 +285,8 @@ export class PdsTable {
 
   @Listen('pdsTableSort')
   handleTableSort(event: CustomEvent<{ column: string; direction: 'asc' | 'desc' }>) {
+    if (event.defaultPrevented) return;
+
     const { direction } = event.detail;
     this.sortTable(event.detail.column, direction);
     this.sortingColumn = event.detail.column;

--- a/libs/core/src/components/pds-table/readme.md
+++ b/libs/core/src/components/pds-table/readme.md
@@ -7,14 +7,16 @@
 
 ## Properties
 
-| Property                   | Attribute      | Description                                                                          | Type      | Default     |
-| -------------------------- | -------------- | ------------------------------------------------------------------------------------ | --------- | ----------- |
-| `compact`                  | `compact`      | Determines if the table displays with reduced table cell padding.                    | `boolean` | `undefined` |
-| `componentId` _(required)_ | `component-id` | A unique identifier used for the table `id` attribute.                               | `string`  | `undefined` |
-| `fixedColumn`              | `fixed-column` | Determines if the should display a fixed first column.                               | `boolean` | `undefined` |
-| `responsive`               | `responsive`   | Enables the table to be responsive by horizontally scrolling on smaller screens.     | `boolean` | `undefined` |
-| `rowDividers`              | `row-dividers` | Adds divider borders between table rows. The last row will not have a bottom border. | `boolean` | `false`     |
-| `selectable`               | `selectable`   | Determines if the table displays checkboxes for selectable rows.                     | `boolean` | `undefined` |
+| Property                   | Attribute                | Description                                                                                                 | Type              | Default     |
+| -------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------- | ----------------- | ----------- |
+| `compact`                  | `compact`                | Determines if the table displays with reduced table cell padding.                                           | `boolean`         | `undefined` |
+| `componentId` _(required)_ | `component-id`           | A unique identifier used for the table `id` attribute.                                                      | `string`          | `undefined` |
+| `defaultSortColumn`        | `default-sort-column`    | The name of the column to sort by on initial load. Must match the text content of a sortable column header. | `string`          | `undefined` |
+| `defaultSortDirection`     | `default-sort-direction` | The direction to sort the default column on initial load. Only applies if `defaultSortColumn` is set.       | `"asc" \| "desc"` | `'asc'`     |
+| `fixedColumn`              | `fixed-column`           | Determines if the should display a fixed first column.                                                      | `boolean`         | `undefined` |
+| `responsive`               | `responsive`             | Enables the table to be responsive by horizontally scrolling on smaller screens.                            | `boolean`         | `undefined` |
+| `rowDividers`              | `row-dividers`           | Adds divider borders between table rows. The last row will not have a bottom border.                        | `boolean`         | `false`     |
+| `selectable`               | `selectable`             | Determines if the table displays checkboxes for selectable rows.                                            | `boolean`         | `undefined` |
 
 
 ## Events

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -24,6 +24,21 @@ export default {
       control: { type: 'boolean' },
       description: 'Adds divider borders between table rows. The last row will not have a bottom border',
     },
+    defaultSortColumn: {
+      control: { type: 'text' },
+      description: 'The name of the column to sort by on initial load. Must match the text content of a sortable column header.',
+      table: {
+        category: 'Sorting',
+      },
+    },
+    defaultSortDirection: {
+      control: { type: 'select' },
+      options: ['asc', 'desc'],
+      description: 'The direction to sort the default column on initial load.',
+      table: {
+        category: 'Sorting',
+      },
+    },
   },
 };
 
@@ -236,6 +251,54 @@ const SortableTemplate = (args) => html`
   </pds-table-body>
 </pds-table>`;
 
+const DefaultSortTemplate = (args) => html`
+<pds-table
+  ?compact=${args.compact}
+  component-id="${args.componentId}"
+  ?fixed-column=${args.fixedColumn}
+  ?responsive=${args.responsive}
+  ?row-dividers=${args.rowDividers}
+  ?selectable=${args.selectable}
+  default-sort-column="${args.defaultSortColumn}"
+  default-sort-direction="${args.defaultSortDirection}"
+>
+  <pds-table-head
+    ?border=${args.border}
+    ?background=${args.background}
+  >
+    <pds-table-head-cell sortable>Name</pds-table-head-cell>
+    <pds-table-head-cell sortable>Email</pds-table-head-cell>
+    <pds-table-head-cell sortable>Account</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell>John Doe</pds-table-cell>
+      <pds-table-cell>john.doe@example.com</pds-table-cell>
+      <pds-table-cell>47321</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Jane Smith</pds-table-cell>
+      <pds-table-cell>jane.smith@example.com</pds-table-cell>
+      <pds-table-cell>89654</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Michael Johnson</pds-table-cell>
+      <pds-table-cell>michael.johnson@example.com</pds-table-cell>
+      <pds-table-cell>21578</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Susan Brown</pds-table-cell>
+      <pds-table-cell>susan.brown@example.com</pds-table-cell>
+      <pds-table-cell>63920</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>William Davis</pds-table-cell>
+      <pds-table-cell>william.davis@example.com</pds-table-cell>
+      <pds-table-cell>17436</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>`;
+
 export const Default = BaseTemplate.bind();
 Default.args = {
   compact: false,
@@ -319,6 +382,20 @@ Sortable.args = {
   rowDividers: false,
   selectable: false,
   sortable: true,
+};
+
+export const DefaultSorting = DefaultSortTemplate.bind();
+DefaultSorting.args = {
+  compact: false,
+  componentId: 'default-sort',
+  fixedColumn: false,
+  border: false,
+  background: false,
+  responsive: false,
+  rowDividers: false,
+  selectable: false,
+  defaultSortColumn: 'Name',
+  defaultSortDirection: 'desc',
 };
 
 export const RowDividers = BaseTemplate.bind();

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -491,4 +491,23 @@ describe('pds-table', () => {
     // Should remain in original order (unsorted)
     expect(values).toEqual(['Charlie', 'Alice', 'Bob']);
   });
+
+  it('does not crash when sorting a table without a body', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell],
+      html: `
+        <pds-table component-id="no-body-test" default-sort-column="Name">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+          </pds-table-head>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    // Should not throw and header should still be marked active
+    const headCell = page.body.querySelector('pds-table-head-cell');
+    expect(headCell).toHaveClass('is-active');
+  });
 });

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -328,4 +328,167 @@ describe('pds-table', () => {
       expect(row.isSelected).toBeUndefined();
     });
   });
+
+  it('applies default sort in ascending order on initial load', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="default-sort-test" default-sort-column="Name">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+            <pds-table-head-cell sortable>Email</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Charlie</pds-table-cell>
+              <pds-table-cell>charlie@example.com</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Alice</pds-table-cell>
+              <pds-table-cell>alice@example.com</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Bob</pds-table-cell>
+              <pds-table-cell>bob@example.com</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
+    const rows = Array.from(tableBody.querySelectorAll('pds-table-row')) as any;
+    const values = rows.map((row) => row.querySelector('pds-table-cell').textContent?.trim());
+
+    // Should be sorted in ascending order by default
+    expect(values).toEqual(['Alice', 'Bob', 'Charlie']);
+  });
+
+  it('applies default sort in descending order when defaultSortDirection is desc', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="default-sort-desc-test" default-sort-column="Name" default-sort-direction="desc">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+            <pds-table-head-cell sortable>Email</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Alice</pds-table-cell>
+              <pds-table-cell>alice@example.com</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Charlie</pds-table-cell>
+              <pds-table-cell>charlie@example.com</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Bob</pds-table-cell>
+              <pds-table-cell>bob@example.com</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
+    const rows = Array.from(tableBody.querySelectorAll('pds-table-row')) as any;
+    const values = rows.map((row) => row.querySelector('pds-table-cell').textContent?.trim());
+
+    // Should be sorted in descending order
+    expect(values).toEqual(['Charlie', 'Bob', 'Alice']);
+  });
+
+  it('marks the correct header cell as active when default sort is applied', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="default-sort-active-test" default-sort-column="Name" default-sort-direction="desc">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+            <pds-table-head-cell sortable>Email</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Alice</pds-table-cell>
+              <pds-table-cell>alice@example.com</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const headCells = page.body.querySelectorAll('pds-table-head-cell');
+    const nameCell = headCells[0];
+    const emailCell = headCells[1];
+
+    // Name cell should be active
+    expect(nameCell).toHaveClass('is-active');
+    // Email cell should not be active
+    expect(emailCell).not.toHaveClass('is-active');
+  });
+
+  it('logs a warning when default sort column is not found', async () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="default-sort-warning-test" default-sort-column="NonExistent">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Alice</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Default sort column "NonExistent" not found.');
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('does not apply default sort when defaultSortColumn is not set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableHeadCell, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table component-id="no-default-sort-test">
+          <pds-table-head>
+            <pds-table-head-cell sortable>Name</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Charlie</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Alice</pds-table-cell>
+            </pds-table-row>
+            <pds-table-row>
+              <pds-table-cell>Bob</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
+    const rows = Array.from(tableBody.querySelectorAll('pds-table-row')) as any;
+    const values = rows.map((row) => row.querySelector('pds-table-cell').textContent?.trim());
+
+    // Should remain in original order (unsorted)
+    expect(values).toEqual(['Charlie', 'Alice', 'Bob']);
+  });
 });


### PR DESCRIPTION
# Description

Add `defaultSortColumn` and `defaultSortDirection` props to `pds-table` to allow tables to render with a pre-sorted column on initial load.

Fixes DSS-70

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

**Test Configuration**:

- Pine versions: N/A
- OS: macOS
- Browsers: Chrome
- Screen readers: N/A
- Misc: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR