### PR TITLE
ci: add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -1,5 +1,10 @@
 name: "Pine Continuous Deployment"
 
+# Restrict default permissions to read-only for security (principle of least privilege)
+# Jobs that need more permissions (like release) explicitly override this
+permissions:
+  contents: read
+
 on:
   ## We will uncomment this when we settle on a deployment schedule
   # schedule:


### PR DESCRIPTION
# Description

Adds explicit `permissions: contents: read` at the workflow level in `schedule-release.yml` to follow the principle of least privilege. This resolves CodeQL security alert [#16](https://github.com/Kajabi/pine/security/code-scanning/16) by ensuring jobs only have the minimum permissions required.

The `release` job retains its existing explicit permissions (`contents: write`, `id-token: write`) which override the workflow default.

Fixes DSS-72

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

Verified that:
- Workflow YAML syntax is valid
- `release` job permissions are unchanged
- All other jobs receive read-only permissions by default

**Test Configuration**:

- N/A (CI configuration change only)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings