### PR TITLE
fix(pds-dropdown-menu): prevent clipping in overflow containers

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
@@ -12,7 +12,7 @@
   left: var(--pine-dimension-none);
   min-width: 170px;
   padding: var(--pine-dimension-xs);
-  position: absolute;
+  position: fixed;
   z-index: var(--pine-z-index-overlay);
 
   :host-context([data-theme="dark"]) & {

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.tsx
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.tsx
@@ -99,6 +99,7 @@ export class PdsDropdownMenu implements BasePdsProps {
     const updatePosition = () => {
       computePosition(this.triggerEl, this.panelEl as HTMLElement, {
         placement: this.placement,
+        strategy: 'fixed',
         middleware: [offset(6), flip(), shift({padding: 5})],
       }).then(({ x, y }) => {
         Object.assign(this.panelEl.style, {

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -142,7 +142,7 @@ const ResponsiveTemplate = (args) => html`
     <pds-table-head-cell>Column Title</pds-table-head-cell>
     <pds-table-head-cell>Column Title</pds-table-head-cell>
     <pds-table-head-cell>Column Title</pds-table-head-cell>
-    <pds-table-head-cell>Column Title</pds-table-head-cell>
+    <pds-table-head-cell>Actions</pds-table-head-cell>
   </pds-table-head>
   <pds-table-body>
     <pds-table-row value="responsive1">
@@ -157,7 +157,15 @@ const ResponsiveTemplate = (args) => html`
       <pds-table-cell>Row Item Juliett</pds-table-cell>
       <pds-table-cell>Row Item Kilo</pds-table-cell>
       <pds-table-cell>Row Item Lima</pds-table-cell>
-      <pds-table-cell>Row Item Mike</pds-table-cell>
+      <pds-table-cell>
+        <pds-dropdown-menu placement="bottom-end">
+          <pds-button slot="trigger" size="sm" variant="icon-only"><pds-icon name="dot-menu-horizontal"></pds-icon></pds-button>
+          <pds-dropdown-menu-item>Edit</pds-dropdown-menu-item>
+          <pds-dropdown-menu-item>Duplicate</pds-dropdown-menu-item>
+          <pds-dropdown-menu-separator></pds-dropdown-menu-separator>
+          <pds-dropdown-menu-item destructive>Delete</pds-dropdown-menu-item>
+        </pds-dropdown-menu>
+      </pds-table-cell>
     </pds-table-row>
     <pds-table-row value="responsive2">
       <pds-table-cell>Row Item Alpha</pds-table-cell>
@@ -171,7 +179,15 @@ const ResponsiveTemplate = (args) => html`
       <pds-table-cell>Row Item Juliett</pds-table-cell>
       <pds-table-cell>Row Item Kilo</pds-table-cell>
       <pds-table-cell>Row Item Lima</pds-table-cell>
-      <pds-table-cell>Row Item Mike</pds-table-cell>
+      <pds-table-cell>
+        <pds-dropdown-menu placement="bottom-end">
+          <pds-button slot="trigger" size="sm" variant="icon-only"><pds-icon name="dot-menu-horizontal"></pds-icon></pds-button>
+          <pds-dropdown-menu-item>Edit</pds-dropdown-menu-item>
+          <pds-dropdown-menu-item>Duplicate</pds-dropdown-menu-item>
+          <pds-dropdown-menu-separator></pds-dropdown-menu-separator>
+          <pds-dropdown-menu-item destructive>Delete</pds-dropdown-menu-item>
+        </pds-dropdown-menu>
+      </pds-table-cell>
     </pds-table-row>
     <pds-table-row value="responsive3">
       <pds-table-cell>Row Item Alpha</pds-table-cell>
@@ -185,7 +201,15 @@ const ResponsiveTemplate = (args) => html`
       <pds-table-cell>Row Item Juliett</pds-table-cell>
       <pds-table-cell>Row Item Kilo</pds-table-cell>
       <pds-table-cell>Row Item Lima</pds-table-cell>
-      <pds-table-cell>Row Item Mike</pds-table-cell>
+      <pds-table-cell>
+        <pds-dropdown-menu placement="bottom-end">
+          <pds-button slot="trigger" size="sm" variant="icon-only"><pds-icon name="dot-menu-horizontal"></pds-icon></pds-button>
+          <pds-dropdown-menu-item>Edit</pds-dropdown-menu-item>
+          <pds-dropdown-menu-item>Duplicate</pds-dropdown-menu-item>
+          <pds-dropdown-menu-separator></pds-dropdown-menu-separator>
+          <pds-dropdown-menu-item destructive>Delete</pds-dropdown-menu-item>
+        </pds-dropdown-menu>
+      </pds-table-cell>
     </pds-table-row>
   </pds-table-body>
 </pds-table>`;


### PR DESCRIPTION
# Description

Fixes an issue where `pds-dropdown-menu` gets clipped when placed inside containers with `overflow: hidden` (e.g., responsive `pds-table`).

The fix uses Floating UI's `strategy: 'fixed'` option instead of the default `'absolute'` positioning, which allows the dropdown panel to "break out" of clipping ancestors.

Fixes DSS-89

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

**Manual Testing:**
- Verified dropdown appears correctly in responsive tables (no clipping)
- Verified dropdown still works in normal contexts
- Verified `::part(menu-panel)` styling still works
- Verified keyboard navigation still functions

**Test Configuration**:

- Pine versions: 3.14.0
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes