### PR TITLE
chore(pds-box): replace deprecated Sass if() with @if directive

### DIFF
--- a/libs/core/src/components/pds-box/pds-box.mixins.scss
+++ b/libs/core/src/components/pds-box/pds-box.mixins.scss
@@ -1,8 +1,10 @@
 @mixin generate-spacing-classes($directions, $tokens) {
   @each $direction in $directions {
     @each $key, $value in $tokens {
-      /* stylelint-disable-next-line function-no-unknown */
-      $class-name: if($direction, 'pds-spacing-#{$direction}-#{$key}', 'pds-spacing-#{$key}');
+      $class-name: 'pds-spacing-#{$key}';
+      @if $direction {
+        $class-name: 'pds-spacing-#{$direction}-#{$key}';
+      }
       .#{$class-name} {
         @if $direction == 'top' {
           margin-block-start: $value;
@@ -22,8 +24,10 @@
 
 @mixin generate-columns($prefix, $columns) {
   @for $i from 0 through $columns {
-    /* stylelint-disable-next-line function-no-unknown */
-    $class-name: if($prefix, 'pds-box-#{$prefix}-#{$i}', 'pds-box-#{$i}');
+    $class-name: 'pds-box-#{$i}';
+    @if $prefix {
+      $class-name: 'pds-box-#{$prefix}-#{$i}';
+    }
     .#{$class-name} {
       @if $i == 0 {
         display: none;
@@ -38,8 +42,10 @@
 
 @mixin generate-column-offsets($prefix, $columns) {
   @for $i from 0 through $columns {
-    /* stylelint-disable-next-line function-no-unknown */
-    $class-name: if($prefix, 'pds-box-offset-#{$prefix}-#{$i}', 'pds-box-offset-#{$i}');
+    $class-name: 'pds-box-offset-#{$i}';
+    @if $prefix {
+      $class-name: 'pds-box-offset-#{$prefix}-#{$i}';
+    }
     .#{$class-name} {
       @if $i == 0 {
         margin-inline-start: 0;


### PR DESCRIPTION
# Description

Replace deprecated Sass `if()` function with `@if/@else` directives to resolve deprecation warnings when running Storybook.

## Solution

The Sass `if()` function is deprecated in favor of the native CSS `if()` function. To resolve this, the conditional class name assignment was refactored to use `@if/@else` directives instead.

The pattern declares a variable with a default value first, then uses `@if` to conditionally reassign it when a prefix/direction is provided. This produces identical CSS output while avoiding the deprecation warning.

Three mixins were updated in `pds-box.mixins.scss`:
- `generate-spacing-classes` - generates pds-spacing-* utility classes
- `generate-columns` - generates pds-box-* column width classes  
- `generate-column-offsets` - generates pds-box-offset-* classes

Fixes DSS-90

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually
- Verified build passes
- Verified all CSS classes are generated correctly (pds-box-*, pds-box-offset-*, pds-spacing-*)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes