### PR TITLE
style(pds-chip): update default chip padding

### DIFF
--- a/libs/core/src/components/pds-chip/pds-chip.scss
+++ b/libs/core/src/components/pds-chip/pds-chip.scss
@@ -7,7 +7,7 @@
   border-radius: var(--pine-dimension-sm);
   display: inline-flex;
   padding-block: var(--pine-dimension-025);
-  padding-inline: var(--pine-dimension-150);
+  padding-inline: var(--pine-dimension-100);
 }
 
 $pds-chip-sentiment: (
@@ -115,7 +115,7 @@ $pds-chip-sentiment-hover: (
   border-radius: var(--pine-dimension-sm);
   cursor: pointer;
   display: flex;
-  padding: var(--pine-dimension-025) var(--pine-dimension-150);
+  padding: var(--pine-dimension-025) var(--pine-dimension-100);
 
   &:focus-visible {
     outline: var(--pine-outline-focus);
@@ -192,7 +192,7 @@ $pds-chip-sentiment-hover: (
     /* stylelint-disable-next-line pine-design-system/prefer-semantic-tokens */
     color: var(--pine-color-grey-900);
     font-weight: var(--pine-font-weight-medium);
-    padding: var(--pine-dimension-025) var(--pine-dimension-150);
+    padding: var(--pine-dimension-025) var(--pine-dimension-100);
     position: relative;
     z-index: var(--pine-z-index-raised);
 


### PR DESCRIPTION
# Description

Updates the default chip component horizontal padding from 12px to 8px to align with updated Figma designs.

Fixes UX-43

<img width="633" height="320" alt="Screenshot 2026-01-26 at 4 17 32 PM" src="https://github.com/user-attachments/assets/79d571d2-d67e-4e0b-bf46-e2264ecb6e57" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.14.1
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR