### PR TITLE
fix: prevent double-initialization crashes with CDN and React

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -127,7 +127,8 @@ export class PdsCheckbox {
   }
 
   connectedCallback() {
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
 

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -184,8 +184,8 @@ export class PdsCombobox implements BasePdsProps {
   private isUpdatingFromSelection: boolean = false;
 
   connectedCallback() {
-    // Initialize ElementInternals for form association
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
   }

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -308,8 +308,8 @@ export class PdsInput {
   }
 
   connectedCallback() {
-    // Initialize ElementInternals for form association
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
   }

--- a/libs/core/src/components/pds-loader/pds-loader.tsx
+++ b/libs/core/src/components/pds-loader/pds-loader.tsx
@@ -53,7 +53,7 @@ export class PdsLoader {
     }
   }
 
-  private style = () => {
+  private getSvgStyle = () => {
     if (this.size !== undefined) {
       return {
         height: this.loaderSize(),
@@ -67,7 +67,7 @@ export class PdsLoader {
       <Host class={`pds-loader ${this.isLoading ? '' : 'pds-loader--hidden'}`} aria-hidden={!this.isLoading} aria-busy={this.isLoading} aria-live="polite">
         {this.variant === 'spinner' && (
           <div class="pds-loader--spinner">
-            <svg style={this.style()} viewBox="0 0 200 200" fill="none" part="loader-svg">
+            <svg style={this.getSvgStyle()} viewBox="0 0 200 200" fill="none" part="loader-svg">
               <defs>
                 <linearGradient id="spinner-secondHalf">
                   <stop offset="0%" stop-opacity="0" stop-color="currentColor" />

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -176,7 +176,8 @@ export class PdsMultiselect {
   private originalSearchEmitter?: EventEmitter<MultiselectSearchEventDetail>;
 
   connectedCallback() {
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
   }

--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -135,8 +135,8 @@ export class PdsSelect {
   }
 
   connectedCallback() {
-    // Initialize ElementInternals for form association
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
 

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -103,7 +103,8 @@ export class PdsSwitch {
   };
 
   connectedCallback() {
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
 

--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -308,8 +308,8 @@ export class PdsTextarea {
 
   connectedCallback() {
     this.debounceChanged();
-    // Initialize ElementInternals for form association
-    if (this.el.attachInternals) {
+    // Initialize ElementInternals for form association (only once per element instance)
+    if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
   }


### PR DESCRIPTION
## Summary

When both CDN and `@pine-ds/react` are loaded on the same page, components can be initialized twice, causing crashes. This PR makes components resilient to double-initialization.

**Changes:**
- Add `!this.internals` guard before calling `attachInternals()` in 7 form-associated components
- Rename `style()` to `getSvgStyle()` in `pds-loader` to avoid conflict with `HTMLElement.style`

Fixes DSS-94

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

Tested locally in kajabi-products with CDN + @pine-ds/react both loaded. Errors no longer appear and components render correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code