### PR TITLE
style(pds-table-cell): update vertical align styles

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
+++ b/libs/core/src/components/pds-table/pds-table-cell/pds-table-cell.scss
@@ -11,7 +11,7 @@
   letter-spacing: var(--pine-letter-spacing);
   line-height: var(--pine-line-height-body);
   padding: var(--pine-dimension-sm);
-  vertical-align: inherit;
+  vertical-align: middle;
 }
 
 :host(.is-compact) {


### PR DESCRIPTION
# Description
- [x] update `vertical-aligm: middle;` for tables that have an image. Was causing misalignment

Fixes DSS-99

## Type of change

Please delete options that are not relevant.
If your type of change is not present, add that option.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When converting the Offers table, this issue was noticed

| Before | After |
|--------|--------|
|<img width="984" height="352" alt="Screenshot 2026-01-28 at 10 48 32 AM" src="https://github.com/user-attachments/assets/e84eac84-985b-42bc-91e0-32e7b75cb518" />|<img width="976" height="365" alt="Screenshot 2026-01-28 at 10 48 46 AM" src="https://github.com/user-attachments/assets/6b62029b-35f6-4e5a-a5e4-9488dcfbb05d" />|

- [x] tested manually

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
