### PR TITLE
feat(pds-multiselect): add create tag functionality to pds-multiselect

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -11,7 +11,7 @@ import { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-in
 import { ChipSentimentType, ChipVariantType, PlacementType } from "./utils/types";
 import { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 import { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
-import { MultiselectChangeEventDetail, MultiselectLoadOptionsEventDetail, MultiselectOption, MultiselectSearchEventDetail } from "./components/pds-multiselect/multiselect-interface";
+import { MultiselectChangeEventDetail, MultiselectCreateEventDetail, MultiselectLoadOptionsEventDetail, MultiselectOption, MultiselectSearchEventDetail } from "./components/pds-multiselect/multiselect-interface";
 import { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
 import { RadioGroupChangeEventDetail } from "./components/pds-radio-group/radio-group-interface";
 import { SortableEvent } from "sortablejs";
@@ -22,7 +22,7 @@ export { CheckboxChangeEventDetail } from "./components/pds-checkbox/checkbox-in
 export { ChipSentimentType, ChipVariantType, PlacementType } from "./utils/types";
 export { PdsFilterClearEventDetail, PdsFilterCloseEventDetail, PdsFilterOpenEventDetail, PdsFilterVariant } from "./components/pds-filters/pds-filter/filter-interface";
 export { InputChangeEventDetail, InputInputEventDetail } from "./components/pds-input/input-interface";
-export { MultiselectChangeEventDetail, MultiselectLoadOptionsEventDetail, MultiselectOption, MultiselectSearchEventDetail } from "./components/pds-multiselect/multiselect-interface";
+export { MultiselectChangeEventDetail, MultiselectCreateEventDetail, MultiselectLoadOptionsEventDetail, MultiselectOption, MultiselectSearchEventDetail } from "./components/pds-multiselect/multiselect-interface";
 export { PdsPopoverEventDetail } from "./components/pds-popover/popover-interface";
 export { RadioGroupChangeEventDetail } from "./components/pds-radio-group/radio-group-interface";
 export { SortableEvent } from "sortablejs";
@@ -1333,6 +1333,10 @@ export namespace Components {
          */
         "componentId": string;
         /**
+          * URL endpoint for creating new options. When set, shows "Add" option when no matches found.
+         */
+        "createUrl"?: string;
+        /**
           * Debounce delay in milliseconds for search/fetch.
           * @default 300
          */
@@ -2550,6 +2554,7 @@ declare global {
         "pdsMultiselectChange": MultiselectChangeEventDetail;
         "pdsMultiselectSearch": MultiselectSearchEventDetail;
         "pdsMultiselectLoadOptions": MultiselectLoadOptionsEventDetail;
+        "pdsMultiselectCreate": MultiselectCreateEventDetail;
     }
     interface HTMLPdsMultiselectElement extends Components.PdsMultiselect, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPdsMultiselectElementEventMap>(type: K, listener: (this: HTMLPdsMultiselectElement, ev: PdsMultiselectCustomEvent<HTMLPdsMultiselectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4250,6 +4255,10 @@ declare namespace LocalJSX {
          */
         "componentId": string;
         /**
+          * URL endpoint for creating new options. When set, shows "Add" option when no matches found.
+         */
+        "createUrl"?: string;
+        /**
           * Debounce delay in milliseconds for search/fetch.
           * @default 300
          */
@@ -4311,6 +4320,10 @@ declare namespace LocalJSX {
           * Emitted when selection changes.
          */
         "onPdsMultiselectChange"?: (event: PdsMultiselectCustomEvent<MultiselectChangeEventDetail>) => void;
+        /**
+          * Emitted when a new option is created.
+         */
+        "onPdsMultiselectCreate"?: (event: PdsMultiselectCustomEvent<MultiselectCreateEventDetail>) => void;
         /**
           * Emitted to request more options (pagination).
          */

--- a/libs/core/src/components/pds-box/readme.md
+++ b/libs/core/src/components/pds-box/readme.md
@@ -136,6 +136,7 @@
  - [pds-alert](../pds-alert)
  - [pds-combobox](../pds-combobox)
  - [pds-dropdown-menu](../pds-dropdown-menu)
+ - [pds-multiselect](../pds-multiselect)
  - [pds-property](../pds-property)
 
 ### Graph
@@ -144,6 +145,7 @@ graph TD;
   pds-alert --> pds-box
   pds-combobox --> pds-box
   pds-dropdown-menu --> pds-box
+  pds-multiselect --> pds-box
   pds-property --> pds-box
   style pds-box fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
+++ b/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
@@ -373,6 +373,7 @@ Enable users to create new options when no matches are found by setting the `cre
     component-id="tags-create"
     label="Manage Tags"
     placeholder="Select or create tags..."
+    create-url="/api/tags"
   >
     <option value="1">Marketing</option>
     <option value="2">Sales</option>

--- a/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
+++ b/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
@@ -21,7 +21,6 @@ The multiselect component allows users to select multiple options from a searcha
 ### When not to use
 - For single selection - use `pds-combobox` or `pds-select` instead
 - For very short lists (3-4 items) - consider using checkboxes directly
-- When users need to create new options - consider a tag input component
 
 ### Accessibility
 - Implements WAI-ARIA Combobox pattern with multiselect support
@@ -340,6 +339,76 @@ Display validation errors with the `errorMessage` prop.
     <option value="2">Tag B</option>
   </pds-multiselect>
 </DocCanvas>
+
+### With Create Option
+
+Enable users to create new options when no matches are found by setting the `create-url` prop. When a user types a search query that doesn't match any existing options, they'll see an "Add" option that posts to the specified endpoint.
+
+<DocCanvas
+  mdxSource={{
+    webComponent: `<pds-multiselect
+  component-id="tags-create"
+  label="Manage Tags"
+  placeholder="Select or create tags..."
+  create-url="/api/tags"
+>
+  <option value="1">Marketing</option>
+  <option value="2">Sales</option>
+  <option value="3">Support</option>
+</pds-multiselect>`,
+    react: `<PdsMultiselect
+  componentId="tags-create"
+  label="Manage Tags"
+  placeholder="Select or create tags..."
+  createUrl="/api/tags"
+  onPdsMultiselectCreate={(e) => console.log('Created:', e.detail.newOption)}
+>
+  <option value="1">Marketing</option>
+  <option value="2">Sales</option>
+  <option value="3">Support</option>
+</PdsMultiselect>`,
+  }}
+>
+  <pds-multiselect
+    component-id="tags-create"
+    label="Manage Tags"
+    placeholder="Select or create tags..."
+  >
+    <option value="1">Marketing</option>
+    <option value="2">Sales</option>
+    <option value="3">Support</option>
+  </pds-multiselect>
+</DocCanvas>
+
+> **Note:** The live preview uses static options. In production with `create-url` set, typing a query with no matches shows "Add 'query'" option.
+
+#### Create Option API Contract
+
+When the create option is clicked, the component sends a POST request:
+
+**Request:**
+```json
+POST /api/tags
+Content-Type: application/json
+
+{
+  "text": "New Tag Name"
+}
+```
+
+**Expected Response:**
+```json
+{
+  "id": "4",
+  "text": "New Tag Name"
+}
+```
+
+The newly created option is automatically added to the list and selected. The component emits:
+- `pdsMultiselectCreate` - Contains the query and new option details
+- `pdsMultiselectChange` - Updated selection including the new option
+
+**Error Handling:** If the create request fails, an error is logged to the console and the component remains in a usable state. Consider implementing your own error handling by monitoring the `pdsMultiselectCreate` event or network requests.
 
 ## Form Integration
 

--- a/libs/core/src/components/pds-multiselect/multiselect-interface.ts
+++ b/libs/core/src/components/pds-multiselect/multiselect-interface.ts
@@ -1,6 +1,7 @@
 export interface MultiselectOption {
   id: string | number;
   text: string;
+  isCreateOption?: boolean;
   [key: string]: unknown;
 }
 
@@ -18,7 +19,18 @@ export interface MultiselectLoadOptionsEventDetail {
   page: number;
 }
 
+export interface MultiselectCreateEventDetail {
+  query: string;
+  newOption: MultiselectOption;
+}
+
 export interface AsyncResponse {
   results: Array<{ id: string | number; text: string; [key: string]: unknown }>;
   totalCount?: number;
+}
+
+export interface CreateResponse {
+  id: string | number;
+  text: string;
+  [key: string]: unknown;
 }

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -196,6 +196,26 @@
   &:focus-visible {
     outline: var(--pine-dimension-none);
   }
+
+  &.pds-multiselect__option--create {
+    border-top: var(--pine-border);
+    border-top-color: var(--pine-color-border-subtle);
+    margin-top: var(--pine-dimension-xs);
+    padding-top: var(--pine-dimension-xs);
+  }
+}
+
+.pds-multiselect__create-option {
+  align-items: center;
+  color: var(--pine-color-text-strong);
+  display: flex;
+  gap: var(--pine-dimension-xs);
+  width: 100%;
+
+  pds-icon {
+    color: var(--pine-color-text-muted);
+    flex-shrink: var(--pine-dimension-none);
+  }
 }
 
 .pds-multiselect__empty,

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -196,20 +196,10 @@
   &:focus-visible {
     outline: var(--pine-dimension-none);
   }
-
-  &.pds-multiselect__option--create {
-    border-top: var(--pine-border);
-    border-top-color: var(--pine-color-border-subtle);
-    margin-top: var(--pine-dimension-xs);
-    padding-top: var(--pine-dimension-xs);
-  }
 }
 
 .pds-multiselect__create-option {
-  align-items: center;
   color: var(--pine-color-text-strong);
-  display: flex;
-  gap: var(--pine-dimension-xs);
   width: 100%;
 
   pds-icon {

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -742,7 +742,7 @@ export class PdsMultiselect {
 
   private toggleOption(option: MultiselectOption) {
     // Handle create option
-    if (option.isCreateOption || option.id === '__create__') {
+    if (option.isCreateOption) {
       // Prevent multiple create calls while one is in-flight
       if (!this.creating) {
         this.createOption(this.searchQuery);

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -8,7 +8,9 @@ import type {
   MultiselectChangeEventDetail,
   MultiselectSearchEventDetail,
   MultiselectLoadOptionsEventDetail,
+  MultiselectCreateEventDetail,
   AsyncResponse,
+  CreateResponse,
 } from './multiselect-interface';
 
 /**
@@ -146,6 +148,11 @@ export class PdsMultiselect {
    */
   @Prop() formatResult?: (item: unknown) => MultiselectOption;
 
+  /**
+   * URL endpoint for creating new options. When set, shows "Add" option when no matches found.
+   */
+  @Prop() createUrl?: string;
+
   // Internal state
   @State() isOpen: boolean = false;
   @State() searchQuery: string = '';
@@ -154,6 +161,7 @@ export class PdsMultiselect {
   @State() selectedItems: MultiselectOption[] = [];
   @State() currentPage: number = 1;
   @State() hasMore: boolean = false;
+  @State() creating: boolean = false;
 
   // Flag to prevent focusout from closing during open transition
   private isOpening: boolean = false;
@@ -172,6 +180,11 @@ export class PdsMultiselect {
    * Emitted to request more options (pagination).
    */
   @Event() pdsMultiselectLoadOptions!: EventEmitter<MultiselectLoadOptionsEventDetail>;
+
+  /**
+   * Emitted when a new option is created.
+   */
+  @Event() pdsMultiselectCreate!: EventEmitter<MultiselectCreateEventDetail>;
 
   private originalSearchEmitter?: EventEmitter<MultiselectSearchEventDetail>;
 
@@ -372,13 +385,24 @@ export class PdsMultiselect {
     const allOptions = this.getAllOptions();
     const query = this.searchQuery.toLowerCase();
 
-    return allOptions.filter(opt => {
+    const filtered = allOptions.filter(opt => {
       // Filter by search query only - don't filter out selected items
       if (query) {
         return opt.text.toLowerCase().includes(query);
       }
       return true;
     });
+
+    // Add create option if enabled and no matches found
+    if (this.createUrl && this.searchQuery.trim() && filtered.length === 0) {
+      return [{
+        id: '__create__',
+        text: this.searchQuery.trim(),
+        isCreateOption: true,
+      }];
+    }
+
+    return filtered;
   }
 
   private updateFormValue() {
@@ -465,6 +489,70 @@ export class PdsMultiselect {
       }
     } finally {
       this.loading = false;
+    }
+  }
+
+  private async createOption(query: string) {
+    if (!this.createUrl || !query.trim()) return;
+
+    this.creating = true;
+
+    try {
+      const url = new URL(this.createUrl, window.location.origin);
+
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: JSON.stringify({ text: query.trim() }),
+      });
+
+      if (!response.ok) throw new Error('Failed to create option');
+
+      const data: CreateResponse = await response.json();
+
+      const newOption: MultiselectOption = {
+        id: data.id,
+        text: data.text,
+        ...data,
+      };
+
+      // Add to internal options
+      this.internalOptions = [...this.internalOptions, newOption];
+
+      // Select the new option
+      this.value = [...this.value, String(newOption.id)];
+
+      // Sync selected items
+      this.syncSelectedItems();
+
+      // Emit create event
+      this.pdsMultiselectCreate.emit({
+        query: query.trim(),
+        newOption,
+      });
+
+      // Emit change event
+      this.pdsMultiselectChange.emit({
+        values: this.value,
+        items: this.selectedItems,
+      });
+
+      // Clear search and keep dropdown open
+      this.searchQuery = '';
+      this.highlightedIndex = -1;
+
+      // Focus back on search input
+      requestAnimationFrame(() => {
+        this.searchInputEl?.focus();
+      });
+
+    } catch (error) {
+      console.error('PdsMultiselect: Failed to create option', error);
+    } finally {
+      this.creating = false;
     }
   }
 
@@ -650,6 +738,12 @@ export class PdsMultiselect {
   }
 
   private toggleOption(option: MultiselectOption) {
+    // Handle create option
+    if (option.isCreateOption || option.id === '__create__') {
+      this.createOption(this.searchQuery);
+      return;
+    }
+
     const isSelected = this.value.includes(String(option.id));
 
     if (isSelected) {
@@ -806,6 +900,7 @@ export class PdsMultiselect {
             const isSelected = valueArray.includes(String(option.id));
             const isHighlighted = index === this.highlightedIndex;
             const optionId = `${this.componentId}-option-${index}`;
+            const isCreateOption = option.isCreateOption;
 
             return (
               <li
@@ -815,19 +910,28 @@ export class PdsMultiselect {
                   'pds-multiselect__option': true,
                   'pds-multiselect__option--highlighted': isHighlighted,
                   'pds-multiselect__option--selected': isSelected,
+                  'pds-multiselect__option--create': isCreateOption,
                 }}
                 role="option"
                 aria-selected={isSelected ? 'true' : 'false'}
+                aria-label={isCreateOption ? `Create new tag: ${option.text}` : undefined}
                 data-index={index}
                 onMouseDown={this.handleOptionMouseDown(option)}
                 onMouseEnter={this.handleOptionMouseEnter(index)}
               >
-                <pds-checkbox
-                  componentId={`${this.componentId}-checkbox-${index}`}
-                  checked={isSelected}
-                  label={option.text}
-                  style={{ pointerEvents: 'none' }}
-                />
+                {isCreateOption ? (
+                  <div class="pds-multiselect__create-option">
+                    <pds-icon name="add" size="small" />
+                    <span>Add "{option.text}"</span>
+                  </div>
+                ) : (
+                  <pds-checkbox
+                    componentId={`${this.componentId}-checkbox-${index}`}
+                    checked={isSelected}
+                    label={option.text}
+                    style={{ pointerEvents: 'none' }}
+                  />
+                )}
               </li>
             );
           })}
@@ -912,7 +1016,7 @@ export class PdsMultiselect {
             {this.renderDropdown()}
           </div>
 
-          {this.helperMessage && !this.errorMessage && (
+          {this.helperMessage && !(this.errorMessage && this.errorMessage.length > 0) && (
             <p class="pds-multiselect__helper" id={messageId(this.componentId, 'helper')}>
               {this.helperMessage}
             </p>

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -904,9 +904,9 @@ export class PdsMultiselect {
 
           {filteredOptions.map((option, index) => {
             const isSelected = valueArray.includes(String(option.id));
-            const isHighlighted = index === this.highlightedIndex;
-            const optionId = `${this.componentId}-option-${index}`;
             const isCreateOption = option.isCreateOption;
+            const isHighlighted = index === this.highlightedIndex && !isCreateOption;
+            const optionId = `${this.componentId}-option-${index}`;
             const isCreateDisabled = isCreateOption && this.creating;
 
             return (
@@ -929,10 +929,10 @@ export class PdsMultiselect {
                 onMouseEnter={this.handleOptionMouseEnter(index)}
               >
                 {isCreateOption ? (
-                  <div class="pds-multiselect__create-option">
+                  <pds-box class="pds-multiselect__create-option" align-items="center" gap="xs">
                     <pds-icon name="add" size="small" />
-                    <span>Add "{option.text}"</span>
-                  </div>
+                    <pds-text>Add "{option.text}"</pds-text>
+                  </pds-box>
                 ) : (
                   <pds-checkbox
                     componentId={`${this.componentId}-checkbox-${index}`}

--- a/libs/core/src/components/pds-multiselect/readme.md
+++ b/libs/core/src/components/pds-multiselect/readme.md
@@ -24,7 +24,7 @@ A multiselect component that allows users to select multiple options from a sear
 | `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                      | `string`                               | `undefined`   |
 | `createUrl`                | `create-url`     | URL endpoint for creating new options. When set, shows "Add" option when no matches found. | `string`                               | `undefined`   |
 | `debounce`                 | `debounce`       | Debounce delay in milliseconds for search/fetch.                                           | `number`                               | `300`         |
-| `disabled`                 | `disabled`       | Determines whether the multiselect is disabled.                                            | `boolean`                              | `false`       |
+| `disabled`                 | `disabled`       | Determines whether or not the multiselect is disabled.                                     | `boolean`                              | `false`       |
 | `errorMessage`             | `error-message`  | Error message to display.                                                                  | `string`                               | `undefined`   |
 | `formatResult`             | --               | Function to format async results. Receives raw API response item.                          | `(item: unknown) => MultiselectOption` | `undefined`   |
 | `helperMessage`            | `helper-message` | Helper message to display below the input.                                                 | `string`                               | `undefined`   |
@@ -82,6 +82,8 @@ Type: `Promise<void>`
 
 - pds-icon
 - [pds-loader](../pds-loader)
+- [pds-box](../pds-box)
+- [pds-text](../pds-text)
 - [pds-checkbox](../pds-checkbox)
 
 ### Graph
@@ -89,6 +91,8 @@ Type: `Promise<void>`
 graph TD;
   pds-multiselect --> pds-icon
   pds-multiselect --> pds-loader
+  pds-multiselect --> pds-box
+  pds-multiselect --> pds-text
   pds-multiselect --> pds-checkbox
   pds-checkbox --> pds-icon
   style pds-multiselect fill:#f9f,stroke:#333,stroke-width:4px

--- a/libs/core/src/components/pds-multiselect/readme.md
+++ b/libs/core/src/components/pds-multiselect/readme.md
@@ -24,7 +24,7 @@ A multiselect component that allows users to select multiple options from a sear
 | `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                      | `string`                               | `undefined`   |
 | `createUrl`                | `create-url`     | URL endpoint for creating new options. When set, shows "Add" option when no matches found. | `string`                               | `undefined`   |
 | `debounce`                 | `debounce`       | Debounce delay in milliseconds for search/fetch.                                           | `number`                               | `300`         |
-| `disabled`                 | `disabled`       | Determines whether or not the multiselect is disabled.                                     | `boolean`                              | `false`       |
+| `disabled`                 | `disabled`       | Determines whether the multiselect is disabled.                                            | `boolean`                              | `false`       |
 | `errorMessage`             | `error-message`  | Error message to display.                                                                  | `string`                               | `undefined`   |
 | `formatResult`             | --               | Function to format async results. Receives raw API response item.                          | `(item: unknown) => MultiselectOption` | `undefined`   |
 | `helperMessage`            | `helper-message` | Helper message to display below the input.                                                 | `string`                               | `undefined`   |

--- a/libs/core/src/components/pds-multiselect/readme.md
+++ b/libs/core/src/components/pds-multiselect/readme.md
@@ -17,30 +17,31 @@ A multiselect component that allows users to select multiple options from a sear
 
 ## Properties
 
-| Property                   | Attribute        | Description                                                               | Type                                   | Default       |
-| -------------------------- | ---------------- | ------------------------------------------------------------------------- | -------------------------------------- | ------------- |
-| `asyncMethod`              | `async-method`   | HTTP method for async requests.                                           | `"GET" \| "POST"`                      | `'GET'`       |
-| `asyncUrl`                 | `async-url`      | URL endpoint for async data fetching.                                     | `string`                               | `undefined`   |
-| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.     | `string`                               | `undefined`   |
-| `debounce`                 | `debounce`       | Debounce delay in milliseconds for search/fetch.                          | `number`                               | `300`         |
-| `disabled`                 | `disabled`       | Determines whether or not the multiselect is disabled.                    | `boolean`                              | `false`       |
-| `errorMessage`             | `error-message`  | Error message to display.                                                 | `string`                               | `undefined`   |
-| `formatResult`             | --               | Function to format async results. Receives raw API response item.         | `(item: unknown) => MultiselectOption` | `undefined`   |
-| `helperMessage`            | `helper-message` | Helper message to display below the input.                                | `string`                               | `undefined`   |
-| `hideLabel`                | `hide-label`     | Visually hides the label but keeps it accessible.                         | `boolean`                              | `false`       |
-| `invalid`                  | `invalid`        | If true, the multiselect is in an invalid state.                          | `boolean`                              | `undefined`   |
-| `label`                    | `label`          | Text to be displayed as the multiselect label.                            | `string`                               | `undefined`   |
-| `loading`                  | `loading`        | Whether the component is currently loading async options.                 | `boolean`                              | `false`       |
-| `maxHeight`                | `max-height`     | Maximum height of the dropdown before scrolling.                          | `string`                               | `'300px'`     |
-| `maxSelections`            | `max-selections` | Maximum number of selections allowed.                                     | `number`                               | `undefined`   |
-| `minWidth`                 | `min-width`      | Minimum width of the dropdown panel.                                      | `string`                               | `'250px'`     |
-| `name`                     | `name`           | Specifies the name. Submitted with the form as part of a name/value pair. | `string`                               | `undefined`   |
-| `options`                  | --               | Options provided externally (for consumer-managed async).                 | `MultiselectOption[]`                  | `undefined`   |
-| `panelWidth`               | `panel-width`    | Width of the dropdown panel. Defaults to the trigger width.               | `string`                               | `undefined`   |
-| `placeholder`              | `placeholder`    | Placeholder text for the input field.                                     | `string`                               | `'Select...'` |
-| `required`                 | `required`       | If true, the multiselect is required.                                     | `boolean`                              | `false`       |
-| `triggerWidth`             | `trigger-width`  | Width of the trigger button (and reference for dropdown positioning).     | `string`                               | `'100%'`      |
-| `value`                    | --               | Array of selected option values.                                          | `string[]`                             | `[]`          |
+| Property                   | Attribute        | Description                                                                                | Type                                   | Default       |
+| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------ | -------------------------------------- | ------------- |
+| `asyncMethod`              | `async-method`   | HTTP method for async requests.                                                            | `"GET" \| "POST"`                      | `'GET'`       |
+| `asyncUrl`                 | `async-url`      | URL endpoint for async data fetching.                                                      | `string`                               | `undefined`   |
+| `componentId` _(required)_ | `component-id`   | A unique identifier used for the underlying component `id` attribute.                      | `string`                               | `undefined`   |
+| `createUrl`                | `create-url`     | URL endpoint for creating new options. When set, shows "Add" option when no matches found. | `string`                               | `undefined`   |
+| `debounce`                 | `debounce`       | Debounce delay in milliseconds for search/fetch.                                           | `number`                               | `300`         |
+| `disabled`                 | `disabled`       | Determines whether or not the multiselect is disabled.                                     | `boolean`                              | `false`       |
+| `errorMessage`             | `error-message`  | Error message to display.                                                                  | `string`                               | `undefined`   |
+| `formatResult`             | --               | Function to format async results. Receives raw API response item.                          | `(item: unknown) => MultiselectOption` | `undefined`   |
+| `helperMessage`            | `helper-message` | Helper message to display below the input.                                                 | `string`                               | `undefined`   |
+| `hideLabel`                | `hide-label`     | Visually hides the label but keeps it accessible.                                          | `boolean`                              | `false`       |
+| `invalid`                  | `invalid`        | If true, the multiselect is in an invalid state.                                           | `boolean`                              | `undefined`   |
+| `label`                    | `label`          | Text to be displayed as the multiselect label.                                             | `string`                               | `undefined`   |
+| `loading`                  | `loading`        | Whether the component is currently loading async options.                                  | `boolean`                              | `false`       |
+| `maxHeight`                | `max-height`     | Maximum height of the dropdown before scrolling.                                           | `string`                               | `'300px'`     |
+| `maxSelections`            | `max-selections` | Maximum number of selections allowed.                                                      | `number`                               | `undefined`   |
+| `minWidth`                 | `min-width`      | Minimum width of the dropdown panel.                                                       | `string`                               | `'250px'`     |
+| `name`                     | `name`           | Specifies the name. Submitted with the form as part of a name/value pair.                  | `string`                               | `undefined`   |
+| `options`                  | --               | Options provided externally (for consumer-managed async).                                  | `MultiselectOption[]`                  | `undefined`   |
+| `panelWidth`               | `panel-width`    | Width of the dropdown panel. Defaults to the trigger width.                                | `string`                               | `undefined`   |
+| `placeholder`              | `placeholder`    | Placeholder text for the input field.                                                      | `string`                               | `'Select...'` |
+| `required`                 | `required`       | If true, the multiselect is required.                                                      | `boolean`                              | `false`       |
+| `triggerWidth`             | `trigger-width`  | Width of the trigger button (and reference for dropdown positioning).                      | `string`                               | `'100%'`      |
+| `value`                    | --               | Array of selected option values.                                                           | `string[]`                             | `[]`          |
 
 
 ## Events
@@ -48,6 +49,7 @@ A multiselect component that allows users to select multiple options from a sear
 | Event                       | Description                                           | Type                                             |
 | --------------------------- | ----------------------------------------------------- | ------------------------------------------------ |
 | `pdsMultiselectChange`      | Emitted when selection changes.                       | `CustomEvent<MultiselectChangeEventDetail>`      |
+| `pdsMultiselectCreate`      | Emitted when a new option is created.                 | `CustomEvent<MultiselectCreateEventDetail>`      |
 | `pdsMultiselectLoadOptions` | Emitted to request more options (pagination).         | `CustomEvent<MultiselectLoadOptionsEventDetail>` |
 | `pdsMultiselectSearch`      | Emitted on search input (for consumer-managed async). | `CustomEvent<MultiselectSearchEventDetail>`      |
 

--- a/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
+++ b/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
@@ -369,3 +369,44 @@ export const CustomEmptyState = {
     </pds-multiselect>
   `,
 };
+
+export const WithCreateOption = {
+  args: {
+    componentId: 'multiselect-create',
+    label: 'Manage Tags',
+    placeholder: 'Select or create tags...',
+    value: [],
+  },
+  render: (args, { updateArgs } = {}) => {
+    return html`
+      <pds-multiselect
+        id="create-example"
+        component-id="${args.componentId}"
+        label="${args.label}"
+        placeholder="${args.placeholder}"
+        create-url="/api/tags"
+        .value=${args.value}
+        @pdsMultiselectCreate=${async (e) => {
+          console.log('Creating new tag:', e.detail.query);
+          // In a real app, the component handles the POST request
+          // This event is just for notification/logging
+        }}
+        @pdsMultiselectChange=${(e) => {
+          console.log('Selected values:', e.detail.values);
+          console.log('Selected items:', e.detail.items);
+          updateArgs?.({ value: e.detail.values });
+        }}
+      >
+        ${unsafeHTML(defaultOptions)}
+      </pds-multiselect>
+      <p style="margin-top: var(--pine-dimension-sm); color: var(--pine-color-text-secondary);">
+        Type a search query that doesn't match any options to see the "Add" option.
+        Open console to see create and change events.
+      </p>
+      <p style="margin-top: var(--pine-dimension-xs); color: var(--pine-color-text-muted); font-size: 0.875rem;">
+        Note: In Storybook, the POST request will fail (expected). In production with a real API endpoint,
+        new tags are created and automatically selected.
+      </p>
+    `;
+  },
+};

--- a/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
+++ b/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
@@ -400,12 +400,12 @@ export const WithCreateOption = {
         ${unsafeHTML(defaultOptions)}
       </pds-multiselect>
       <p style="margin-top: var(--pine-dimension-sm); color: var(--pine-color-text-secondary);">
-        Type a search query that doesn't match any options to see the "Add" option.
-        Open console to see create and change events.
+        Type a search query that doesn't match any options to see the "Add" option appear.
+        Note: In Storybook, the POST request will fail and create events will not be emitted.
       </p>
       <p style="margin-top: var(--pine-dimension-xs); color: var(--pine-color-text-muted); font-size: 0.875rem;">
-        Note: In Storybook, the POST request will fail (expected). In production with a real API endpoint,
-        new tags are created and automatically selected.
+        In production with a real API endpoint, clicking "Add" creates the new tag, emits the create event,
+        and automatically selects the newly created option.
       </p>
     `;
   },

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -9,7 +9,15 @@ if (typeof MutationObserver === 'undefined') {
   };
 }
 
+// Capture original fetch for cleanup
+const originalFetch = global.fetch;
+
 describe('pds-multiselect', () => {
+  afterEach(() => {
+    // Restore original fetch and clean up all mocks after each test
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
   it('renders with label', async () => {
     const page = await newSpecPage({
       components: [PdsMultiselect],

--- a/libs/core/src/components/pds-text/readme.md
+++ b/libs/core/src/components/pds-text/readme.md
@@ -32,11 +32,13 @@
 ### Used by
 
  - [pds-alert](../pds-alert)
+ - [pds-multiselect](../pds-multiselect)
 
 ### Graph
 ```mermaid
 graph TD;
   pds-alert --> pds-text
+  pds-multiselect --> pds-text
   style pds-text fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
# Description

This PR adds the ability for users to create new tags/options directly within the `pds-multiselect` component. When the `create-url` prop is set and a user types a search query that doesn't match any existing options, they'll see an "Add '[query]'" option. Clicking it POSTs to the specified endpoint, creates the tag, and automatically selects it.

This resolves the need for heroes to manage tags on media library assets without leaving the multiselect interface.

Fixes DSS-107

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] unit tests - Added 13 comprehensive tests covering all create functionality
- [x] tested manually - Verified in Storybook with create-url example
- [ ] e2e tests
- [ ] accessibility tests - Proper ARIA labels added for screen readers
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
