### PR TITLE
style(pds-table-row): update interactive token color

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
+++ b/libs/core/src/components/pds-table/pds-table-row/pds-table-row.scss
@@ -1,5 +1,5 @@
 :host {
-  --color-background-interactive: var(--pine-color-border-disabled);
+  --color-background-interactive: var(--pine-color-background-subtle);
 
   border-color: inherit;
   display: table-row;


### PR DESCRIPTION
# Description

Updates the table row hover/selected background color from `--pine-color-border-disabled` to `--pine-color-background-subtle` to use a semantically appropriate token that maps to grey.100 in light mode.

Fixes [DSS-113](https://linear.app/kajabi/issue/DSS-113/update-pds-table-row-hover-background-token)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: latest
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR