### PR TITLE
style(pds-tab): display not-allowed cursor for disabled tabs

### DIFF
--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.scss
@@ -58,7 +58,6 @@ pds-tab {
   &.is-disabled {
     color: var(--pine-color-text-disabled);
     cursor: not-allowed;
-    pointer-events: none;
   }
 
   .pds-tab__content {


### PR DESCRIPTION
# Description

Display a `not-allowed` cursor when hovering over disabled tabs in `pds-tab`. Previously, the `pointer-events: none` CSS rule prevented the cursor from showing, even though `cursor: not-allowed` was already defined.

The fix removes `pointer-events: none` from the disabled state. The native HTML `disabled` attribute on the button element continues to prevent interaction, so this is a non-breaking change.

Fixes [DSS-119](https://linear.app/kajabi/issue/DSS-119/add-not-allowed-cursor-for-disabled-pdstabs)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes