### PR TITLE
fix(pds-dropdown-menu-item): add reflect to prop

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
@@ -24,7 +24,7 @@ export class PdsDropdownMenuItem implements BasePdsProps {
    * It determines whether or not the dropdown-item is disabled.
    * @defaultValue false
    */
-  @Prop() disabled: boolean = false;
+  @Prop({ reflect: true }) disabled: boolean = false;
 
 
   /**


### PR DESCRIPTION
# Description
- Add `reflect: true` to the `disabled` prop on `pds-dropdown-menu-item` to ensure the attribute is properly observed when set via server-rendered HTML

## Problem
When using `pds-dropdown-menu-item` with the `disabled` attribute set in server-rendered HTML (e.g., from Rails templates), the component wasn't properly recognizing the disabled state. The `is-disabled` class wasn't being applied, and the visual disabled styling (opacity, cursor) wasn't rendering.

## Solution
Added `{ reflect: true }` to the `disabled` prop decorator. This ensures:
1. The HTML attribute is properly observed when set during initial render
2. Changes to the prop value are reflected back to the DOM attribute
3. The `is-disabled` class gets applied correctly, enabling the disabled styling


Fixes [DSS-128](https://linear.app/kajabi/issue/DSS-128/add-reflect-true-to-pds-dropdown-menu-item-disabled-prop)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests you've added and run to verify your changes.
Provide instructions so that we can reproduce.
Please also list any relevant details for your test configuration.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions:
- OS:
- Browsers:
- Screen readers:
- Misc:

# Checklist:

If not applicable, leave options unchecked.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR
