### PR TITLE
feat(pds-dropdown-menu): allow raw anchor and button elements

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
+++ b/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
@@ -284,6 +284,118 @@ Menu items can open links in a new tab using the `external` boolean prop. This d
 
 >**Note:** You can also use the `target` prop for more control (e.g., `target="_blank"`, `target="_parent"`). The `target` prop takes precedence over `external` if both are set.
 
+### Mixing Menu Items with Raw Elements
+
+In most cases, use `pds-dropdown-menu-item` for menu options. However, for edge cases requiring native browser or framework behavior (such as handling non-GET HTTP methods or framework-specific data attributes), you can mix in raw `<a>` or `<button>` elements. These elements are included in keyboard navigation but require additional CSS in your application for hover and focus states (see example below).
+
+The example below demonstrates mixing a standard menu item with raw `<a>` and `<button>` elements that use framework-specific data attributes.
+
+<DocCanvas
+  mdxSource={{
+    react:`
+{/* Hover/focus styles for raw elements (add to your app's CSS) */}
+<style>{\`
+  pds-dropdown-menu > a:hover,
+  pds-dropdown-menu > button:hover {
+    background-color: var(--pine-color-background-muted);
+  }
+  pds-dropdown-menu > a:focus,
+  pds-dropdown-menu > button:focus {
+    outline: var(--pine-outline-focus);
+    outline-offset: var(--pine-border-width);
+  }
+  pds-dropdown-menu > a.destructive:hover {
+    background-color: var(--pine-color-danger-disabled);
+  }
+  pds-dropdown-menu > a.destructive:focus {
+    outline: var(--pine-outline-focus-danger);
+  }
+\`}</style>
+
+<PdsDropdownMenu>
+  <PdsButton slot="trigger">Actions</PdsButton>
+  <PdsDropdownMenuItem href="/view">View</PdsDropdownMenuItem>
+  <PdsDropdownMenuSeparator />
+  <a href="/edit" data-remote="true">Edit</a>
+  <a href="/archive" data-method="post">Archive</a>
+  <PdsDropdownMenuSeparator />
+  <button type="button" data-action="modal#open">Open Modal</button>
+  <a href="/delete" data-method="delete" className="destructive">Delete</a>
+</PdsDropdownMenu>
+`,
+    webComponent:`
+<!-- Hover/focus styles for raw elements (add to your app's CSS) -->
+<style>
+  pds-dropdown-menu > a:hover,
+  pds-dropdown-menu > button:hover {
+    background-color: var(--pine-color-background-muted);
+  }
+  pds-dropdown-menu > a:focus,
+  pds-dropdown-menu > button:focus {
+    outline: var(--pine-outline-focus);
+    outline-offset: var(--pine-border-width);
+  }
+  pds-dropdown-menu > a.destructive:hover {
+    background-color: var(--pine-color-danger-disabled);
+  }
+  pds-dropdown-menu > a.destructive:focus {
+    outline: var(--pine-outline-focus-danger);
+  }
+</style>
+
+<pds-dropdown-menu>
+  <pds-button slot="trigger">Actions</pds-button>
+  <pds-dropdown-menu-item href="/view">View</pds-dropdown-menu-item>
+  <pds-dropdown-menu-separator />
+  <a href="/edit" data-remote="true">Edit</a>
+  <a href="/archive" data-method="post">Archive</a>
+  <pds-dropdown-menu-separator />
+  <button type="button" data-action="modal#open">Open Modal</button>
+  <a href="/delete" data-method="delete" class="destructive">Delete</a>
+</pds-dropdown-menu>
+`
+  }}
+>
+<style>
+{`
+  .raw-elements-example pds-dropdown-menu > a:hover,
+  .raw-elements-example pds-dropdown-menu > button:hover {
+    background-color: var(--pine-color-background-muted);
+  }
+  .raw-elements-example pds-dropdown-menu > a:focus,
+  .raw-elements-example pds-dropdown-menu > button:focus {
+    outline: var(--pine-outline-focus);
+    outline-offset: var(--pine-border-width);
+  }
+  .raw-elements-example pds-dropdown-menu > a.destructive:hover {
+    background-color: var(--pine-color-danger-disabled);
+  }
+  .raw-elements-example pds-dropdown-menu > a.destructive:focus {
+    outline: var(--pine-outline-focus-danger);
+  }
+`}
+</style>
+<div className="raw-elements-example" style={{ height: '275px', width: '100%', textAlign: 'center' }}>
+  <pds-dropdown-menu>
+    <pds-button slot="trigger">Actions</pds-button>
+    <pds-dropdown-menu-item href="/view">View</pds-dropdown-menu-item>
+    <pds-dropdown-menu-separator></pds-dropdown-menu-separator>
+    <a href="/edit" data-remote="true">Edit</a>
+    <a href="/archive" data-method="post">Archive</a>
+    <pds-dropdown-menu-separator></pds-dropdown-menu-separator>
+    <button type="button" data-action="modal#open">Open Modal</button>
+    <a href="/delete" data-method="delete" className="destructive">Delete</a>
+  </pds-dropdown-menu>
+</div>
+</DocCanvas>
+
+**Raw element attributes:**
+- Add `class="destructive"` for danger/destructive text color
+- Add `aria-disabled="true"` to visually disable an anchor element
+- Add `disabled` attribute to visually disable a button element
+
+>**Note:** Use `pds-dropdown-menu-item` for most cases. Raw elements should only be used when you need native browser behavior that cannot work through the component's Shadow DOM (e.g., framework-specific data attributes for form submissions). Due to Shadow DOM limitations, hover and focus states for raw elements must be styled by the consuming application's CSS.
+
 ### With Disabled Items
 
 Menu items can be disabled using the disabled attribute.

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
@@ -19,3 +19,44 @@
     border: var(--pine-border);
   }
 }
+
+// Styles for raw <a> and <button> elements slotted into the menu
+// These are allowed for edge cases requiring native browser/framework behavior
+// (e.g., Rails UJS, Turbo) that cannot work through Shadow DOM.
+//
+// Note: ::slotted() cannot be combined with pseudo-classes like :hover or :focus.
+// Raw elements will receive base styling here; hover/focus states must be handled
+// by the consuming application's CSS if needed.
+::slotted(a),
+::slotted(button) {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: var(--pine-dimension-xs);
+  box-sizing: border-box;
+  color: var(--pine-color-text);
+  cursor: pointer;
+  display: flex;
+  flex-grow: 1;
+  font: var(--pine-typography-body-medium);
+  gap: var(--pine-dimension-xs);
+  margin: calc(var(--pine-border-width) + 2px);
+  padding: var(--pine-dimension-xs);
+  text-align: start;
+  text-decoration: none;
+  width: calc(100% - calc(var(--pine-border-width) + 2px) * 2);
+}
+
+// Destructive variant for raw elements
+::slotted(.destructive) {
+  color: var(--pine-color-danger);
+}
+
+// Disabled state for raw elements (using attribute selectors, not pseudo-classes)
+::slotted([aria-disabled="true"]),
+::slotted([disabled]) {
+  cursor: not-allowed;
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
@@ -35,7 +35,7 @@
   border: 0;
   border-radius: var(--pine-dimension-xs);
   box-sizing: border-box;
-  color: var(--pine-color-text);
+  color: var(--pine-color-text) !important;
   cursor: pointer;
   display: flex;
   flex-grow: 1;
@@ -44,13 +44,13 @@
   margin: calc(var(--pine-border-width) + 2px);
   padding: var(--pine-dimension-xs);
   text-align: start;
-  text-decoration: none;
+  text-decoration: none !important;
   width: calc(100% - calc(var(--pine-border-width) + 2px) * 2);
 }
 
 // Destructive variant for raw elements
 ::slotted(.destructive) {
-  color: var(--pine-color-danger);
+  color: var(--pine-color-danger) !important;
 }
 
 // Disabled state for raw elements (using attribute selectors, not pseudo-classes)

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -86,9 +86,12 @@ export class PdsTable {
     }
 
     // Apply default sort if specified
+    // Use requestAnimationFrame to defer until child components are fully initialized
     if (this.defaultSortColumn) {
-      void this.applyDefaultSort().catch((err) => {
-        console.warn('Failed to apply default sort.', err);
+      requestAnimationFrame(() => {
+        void this.applyDefaultSort().catch((err) => {
+          console.warn('Failed to apply default sort.', err);
+        });
       });
     }
   }

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -6,6 +6,9 @@ import { PdsTableBody } from '../pds-table-body/pds-table-body';
 import { PdsTableRow } from '../pds-table-row/pds-table-row';
 import { PdsTableCell } from '../pds-table-cell/pds-table-cell';
 
+// Helper to wait for requestAnimationFrame to complete
+const flushAnimationFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+
 describe('pds-table', () => {
   it('renders', async () => {
     const page = await newSpecPage({
@@ -399,6 +402,7 @@ describe('pds-table', () => {
       `,
     });
 
+    await flushAnimationFrame();
     await page.waitForChanges();
 
     const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
@@ -436,6 +440,7 @@ describe('pds-table', () => {
       `,
     });
 
+    await flushAnimationFrame();
     await page.waitForChanges();
 
     const tableBody = page.body.querySelector('pds-table-body') as HTMLElement;
@@ -465,6 +470,7 @@ describe('pds-table', () => {
       `,
     });
 
+    await flushAnimationFrame();
     await page.waitForChanges();
 
     const headCells = page.body.querySelectorAll('pds-table-head-cell');
@@ -496,6 +502,7 @@ describe('pds-table', () => {
       `,
     });
 
+    await flushAnimationFrame();
     await page.waitForChanges();
 
     expect(consoleWarnSpy).toHaveBeenCalledWith('Default sort column "NonExistent" not found.');
@@ -547,6 +554,7 @@ describe('pds-table', () => {
       `,
     });
 
+    await flushAnimationFrame();
     await page.waitForChanges();
 
     // Should not throw and header should still be marked active


### PR DESCRIPTION
# Description

Relaxes `pds-dropdown-menu` validation to allow raw `<a>` and `<button>` elements alongside `pds-dropdown-menu-item` components.

## Why is this needed?

Consuming applications (like Kajabi-products) using Rails/Turbo need to use `link_to` helpers with framework-specific data attributes (`data-method`, `data-remote`, `data-turbo-*`) that require native browser event handling. These attributes don't work through Shadow DOM because frameworks like Rails UJS and Turbo can't intercept events on elements inside shadow roots.

This change allows developers to mix standard `pds-dropdown-menu-item` components with raw elements for edge cases that need native browser behavior.

## Changes

- **Validation**: Changed from throwing an error to logging a warning for unexpected elements
- **Allowed elements**: `<a>` and `<button>` elements now pass validation alongside existing menu items
- **Keyboard navigation**: Raw elements are included in arrow key, Tab, Home, and End navigation
- **Styling**: Base styles applied via `::slotted()` for raw elements
- **Documentation**: Added "Mixing Menu Items with Raw Elements" section with CSS examples

## Technical Notes

- `::slotted()` cannot style pseudo-classes like `:hover` or `:focus`, so consuming apps must add their own CSS for those states (documented with examples)
- Disabled state checked via `aria-disabled="true"` for anchors and `disabled` attribute for buttons
- Backward compatible - existing `pds-dropdown-menu-item` usage unchanged

Fixes [DSS-134](https://linear.app/kajabi/issue/DSS-134)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

**Test Configuration**:

- Pine versions: latest
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR