### PR TITLE
style(pds-dropdown-menu-item): add flex alignment and spacing

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
@@ -43,7 +43,6 @@
     outline: var(--pine-outline-focus);
     outline-offset: var(--pine-border-width);
   }
-
 }
 
 :host(.destructive) {
@@ -74,7 +73,9 @@ pds-link::part(link):focus-visible {
 }
 
 pds-link::part(link) {
-  display: block;
+  align-items: center;
+  display: flex;
+  gap: var(--pine-dimension-xs);
   margin: calc(var(--pine-dimension-xs) * -1);
   padding: var(--pine-dimension-xs);
   text-decoration: none;


### PR DESCRIPTION
# Description

Fixes icon alignment in `pds-dropdown-menu-item` when rendered as a link (`href` is provided).

When `href` is set, the component renders a `pds-link` internally, and the inner `<a>` tag (via `pds-link::part(link)`) was set to `display: block`. This caused slotted content like `<pds-icon>` + text to lose the flex layout (no gap, no vertical centering) that button-style items get from `.pds-dropdown-menu-item__content`.

The fix changes the `pds-link::part(link)` rule to `display: flex` with matching `align-items: center` and `gap: var(--pine-dimension-xs)`, consistent with the parent content wrapper's layout.

Fixes [DSS-135](https://linear.app/kajabi/issue/DSS-135/fix-icon-alignment-in-pds-dropdown-menu-item-link-items)

| Before | After |
|--------|--------|
|<img width="653" height="467" alt="Screenshot 2026-02-05 at 4 08 53 PM" src="https://github.com/user-attachments/assets/344b0384-b2d7-4776-a9dc-de464fbaf8a7" />|<img width="848" height="512" alt="Screenshot 2026-02-05 at 4 08 05 PM" src="https://github.com/user-attachments/assets/7561e193-1e35-4b8c-ad3f-f021b59d27d1" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions: latest (main)
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR