### PR TITLE
fix(pds-multiselect): resolve async with preselected values not showing selection count on initial render

### DIFF
--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -283,6 +283,16 @@ export class PdsMultiselect {
     }
     this.syncSelectedItems();
     this.updateFormValue();
+
+    // If using asyncUrl and some values couldn't be resolved, fetch options
+    // This handles programmatic value changes where the options aren't loaded yet
+    if (this.asyncUrl && !this.loading) {
+      const valueArray = this.ensureValueArray();
+      const hasUnresolvedValues = valueArray.length > 0 && this.selectedItems.length < valueArray.length;
+      if (hasUnresolvedValues) {
+        this.fetchOptions('', 1);
+      }
+    }
   }
 
   @Watch('options')


### PR DESCRIPTION
# Description

Fixes a bug where `pds-multiselect` with `async-url` and preselected `value` didn't show the selection count ("X items") on initial render. The component would show the placeholder until the user clicked to open the dropdown.

**Changes:**
1. **Initial fetch for preselected values** - When the component mounts with `asyncUrl` and preselected values, it now fetches options immediately so the trigger can display the correct count
2. **Prevent double fetch race condition** - Added `initialAsyncFetchTriggered` flag to prevent a redundant fetch if the user opens the dropdown before the initial fetch completes
3. **Handle programmatic value changes** - The `@Watch('value')` handler now triggers a fetch when values can't be resolved from currently loaded options

Fixes [DSS-139](https://linear.app/kajabi/issue/DSS-139/pds-multiselect-async-url-with-preselected-values-doesnt-show)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:
- Pine versions: 3.16.0
- OS: macOS
- Browsers: Chrome
- Screen readers: N/A
- Misc: Tested with Storybook async stories

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR