### PR TITLE
fix(pds-dropdown-menu-item): update destructive color for pds link sh…

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.scss
@@ -47,6 +47,10 @@
 
 :host(.destructive) {
   .pds-dropdown-menu-item__content {
+    // Set context variables so pds-link's shadow DOM picks up the destructive colors
+    --pds-context-link-color: var(--pine-color-danger);
+    --pds-context-link-color-hover: var(--pine-color-danger-hover);
+
     align-items: center;
     color: var(--pine-color-danger);
 


### PR DESCRIPTION
# Description

Fix destructive `pds-dropdown-menu-item` color not applying when rendered as a link (`href` is provided).

When a `pds-dropdown-menu-item` has both the `destructive` prop and an `href`, it renders a `pds-link` internally. The destructive CSS sets `color: var(--pine-color-danger)` on the `.pds-dropdown-menu-item__content` element, but `pds-link` has its own shadow DOM that resolves color from `--pds-context-link-color` (with a fallback to `--pine-color-text`). Since the context variables were never set, the danger color was lost at the shadow DOM boundary.

This fix adds `--pds-context-link-color` and `--pds-context-link-color-hover` CSS custom properties to the `:host(.destructive)` rule, which properly cascade through the shadow DOM and are picked up by `pds-link`'s internal styles.

Fixes [DSS-136](https://linear.app/kajabi/issue/DSS-136/pds-dropdown-item-delete-items-styles-not-matching-spec)

**Before:** Delete items with `href` render in default text color (no red)
**After:** Delete items with `href` render in danger red with correct hover/focus states

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions: 3.16.0
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes