### PR TITLE
fix(pds-input): style native search clear button with custom icon

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -327,3 +327,15 @@
   white-space: nowrap;
   width: 1px;
 }
+
+  // Custom styling for the search clear (x) button
+  &::-webkit-search-cancel-button {
+    appearance: none;
+    background-color: var(--pds-input-placeholder-color);
+    cursor: pointer;
+    height: var(--pine-dimension-sm);
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.646 3.646a.5.5 0 0 1 .708 0L8 7.293l3.646-3.647a.5.5 0 0 1 .708.708L8.707 8l3.647 3.646a.5.5 0 0 1-.708.708L8 8.707l-3.646 3.647a.5.5 0 0 1-.708-.708L7.293 8 3.646 4.354a.5.5 0 0 1 0-.708'/%3E%3C/svg%3E");
+    mask-size: contain;
+    width: var(--pine-dimension-sm);
+  }
+

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -328,14 +328,14 @@
   width: 1px;
 }
 
-  // Custom styling for the search clear (x) button
-  &::-webkit-search-cancel-button {
-    appearance: none;
-    background-color: var(--pds-input-placeholder-color);
-    cursor: pointer;
-    height: var(--pine-dimension-sm);
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.646 3.646a.5.5 0 0 1 .708 0L8 7.293l3.646-3.647a.5.5 0 0 1 .708.708L8.707 8l3.647 3.646a.5.5 0 0 1-.708.708L8 8.707l-3.646 3.647a.5.5 0 0 1-.708-.708L7.293 8 3.646 4.354a.5.5 0 0 1 0-.708'/%3E%3C/svg%3E");
-    mask-size: contain;
-    width: var(--pine-dimension-sm);
-  }
+// Custom styling for the search clear (x) button
+.pds-input__field::-webkit-search-cancel-button {
+  appearance: none;
+  background-color: var(--pds-input-placeholder-color);
+  cursor: pointer;
+  height: var(--pine-dimension-sm);
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M3.646 3.646a.5.5 0 0 1 .708 0L8 7.293l3.646-3.647a.5.5 0 0 1 .708.708L8.707 8l3.647 3.646a.5.5 0 0 1-.708.708L8 8.707l-3.646 3.647a.5.5 0 0 1-.708-.708L7.293 8 3.646 4.354a.5.5 0 0 1 0-.708'/%3E%3C/svg%3E");
+  mask-size: contain;
+  width: var(--pine-dimension-sm);
+}
 

--- a/libs/core/src/components/pds-input/stories/pds-input.stories.js
+++ b/libs/core/src/components/pds-input/stories/pds-input.stories.js
@@ -71,6 +71,14 @@ Email.args = {
   value: 'user123@test.com'
 };
 
+export const Search = BaseTemplate.bind({});
+Search.args = {
+  componentId: 'pds-input-search-example',
+  label: 'Search',
+  type: 'search',
+  placeholder: 'Search...',
+};
+
 export const Required = BaseTemplate.bind({});
 Required.args = {
   componentId: 'pds-input-required-example',

--- a/libs/react/src/components/react-component-lib/createComponent.tsx
+++ b/libs/react/src/components/react-component-lib/createComponent.tsx
@@ -26,7 +26,10 @@ export const createReactComponent = <
   defineCustomElement?: () => void
 ) => {
   if (defineCustomElement !== undefined) {
-    defineCustomElement();
+    // Guard against double-registration when CDN and @pine-ds/react are both loaded
+    if (typeof customElements !== 'undefined' && !customElements.get(tagName)) {
+      defineCustomElement();
+    }
   }
 
   const displayName = dashToPascalCase(tagName);


### PR DESCRIPTION
# Description

Adds custom styling for the native search clear (x) button on `<input type="search">` within `pds-input`. The browser default clear button styling is replaced with a custom X icon using a mask-image SVG, colored with the `--pds-input-placeholder-color` token for a subtle appearance consistent with the input's design language.

Also commits the auto-generated `createComponent.tsx` from `@stencil/react-output-target@0.5.3`. This file was outdated in the repo — the current dependency version generates it with a `customElements.get()` guard to prevent double-registration. Every local build regenerates this file, causing a persistent diff. This commit syncs it with the current build output.

Fixes [DSS-137](https://linear.app/kajabi/issue/DSS-137/datatable-search-clear-icon-styling)

### Screenshots
||  Before   |  After  |
|--------|--------|--------|
|Light|<img width="390" height="92" alt="Screenshot 2026-02-06 at 10 59 58 AM" src="https://github.com/user-attachments/assets/230d0718-41a1-40cf-9376-918f0d0a169d" />|<img width="579" height="113" alt="Screenshot 2026-02-06 at 10 58 41 AM" src="https://github.com/user-attachments/assets/9765f564-1391-4bd0-b295-633621636d27" />|
|Dark|<img width="396" height="107" alt="Screenshot 2026-02-06 at 11 00 09 AM" src="https://github.com/user-attachments/assets/7f31762f-176e-4bd4-aea2-26f650dd3289" />|<img width="577" height="88" alt="Screenshot 2026-02-06 at 10 58 26 AM" src="https://github.com/user-attachments/assets/c8aea45d-6523-43b7-b49a-cf00653c6c57" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- OS: macOS
- Browsers: Chrome, Safari, Firefox (Firefox does not render a native search clear button)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings