### PR TITLE
fix(pds-dropdown-menu-item): add reflect prop

### DIFF
--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
@@ -24,7 +24,7 @@ export class PdsDropdownMenuItem implements BasePdsProps {
    * It determines whether or not the dropdown-item is disabled.
    * @defaultValue false
    */
-  @Prop() disabled: boolean = false;
+  @Prop({ reflect: true }) disabled: boolean = false;
 
 
   /**


### PR DESCRIPTION
# Description

The `disabled` prop on `pds-dropdown-menu-item` was not reflecting to the DOM attribute. This caused items to appear permanently disabled when `disabled="false"` was set, because the attribute remained present in the DOM regardless of its value. Adding `reflect: true` ensures Stencil properly adds/removes the `disabled` attribute based on the prop value.

This was reported as [FLEXOPS-679](https://linear.app/kajabi/issue/FLEXOPS-679/closed-caption-translations-cant-be-deleted-or-downloaded) — closed caption translation actions (Download, Delete) were greyed out and non-interactive.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- Pine versions: 3.16.1
- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes