### PR TITLE
fix(forms) redefine type property in forms

### DIFF
--- a/libs/core/src/utils/form.ts
+++ b/libs/core/src/utils/form.ts
@@ -37,6 +37,8 @@ export const isRequired = (target, component) => {
  * @param type - The type value (string literal) or a getter function that returns the type
  */
 export function exposeTypeProperty(element: Element, type: string | (() => string)) {
+  if (Object.getOwnPropertyDescriptor(element, 'type')) return;
+
   Object.defineProperty(element, 'type', {
     get: typeof type === 'function' ? type : () => type,
     enumerable: true,

--- a/libs/core/src/utils/test/form.spec.ts
+++ b/libs/core/src/utils/test/form.spec.ts
@@ -1,8 +1,36 @@
-import { isRequired } from '../form';
+import { isRequired, exposeTypeProperty } from '../form';
+
+interface ElementWithType extends Element {
+  type: string;
+}
 
 describe('isRequired', () => {
   it('returns empty string when no target or component defined', () => {
     expect(isRequired(undefined, undefined)).toEqual(undefined);
+  });
+});
+
+describe('exposeTypeProperty', () => {
+  it('defines a readonly type property on the element', () => {
+    const el = document.createElement('div') as unknown as ElementWithType;
+    exposeTypeProperty(el, 'select-one');
+    expect(el.type).toBe('select-one');
+  });
+
+  it('supports a getter function for the type value', () => {
+    const el = document.createElement('div') as unknown as ElementWithType;
+    let dynamicType = 'text';
+    exposeTypeProperty(el, () => dynamicType);
+    expect(el.type).toBe('text');
+    dynamicType = 'email';
+    expect(el.type).toBe('email');
+  });
+
+  it('does not throw when called multiple times on the same element', () => {
+    const el = document.createElement('div') as unknown as ElementWithType;
+    exposeTypeProperty(el, 'select-one');
+    expect(() => exposeTypeProperty(el, 'select-one')).not.toThrow();
+    expect(el.type).toBe('select-one');
   });
 });
 


### PR DESCRIPTION
## Summary                                                                                                                                                                   
  
  Fixes a `TypeError: Cannot redefine property: type` thrown when form-associated components (`pds-select`, `pds-input`, `pds-textarea`, `pds-switch`, `pds-radio`,            
  `pds-checkbox`) are moved in the DOM by a portal (e.g., `pds-popover`).
                                                                                                                                                                               
  ## Problem                                                                                                                                                                   

  The `exposeTypeProperty` utility in `form.ts` calls `Object.defineProperty(el, 'type', { configurable: false })` during `connectedCallback`. When a component is portaled,
  the element disconnects and reconnects, firing `connectedCallback` a second time. The second `defineProperty` call throws because the property was already defined as
  non-configurable.

  ## Fix

  Added an early return guard in `exposeTypeProperty` that checks if the `type` property already exists on the element instance before attempting to define it. This makes the
  function idempotent without changing any existing behavior.

  ## Affected Components

  - `pds-select`
  - `pds-textarea`
  - `pds-switch`
  - `pds-radio`
  - `pds-checkbox`

  ## Test Plan

  - [x] Added unit tests for `exposeTypeProperty` covering static values, getter functions, and duplicate call safety
  - [ ] Verify `pds-select` inside `pds-popover` no longer throws on open
  - [ ] Verify all form components continue to expose `type` correctly

  ## Linear Issue

  Fixes DSS-146