### PR TITLE
fix(pds-button): always render start/end slots for reliable content p…

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -217,6 +217,13 @@
 
 .pds-button__icon {
   display: inline-flex;
+
+  // Hide slot wrapper when no content is slotted to prevent empty flex gap space.
+  // Named slots (start/end) are always rendered in the shadow DOM so the browser
+  // can project light DOM content reliably regardless of render timing.
+  &:not(:has(::slotted(*))) {
+    display: none;
+  }
 }
 
 .pds-button__text {

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -207,28 +207,24 @@ export class PdsButton {
     return classNames.join(' ');
   }
 
-  private hasSlotContent(slotName: string): boolean {
-    const elements = this.el.querySelectorAll(`[slot="${slotName}"]`);
-    return elements.length > 0;
-  }
-
   private renderStartContent() {
-    const hasIcon = this.icon && this.variant !== 'disclosure' && this.variant !== 'filter';
-    const hasStartSlot = this.hasSlotContent('start');
-
     if (this.variant === 'filter') {
       return (
         <pds-icon class={this.loading ? 'pds-button__icon--hidden' : ''} icon={addCircle} part="icon" aria-hidden="true"></pds-icon>
       );
-    } else if (Boolean(hasIcon)) {
+    }
+
+    // Deprecated icon prop still takes precedence over start slot
+    const hasIcon = this.icon && this.variant !== 'disclosure';
+    if (Boolean(hasIcon)) {
       return (
         <pds-icon class={this.loading ? 'pds-button__icon--hidden' : ''} name={this.icon} part="icon" aria-hidden="true"></pds-icon>
       );
-    } else if (Boolean(hasStartSlot)) {
-      return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="start" /></span>;
     }
 
-    return null;
+    // Always render the start slot so slotted content is projected reliably.
+    // CSS hides the wrapper when no content is slotted (prevents empty gap space).
+    return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="start" /></span>;
   }
 
   private renderEndContent() {
@@ -240,11 +236,11 @@ export class PdsButton {
       return (
         <pds-icon class={this.loading ? 'pds-button__icon--hidden' : ''} icon={caretDown} part="caret" aria-hidden="true"></pds-icon>
       );
-    } else if (this.hasSlotContent('end')) {
-      return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="end" /></span>;
     }
 
-    return null;
+    // Always render the end slot so slotted content is projected reliably.
+    // CSS hides the wrapper when no content is slotted (prevents empty gap space).
+    return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="end" /></span>;
   }
 
   render() {

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -13,9 +13,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -33,9 +35,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--accent" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -53,9 +57,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--tertiary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -73,9 +79,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--small" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -93,9 +101,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--micro" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -157,9 +167,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--unstyled" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -177,9 +189,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button" disabled>
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -198,9 +212,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -222,6 +238,7 @@ describe('pds-button', () => {
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -240,6 +257,7 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
@@ -267,6 +285,7 @@ describe('pds-button', () => {
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -286,12 +305,14 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button aria-busy="true" aria-live="polite" class="pds-button pds-button--primary pds-button--loading" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon pds-button__icon--hidden"><slot name="start"></slot></span>
               <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
               <span class="pds-button__loader">
                 <pds-loader is-loading size="var(--pine-font-size-body-2xl)" variant="spinner" exportparts="loader-svg">Loading...</pds-loader>
               </span>
+              <span class="pds-button__icon pds-button__icon--hidden"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -352,9 +373,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -412,9 +435,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <a class="pds-button pds-button--primary" part="button" href="https://example.com" target="_blank">
             <div class="pds-button__content" part="button-content">
+              <span class="pds-button__icon"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
+              <span class="pds-button__icon"><slot name="end"></slot></span>
             </div>
           </a>
         </mock:shadow-root>
@@ -593,9 +618,9 @@ describe('pds-button', () => {
       expect(filterIcon).toBeTruthy();
       expect(filterIcon?.getAttribute('icon')).toBe(addCircle);
 
-      // Should not render start slot
-      const slotSpan = root?.shadowRoot?.querySelector('.pds-button__icon');
-      expect(slotSpan).toBeFalsy();
+      // Should not render start slot (filter variant overrides with its own icon)
+      const startSlot = root?.shadowRoot?.querySelector('slot[name="start"]');
+      expect(startSlot).toBeFalsy();
     });
 
     it('renders filter variant as anchor when href is provided', async () => {


### PR DESCRIPTION
# Description

The `pds-button` component was conditionally rendering `<slot name="start">` and `<slot name="end">` based on a synchronous DOM query (`this.el.querySelectorAll`) during `render()`. With Stencil's async task queue (`taskQueue: 'async'`), this created a race condition where `hasSlotContent()` could return `false` if light DOM children weren't yet queryable at render time. Since the component has no `@State`, `slotchange` listener, or `MutationObserver`, the slots were never placed in the shadow DOM and slotted content was never projected.

This was discovered in [kajabi-products PR #48962](https://github.com/Kajabi/kajabi-products/pull/48962) where using `<pds-icon slot="start">` instead of the deprecated `icon` prop resulted in the icon not rendering.

**The fix:**
- Always render `<slot name="start">` and `<slot name="end">` in the shadow DOM (removing the `hasSlotContent` DOM query)
- Use CSS `:has(::slotted(*))` to hide the wrapper `<span>` when no content is slotted, preventing empty flex gap space
- Deprecated `icon` prop and special variant behavior (filter, disclosure) remain unchanged

Fixes [DSS-147](https://linear.app/kajabi/issue/DSS-147/pds-button-slotted-startend-icons-not-rendering-due-to-conditional)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.16.2
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc:

Fixes 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR