### PR TITLE
feat(pds-multiselect): add hideSelectedItems prop

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1441,6 +1441,11 @@ export namespace Components {
          */
         "hideLabel": boolean;
         /**
+          * Hides the selected items summary section in the dropdown panel.
+          * @default false
+         */
+        "hideSelectedItems": boolean;
+        /**
           * If true, the multiselect is in an invalid state.
          */
         "invalid"?: boolean;
@@ -4447,6 +4452,11 @@ declare namespace LocalJSX {
           * @default false
          */
         "hideLabel"?: boolean;
+        /**
+          * Hides the selected items summary section in the dropdown panel.
+          * @default false
+         */
+        "hideSelectedItems"?: boolean;
         /**
           * If true, the multiselect is in an invalid state.
          */

--- a/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
+++ b/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
@@ -133,6 +133,52 @@ Use the `value` prop to set initially selected items. The trigger will display t
   </pds-multiselect>
 </DocCanvas>
 
+### Hidden Selected Items
+
+Use the `hide-selected-items` attribute to hide the selected items summary that appears above the options list in the dropdown. This prevents layout shift when selecting multiple items.
+
+<DocCanvas
+  mdxSource={{
+    webComponent: `<pds-multiselect
+  component-id="hidden-selected-select"
+  label="Departments"
+  placeholder="Select..."
+  hide-selected-items
+  value='["1", "3"]'
+>
+  <option value="1">Marketing</option>
+  <option value="2">Sales</option>
+  <option value="3">Support</option>
+  <option value="4">Engineering</option>
+</pds-multiselect>`,
+    react: `<PdsMultiselect
+  componentId="hidden-selected-select"
+  label="Departments"
+  placeholder="Select..."
+  hideSelectedItems
+  value={['1', '3']}
+>
+  <option value="1">Marketing</option>
+  <option value="2">Sales</option>
+  <option value="3">Support</option>
+  <option value="4">Engineering</option>
+</PdsMultiselect>`,
+  }}
+>
+  <pds-multiselect
+    component-id="hidden-selected-select"
+    label="Departments"
+    placeholder="Select..."
+    hide-selected-items
+    value='["1", "3"]'
+  >
+    <option value="1">Marketing</option>
+    <option value="2">Sales</option>
+    <option value="3">Support</option>
+    <option value="4">Engineering</option>
+  </pds-multiselect>
+</DocCanvas>
+
 ### Max Selections
 
 Limit the number of items that can be selected.

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -120,6 +120,11 @@ export class PdsMultiselect {
   @Prop() hideLabel: boolean = false;
 
   /**
+   * Hides the selected items summary section in the dropdown panel.
+   */
+  @Prop() hideSelectedItems: boolean = false;
+
+  /**
    * Error message to display.
    */
   @Prop() errorMessage?: string;
@@ -955,7 +960,7 @@ export class PdsMultiselect {
 
 
   private renderSelectedItemsList() {
-    if (this.selectedItems.length === 0) return null;
+    if (this.hideSelectedItems || this.selectedItems.length === 0) return null;
 
     return (
       <div class="pds-multiselect__selected-section">

--- a/libs/core/src/components/pds-multiselect/readme.md
+++ b/libs/core/src/components/pds-multiselect/readme.md
@@ -17,34 +17,35 @@ A multiselect component that allows users to select multiple options from a sear
 
 ## Properties
 
-| Property                   | Attribute          | Description                                                                                | Type                                   | Default          |
-| -------------------------- | ------------------ | ------------------------------------------------------------------------------------------ | -------------------------------------- | ---------------- |
-| `asyncMethod`              | `async-method`     | HTTP method for async requests.                                                            | `"GET" \| "POST"`                      | `'GET'`          |
-| `asyncUrl`                 | `async-url`        | URL endpoint for async data fetching.                                                      | `string`                               | `undefined`      |
-| `componentId` _(required)_ | `component-id`     | A unique identifier used for the underlying component `id` attribute.                      | `string`                               | `undefined`      |
-| `createUrl`                | `create-url`       | URL endpoint for creating new options. When set, shows "Add" option when no matches found. | `string`                               | `undefined`      |
-| `csrfHeaderName`           | `csrf-header-name` | CSRF header name for authenticated requests. Defaults to `X-CSRF-Token`.                   | `string`                               | `'X-CSRF-Token'` |
-| `csrfToken`                | `csrf-token`       | CSRF token for authenticated requests. If not provided, attempts to read from meta tag.    | `string`                               | `undefined`      |
-| `debounce`                 | `debounce`         | Debounce delay in milliseconds for search/fetch.                                           | `number`                               | `300`            |
-| `disabled`                 | `disabled`         | Determines whether or not the multiselect is disabled.                                     | `boolean`                              | `false`          |
-| `errorMessage`             | `error-message`    | Error message to display.                                                                  | `string`                               | `undefined`      |
-| `fetchTimeout`             | `fetch-timeout`    | Timeout in milliseconds for async fetch requests.                                          | `number`                               | `30000`          |
-| `formatResult`             | --                 | Function to format async results. Receives raw API response item.                          | `(item: unknown) => MultiselectOption` | `undefined`      |
-| `helperMessage`            | `helper-message`   | Helper message to display below the input.                                                 | `string`                               | `undefined`      |
-| `hideLabel`                | `hide-label`       | Visually hides the label but keeps it accessible.                                          | `boolean`                              | `false`          |
-| `invalid`                  | `invalid`          | If true, the multiselect is in an invalid state.                                           | `boolean`                              | `undefined`      |
-| `label`                    | `label`            | Text to be displayed as the multiselect label.                                             | `string`                               | `undefined`      |
-| `loading`                  | `loading`          | Whether the component is currently loading async options.                                  | `boolean`                              | `false`          |
-| `maxHeight`                | `max-height`       | Maximum height of the dropdown before scrolling.                                           | `string`                               | `'300px'`        |
-| `maxSelections`            | `max-selections`   | Maximum number of selections allowed.                                                      | `number`                               | `undefined`      |
-| `minWidth`                 | `min-width`        | Minimum width of the dropdown panel.                                                       | `string`                               | `'250px'`        |
-| `name`                     | `name`             | Specifies the name. Submitted with the form as part of a name/value pair.                  | `string`                               | `undefined`      |
-| `options`                  | --                 | Options provided externally (for consumer-managed async).                                  | `MultiselectOption[]`                  | `undefined`      |
-| `panelWidth`               | `panel-width`      | Width of the dropdown panel. Defaults to the trigger width.                                | `string`                               | `undefined`      |
-| `placeholder`              | `placeholder`      | Placeholder text for the input field.                                                      | `string`                               | `'Select...'`    |
-| `required`                 | `required`         | If true, the multiselect is required.                                                      | `boolean`                              | `false`          |
-| `triggerWidth`             | `trigger-width`    | Width of the trigger button (and reference for dropdown positioning).                      | `string`                               | `'100%'`         |
-| `value`                    | --                 | Array of selected option values.                                                           | `string[]`                             | `[]`             |
+| Property                   | Attribute             | Description                                                                                | Type                                   | Default          |
+| -------------------------- | --------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------- | ---------------- |
+| `asyncMethod`              | `async-method`        | HTTP method for async requests.                                                            | `"GET" \| "POST"`                      | `'GET'`          |
+| `asyncUrl`                 | `async-url`           | URL endpoint for async data fetching.                                                      | `string`                               | `undefined`      |
+| `componentId` _(required)_ | `component-id`        | A unique identifier used for the underlying component `id` attribute.                      | `string`                               | `undefined`      |
+| `createUrl`                | `create-url`          | URL endpoint for creating new options. When set, shows "Add" option when no matches found. | `string`                               | `undefined`      |
+| `csrfHeaderName`           | `csrf-header-name`    | CSRF header name for authenticated requests. Defaults to `X-CSRF-Token`.                   | `string`                               | `'X-CSRF-Token'` |
+| `csrfToken`                | `csrf-token`          | CSRF token for authenticated requests. If not provided, attempts to read from meta tag.    | `string`                               | `undefined`      |
+| `debounce`                 | `debounce`            | Debounce delay in milliseconds for search/fetch.                                           | `number`                               | `300`            |
+| `disabled`                 | `disabled`            | Determines whether or not the multiselect is disabled.                                     | `boolean`                              | `false`          |
+| `errorMessage`             | `error-message`       | Error message to display.                                                                  | `string`                               | `undefined`      |
+| `fetchTimeout`             | `fetch-timeout`       | Timeout in milliseconds for async fetch requests.                                          | `number`                               | `30000`          |
+| `formatResult`             | --                    | Function to format async results. Receives raw API response item.                          | `(item: unknown) => MultiselectOption` | `undefined`      |
+| `helperMessage`            | `helper-message`      | Helper message to display below the input.                                                 | `string`                               | `undefined`      |
+| `hideLabel`                | `hide-label`          | Visually hides the label but keeps it accessible.                                          | `boolean`                              | `false`          |
+| `hideSelectedItems`        | `hide-selected-items` | Hides the selected items summary section in the dropdown panel.                            | `boolean`                              | `false`          |
+| `invalid`                  | `invalid`             | If true, the multiselect is in an invalid state.                                           | `boolean`                              | `undefined`      |
+| `label`                    | `label`               | Text to be displayed as the multiselect label.                                             | `string`                               | `undefined`      |
+| `loading`                  | `loading`             | Whether the component is currently loading async options.                                  | `boolean`                              | `false`          |
+| `maxHeight`                | `max-height`          | Maximum height of the dropdown before scrolling.                                           | `string`                               | `'300px'`        |
+| `maxSelections`            | `max-selections`      | Maximum number of selections allowed.                                                      | `number`                               | `undefined`      |
+| `minWidth`                 | `min-width`           | Minimum width of the dropdown panel.                                                       | `string`                               | `'250px'`        |
+| `name`                     | `name`                | Specifies the name. Submitted with the form as part of a name/value pair.                  | `string`                               | `undefined`      |
+| `options`                  | --                    | Options provided externally (for consumer-managed async).                                  | `MultiselectOption[]`                  | `undefined`      |
+| `panelWidth`               | `panel-width`         | Width of the dropdown panel. Defaults to the trigger width.                                | `string`                               | `undefined`      |
+| `placeholder`              | `placeholder`         | Placeholder text for the input field.                                                      | `string`                               | `'Select...'`    |
+| `required`                 | `required`            | If true, the multiselect is required.                                                      | `boolean`                              | `false`          |
+| `triggerWidth`             | `trigger-width`       | Width of the trigger button (and reference for dropdown positioning).                      | `string`                               | `'100%'`         |
+| `value`                    | --                    | Array of selected option values.                                                           | `string[]`                             | `[]`             |
 
 
 ## Events

--- a/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
+++ b/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
@@ -94,6 +94,7 @@ export const Default = {
       component-id="${args.componentId}"
       label="${args.label}"
       placeholder="${args.placeholder}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -114,6 +115,7 @@ export const WithPreselectedValues = {
       component-id="${args.componentId}"
       label="${args.label}"
       placeholder="${args.placeholder}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -136,6 +138,7 @@ export const MaxSelections = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       max-selections="${args.maxSelections}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -161,6 +164,7 @@ export const WithMessage = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       helper-message="${args.helperMessage}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -185,6 +189,7 @@ export const Invalid = {
       placeholder="${args.placeholder}"
       error-message="${args.errorMessage}"
       ?invalid=${args.invalid}
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -207,6 +212,7 @@ export const Disabled = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       ?disabled=${args.disabled}
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -229,6 +235,7 @@ export const HiddenLabel = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       ?hide-label=${args.hideLabel}
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -273,6 +280,7 @@ export const LongList = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       max-height="${args.maxHeight}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -318,6 +326,7 @@ export const CustomWidths = {
       trigger-width="${args.triggerWidth}"
       panel-width="${args.panelWidth}"
       min-width="${args.minWidth}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -351,6 +360,7 @@ export const ConsumerManagedAsync = {
         label="${args.label}"
         placeholder="${args.placeholder}"
         .options=${allContacts}
+        ?hide-selected-items=${args.hideSelectedItems}
         .value=${args.value}
         @pdsMultiselectSearch=${(e) => {
           console.log('Search query:', e.detail.query);
@@ -383,6 +393,7 @@ export const CustomEmptyState = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       .options=${[]}
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >
@@ -411,6 +422,7 @@ export const WithCreateOption = {
         label="${args.label}"
         placeholder="${args.placeholder}"
         create-url="/api/tags"
+        ?hide-selected-items=${args.hideSelectedItems}
         .value=${args.value}
         @pdsMultiselectCreate=${async (e) => {
           console.log('Creating new tag:', e.detail.query);

--- a/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
+++ b/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
@@ -52,6 +52,10 @@ export default {
       control: 'boolean',
       description: 'Visually hide the label (keeps it accessible)',
     },
+    hideSelectedItems: {
+      control: 'boolean',
+      description: 'Hides the selected items summary section in the dropdown panel',
+    },
     errorMessage: {
       control: 'text',
       description: 'Error message to display',
@@ -225,6 +229,28 @@ export const HiddenLabel = {
       label="${args.label}"
       placeholder="${args.placeholder}"
       ?hide-label=${args.hideLabel}
+      .value=${args.value}
+      @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
+    >
+      ${unsafeHTML(defaultOptions)}
+    </pds-multiselect>
+  `,
+};
+
+export const HiddenSelectedItems = {
+  args: {
+    componentId: 'multiselect-hidden-selected',
+    label: 'Departments',
+    placeholder: 'Select...',
+    hideSelectedItems: true,
+    value: ['1', '2', '3'],
+  },
+  render: (args, { updateArgs } = {}) => html`
+    <pds-multiselect
+      component-id="${args.componentId}"
+      label="${args.label}"
+      placeholder="${args.placeholder}"
+      ?hide-selected-items=${args.hideSelectedItems}
       .value=${args.value}
       @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
     >

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -542,6 +542,47 @@ describe('pds-multiselect', () => {
       const selectedSection = page.root.shadowRoot.querySelector('.pds-multiselect__selected-section');
       expect(selectedSection).toBeNull();
     });
+
+    it('does not render selected items section when hideSelectedItems is true', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test" hide-selected-items></pds-multiselect>`,
+      });
+
+      page.rootInstance.value = ['1', '2'];
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Option 1' },
+        { id: '2', text: 'Option 2' },
+        { id: '3', text: 'Option 3' },
+      ];
+      page.rootInstance.isOpen = true;
+      await page.waitForChanges();
+
+      const selectedSection = page.root.shadowRoot.querySelector('.pds-multiselect__selected-section');
+      expect(selectedSection).toBeNull();
+    });
+
+    it('still emits pdsMultiselectChange when hideSelectedItems is true', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test" hide-selected-items></pds-multiselect>`,
+      });
+
+      const changeSpy = jest.fn();
+      page.root.addEventListener('pdsMultiselectChange', changeSpy);
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Option 1' },
+        { id: '2', text: 'Option 2' },
+      ];
+      await page.waitForChanges();
+
+      page.rootInstance.toggleOption({ id: '1', text: 'Option 1' });
+      await page.waitForChanges();
+
+      expect(changeSpy).toHaveBeenCalled();
+      expect(changeSpy.mock.calls[0][0].detail.values).toEqual(['1']);
+    });
   });
 
   describe('required validation', () => {


### PR DESCRIPTION
# Description

Adds a `hideSelectedItems` boolean prop (default `false`) to `pds-multiselect` that hides the selected items summary section in the dropdown panel. This prevents layout shift when selecting multiple items, addressing a UX pain point where the growing summary pushes the checkbox list down and forces users to reposition their mouse.

Non-breaking change — all existing implementations are unaffected.

Fixes DSS-155

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.16.3
- OS: macOS
- Browsers:
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR