### PR TITLE
feat(pds-table): add disableSelectAll prop to hide header checkbox

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1913,6 +1913,11 @@ export namespace Components {
          */
         "defaultSortDirection"?: 'asc' | 'desc';
         /**
+          * Hides the select-all checkbox in the table header while keeping individual row checkboxes functional. Only applies when `selectable` is true.
+          * @defaultValue false
+         */
+        "disableSelectAll": boolean;
+        /**
           * Determines if the should display a fixed first column.
          */
         "fixedColumn": boolean;
@@ -4965,6 +4970,11 @@ declare namespace LocalJSX {
           * @defaultValue 'asc'
          */
         "defaultSortDirection"?: 'asc' | 'desc';
+        /**
+          * Hides the select-all checkbox in the table header while keeping individual row checkboxes functional. Only applies when `selectable` is true.
+          * @defaultValue false
+         */
+        "disableSelectAll"?: boolean;
         /**
           * Determines if the should display a fixed first column.
          */

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -380,6 +380,86 @@ When the `selectable` prop is set to `true`, the table will render a checkbox in
   </pds-table>
 </DocCanvas>
 
+### Selectable without Select All
+
+When the `disable-select-all` prop is set to `true` alongside `selectable`, the select-all checkbox in the header is hidden while individual row checkboxes remain functional. This is useful when bulk selection is not appropriate but per-row selection is still needed.
+
+<DocCanvas mdxSource={{
+  react: `<PdsTable componentId="selectable-no-select-all" selectable={true} disableSelectAll={true}>
+  <PdsTableHead>
+    <PdsTableHeadCell>Column Title</PdsTableHeadCell>
+    <PdsTableHeadCell>Column Title</PdsTableHeadCell>
+    <PdsTableHeadCell>Column Title</PdsTableHeadCell>
+  </PdsTableHead>
+  <PdsTableBody>
+    <PdsTableRow>
+      <PdsTableCell>Row Item Alpha</PdsTableCell>
+      <PdsTableCell>Row Item Beta</PdsTableCell>
+      <PdsTableCell>Row Item Charlie</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>Row Item Alpha</PdsTableCell>
+      <PdsTableCell>Row Item Beta</PdsTableCell>
+      <PdsTableCell>Row Item Charlie</PdsTableCell>
+    </PdsTableRow>
+    <PdsTableRow>
+      <PdsTableCell>Row Item Alpha</PdsTableCell>
+      <PdsTableCell>Row Item Beta</PdsTableCell>
+      <PdsTableCell>Row Item Charlie</PdsTableCell>
+    </PdsTableRow>
+  </PdsTableBody>
+</PdsTable>`,
+  webComponent: `<pds-table component-id="selectable-no-select-all" selectable disable-select-all>
+  <pds-table-head>
+    <pds-table-head-cell>Column Title</pds-table-head-cell>
+    <pds-table-head-cell>Column Title</pds-table-head-cell>
+    <pds-table-head-cell>Column Title</pds-table-head-cell>
+  </pds-table-head>
+  <pds-table-body>
+    <pds-table-row>
+      <pds-table-cell>Row Item Alpha</pds-table-cell>
+      <pds-table-cell>Row Item Beta</pds-table-cell>
+      <pds-table-cell>Row Item Charlie</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Row Item Alpha</pds-table-cell>
+      <pds-table-cell>Row Item Beta</pds-table-cell>
+      <pds-table-cell>Row Item Charlie</pds-table-cell>
+    </pds-table-row>
+    <pds-table-row>
+      <pds-table-cell>Row Item Alpha</pds-table-cell>
+      <pds-table-cell>Row Item Beta</pds-table-cell>
+      <pds-table-cell>Row Item Charlie</pds-table-cell>
+    </pds-table-row>
+  </pds-table-body>
+</pds-table>
+`}}>
+  <pds-table component-id="selectable-no-select-all" selectable disable-select-all>
+    <pds-table-head>
+      <pds-table-head-cell>Column Title</pds-table-head-cell>
+      <pds-table-head-cell>Column Title</pds-table-head-cell>
+      <pds-table-head-cell>Column Title</pds-table-head-cell>
+    </pds-table-head>
+    <pds-table-body>
+      <pds-table-row>
+        <pds-table-cell>Row Item Alpha</pds-table-cell>
+        <pds-table-cell>Row Item Beta</pds-table-cell>
+        <pds-table-cell>Row Item Charlie</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Row Item Alpha</pds-table-cell>
+        <pds-table-cell>Row Item Beta</pds-table-cell>
+        <pds-table-cell>Row Item Charlie</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell>Row Item Alpha</pds-table-cell>
+        <pds-table-cell>Row Item Beta</pds-table-cell>
+        <pds-table-cell>Row Item Charlie</pds-table-cell>
+      </pds-table-row>
+    </pds-table-body>
+  </pds-table>
+</DocCanvas>
+
 
 ### Responsive
 

--- a/libs/core/src/components/pds-table/pds-table-head/pds-table-head.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head/pds-table-head.tsx
@@ -79,15 +79,17 @@ export class PdsTableHead {
       <Host role="row" part="head">
         {this.tableRef && this.tableRef.selectable && (
           <pds-table-head-cell part={this.tableRef.selectable ? 'checkbox-cell' : ''}>
-            <pds-checkbox
-              componentId={this.generateUniqueId()}
-              indeterminate={this.indeterminate}
-              onInput={this.handleInput}
-              label={"Select All Rows"}
-              hideLabel={true}
-              checked={this.isSelected}
-              part="select-all-checkbox"
-            />
+            {!this.tableRef.disableSelectAll && (
+              <pds-checkbox
+                componentId={this.generateUniqueId()}
+                indeterminate={this.indeterminate}
+                onInput={this.handleInput}
+                label={"Select All Rows"}
+                hideLabel={true}
+                checked={this.isSelected}
+                part="select-all-checkbox"
+              />
+            )}
           </pds-table-head-cell>
         )}
         <slot></slot>

--- a/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-head/test/pds-table-head.spec.tsx
@@ -129,6 +129,29 @@ describe('pds-table-head', () => {
     expect((head as unknown as PdsTableHead).isSelected).toBe(true);
   });
 
+  it('does not render pds-checkbox when disableSelectAll is set on parent table', async () => {
+    const page = await newSpecPage({
+      components: [PdsTableHead, PdsTable],
+      html: `
+        <pds-table selectable="true" disable-select-all="true">
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+        </pds-table>`,
+    });
+
+    const head = page.root?.querySelector('pds-table-head');
+    const checkbox = head?.shadowRoot?.querySelector('pds-checkbox');
+    const headCell = head?.shadowRoot?.querySelector('pds-table-head-cell');
+
+    // Checkbox should not be rendered
+    expect(checkbox).toBeNull();
+    // But the container cell should still exist for column alignment
+    expect(headCell).not.toBeNull();
+  });
+
   it('renders with border attribute when border prop is set', async () => {
     const page = await newSpecPage({
       components: [PdsTableHead],

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -39,6 +39,13 @@ export class PdsTable {
   @Prop() selectable: boolean;
 
   /**
+   * Hides the select-all checkbox in the table header while keeping individual row checkboxes functional.
+   * Only applies when `selectable` is true.
+   * @defaultValue false
+   */
+  @Prop() disableSelectAll: boolean = false;
+
+  /**
    * Adds divider borders between table rows. The last row will not have a bottom border.
    * @defaultValue false
    */
@@ -319,8 +326,10 @@ export class PdsTable {
     if (!pdsTableHead) return;
 
     const headerCheckbox = pdsTableHead.shadowRoot.querySelector('pds-checkbox');
-    headerCheckbox.checked = allSelectedRows;
-    headerCheckbox.indeterminate = !allSelectedRows && !noneSelectedRows;
+    if (headerCheckbox) {
+      headerCheckbox.checked = allSelectedRows;
+      headerCheckbox.indeterminate = !allSelectedRows && !noneSelectedRows;
+    }
   }
 
   render() {

--- a/libs/core/src/components/pds-table/readme.md
+++ b/libs/core/src/components/pds-table/readme.md
@@ -7,16 +7,17 @@
 
 ## Properties
 
-| Property                   | Attribute                | Description                                                                                                 | Type              | Default     |
-| -------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------- | ----------------- | ----------- |
-| `compact`                  | `compact`                | Determines if the table displays with reduced table cell padding.                                           | `boolean`         | `undefined` |
-| `componentId` _(required)_ | `component-id`           | A unique identifier used for the table `id` attribute.                                                      | `string`          | `undefined` |
-| `defaultSortColumn`        | `default-sort-column`    | The name of the column to sort by on initial load. Must match the text content of a sortable column header. | `string`          | `undefined` |
-| `defaultSortDirection`     | `default-sort-direction` | The direction to sort the default column on initial load. Only applies if `defaultSortColumn` is set.       | `"asc" \| "desc"` | `'asc'`     |
-| `fixedColumn`              | `fixed-column`           | Determines if the should display a fixed first column.                                                      | `boolean`         | `undefined` |
-| `responsive`               | `responsive`             | Enables the table to be responsive by horizontally scrolling on smaller screens.                            | `boolean`         | `undefined` |
-| `rowDividers`              | `row-dividers`           | Adds divider borders between table rows. The last row will not have a bottom border.                        | `boolean`         | `false`     |
-| `selectable`               | `selectable`             | Determines if the table displays checkboxes for selectable rows.                                            | `boolean`         | `undefined` |
+| Property                   | Attribute                | Description                                                                                                                                   | Type              | Default     |
+| -------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ----------- |
+| `compact`                  | `compact`                | Determines if the table displays with reduced table cell padding.                                                                             | `boolean`         | `undefined` |
+| `componentId` _(required)_ | `component-id`           | A unique identifier used for the table `id` attribute.                                                                                        | `string`          | `undefined` |
+| `defaultSortColumn`        | `default-sort-column`    | The name of the column to sort by on initial load. Must match the text content of a sortable column header.                                   | `string`          | `undefined` |
+| `defaultSortDirection`     | `default-sort-direction` | The direction to sort the default column on initial load. Only applies if `defaultSortColumn` is set.                                         | `"asc" \| "desc"` | `'asc'`     |
+| `disableSelectAll`         | `disable-select-all`     | Hides the select-all checkbox in the table header while keeping individual row checkboxes functional. Only applies when `selectable` is true. | `boolean`         | `false`     |
+| `fixedColumn`              | `fixed-column`           | Determines if the should display a fixed first column.                                                                                        | `boolean`         | `undefined` |
+| `responsive`               | `responsive`             | Enables the table to be responsive by horizontally scrolling on smaller screens.                                                              | `boolean`         | `undefined` |
+| `rowDividers`              | `row-dividers`           | Adds divider borders between table rows. The last row will not have a bottom border.                                                          | `boolean`         | `false`     |
+| `selectable`               | `selectable`             | Determines if the table displays checkboxes for selectable rows.                                                                              | `boolean`         | `undefined` |
 
 
 ## Events

--- a/libs/core/src/components/pds-table/stories/pds-table.stories.js
+++ b/libs/core/src/components/pds-table/stories/pds-table.stories.js
@@ -24,6 +24,10 @@ export default {
       control: { type: 'boolean' },
       description: 'Adds divider borders between table rows. The last row will not have a bottom border',
     },
+    disableSelectAll: {
+      control: { type: 'boolean' },
+      description: 'Hides the select-all checkbox in the table header while keeping individual row checkboxes functional. Only applies when selectable is true.',
+    },
     defaultSortColumn: {
       control: { type: 'text' },
       description: 'The name of the column to sort by on initial load. Must match the text content of a sortable column header.',
@@ -50,6 +54,7 @@ const BaseTemplate = (args) => html`
   ?responsive=${args.responsive}
   ?row-dividers=${args.rowDividers}
   ?selectable=${args.selectable}
+  ?disable-select-all=${args.disableSelectAll}
 >
   <pds-table-head
     ?border=${args.border}
@@ -371,6 +376,19 @@ Selectable.args = {
   responsive: false,
   rowDividers: false,
   selectable: true,
+};
+
+export const DisableSelectAll = BaseTemplate.bind();
+DisableSelectAll.args = {
+  compact: false,
+  componentId: 'selectable-no-select-all',
+  fixedColumn: false,
+  border: false,
+  background: false,
+  responsive: false,
+  rowDividers: false,
+  selectable: true,
+  disableSelectAll: true,
 };
 
 export const Responsive = ResponsiveTemplate.bind();

--- a/libs/core/src/components/pds-table/test/pds-table.spec.tsx
+++ b/libs/core/src/components/pds-table/test/pds-table.spec.tsx
@@ -542,6 +542,112 @@ describe('pds-table', () => {
     expect(values).toEqual(['Charlie', 'Alice', 'Bob']);
   });
 
+  it('does not render header checkbox when disableSelectAll is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table selectable disable-select-all>
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Row 1, Column 1</pds-table-cell>
+              <pds-table-cell>Row 1, Column 2</pds-table-cell>
+              <pds-table-cell>Row 1, Column 3</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const head = page.root?.querySelector('pds-table-head');
+    const headerCheckbox = head?.shadowRoot?.querySelector('pds-checkbox');
+
+    // Checkbox should NOT be rendered
+    expect(headerCheckbox).toBeNull();
+  });
+
+  it('still renders the header checkbox cell for column alignment when disableSelectAll is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table selectable disable-select-all>
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Row 1</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const head = page.root?.querySelector('pds-table-head');
+    const headCells = head?.shadowRoot?.querySelectorAll('pds-table-head-cell');
+
+    // The checkbox cell container should still exist (for column alignment)
+    expect(headCells?.length).toBeGreaterThan(0);
+  });
+
+  it('row checkboxes still render when disableSelectAll is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table selectable disable-select-all>
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Row 1</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const row = page.root?.querySelector('pds-table-row');
+    const rowCheckbox = row?.shadowRoot?.querySelector('pds-checkbox');
+
+    // Row checkbox should still be rendered
+    expect(rowCheckbox).not.toBeNull();
+  });
+
+  it('does not throw when row is selected and header checkbox is absent (disableSelectAll)', async () => {
+    const page = await newSpecPage({
+      components: [PdsTable, PdsTableHead, PdsTableBody, PdsTableRow, PdsTableCell],
+      html: `
+        <pds-table selectable disable-select-all>
+          <pds-table-head>
+            <pds-table-head-cell>Column Title</pds-table-head-cell>
+          </pds-table-head>
+          <pds-table-body>
+            <pds-table-row>
+              <pds-table-cell>Row 1</pds-table-cell>
+            </pds-table-row>
+          </pds-table-body>
+        </pds-table>
+      `,
+    });
+
+    const table = page.root;
+
+    // Should not throw when dispatching row selection event
+    expect(() => {
+      table?.dispatchEvent(
+        new CustomEvent('pdsTableRowSelected', {
+          detail: { rowIndex: 0, isSelected: true },
+          bubbles: true,
+        })
+      );
+    }).not.toThrow();
+  });
+
   it('does not crash when sorting a table without a body', async () => {
     const page = await newSpecPage({
       components: [PdsTable, PdsTableHead, PdsTableHeadCell],


### PR DESCRIPTION
# Description

Adds a `disableSelectAll` boolean prop to `pds-table` that hides the select-all checkbox in the table header while keeping individual row checkboxes functional. This is useful when bulk selection isn't appropriate but per-row selection is still needed.

The header cell container is preserved when `disableSelectAll` is true to maintain column alignment with row checkbox cells. A null guard is added to `handleTableSelect` to prevent crashes when the header checkbox doesn't exist.

Fixes [DSS-162](https://linear.app/kajabi/issue/DSS-162/add-disableselectall-prop-to-pds-table)

<img width="1075" height="435" alt="Screenshot 2026-02-13 at 11 38 35 AM" src="https://github.com/user-attachments/assets/b1118abb-5d5b-4a1e-83cc-11205daeede9" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.17.0
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR