### PR TITLE
fix(pds-table): remove unused pdsTableSelect event declaration

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -2807,7 +2807,6 @@ declare global {
         new (): HTMLPdsTabElement;
     };
     interface HTMLPdsTableElementEventMap {
-        "pdsTableSelect": { rowIndex: number; isSelected: boolean };
         "pdsTableSelectAll": { isSelected: boolean };
     }
     interface HTMLPdsTableElement extends Components.PdsTable, HTMLStencilElement {
@@ -4979,10 +4978,6 @@ declare namespace LocalJSX {
           * Determines if the should display a fixed first column.
          */
         "fixedColumn"?: boolean;
-        /**
-          * Event that is emitted when the checkbox is clicked, carrying the rowIndex and selected value.
-         */
-        "onPdsTableSelect"?: (event: PdsTableCustomEvent<{ rowIndex: number; isSelected: boolean }>) => void;
         /**
           * Event that is emitted when the select all checkbox is clicked, carrying the selected value.
          */

--- a/libs/core/src/components/pds-table/pds-table.tsx
+++ b/libs/core/src/components/pds-table/pds-table.tsx
@@ -78,11 +78,6 @@ export class PdsTable {
 
 
   /**
-   * Event that is emitted when the checkbox is clicked, carrying the rowIndex and selected value.
-   */
-  @Event() pdsTableSelect: EventEmitter<{ rowIndex: number; isSelected: boolean }>;
-
-  /**
    * Event that is emitted when the select all checkbox is clicked, carrying the selected value.
    */
   @Event() pdsTableSelectAll: EventEmitter<{ isSelected: boolean }>;

--- a/libs/core/src/components/pds-table/readme.md
+++ b/libs/core/src/components/pds-table/readme.md
@@ -22,10 +22,9 @@
 
 ## Events
 
-| Event               | Description                                                                                   | Type                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| `pdsTableSelect`    | Event that is emitted when the checkbox is clicked, carrying the rowIndex and selected value. | `CustomEvent<{ rowIndex: number; isSelected: boolean; }>` |
-| `pdsTableSelectAll` | Event that is emitted when the select all checkbox is clicked, carrying the selected value.   | `CustomEvent<{ isSelected: boolean; }>`                   |
+| Event               | Description                                                                                 | Type                                    |
+| ------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `pdsTableSelectAll` | Event that is emitted when the select all checkbox is clicked, carrying the selected value. | `CustomEvent<{ isSelected: boolean; }>` |
 
 
 ## Shadow Parts


### PR DESCRIPTION
# Description

Removes the unused `pdsTableSelect` event declaration from `pds-table`. This event was declared via `@Event()` but never `.emit()`ed anywhere in the codebase. The actual row selection event is `pdsTableRowSelected`, which is emitted by `pds-table-row` and listened to by `pds-table` via `@Listen('pdsTableRowSelected')`.

The nearly identical JSDoc descriptions between `pdsTableSelect` and `pdsTableRowSelected` caused confusion in the generated docs.

Fixes [DSS-164](https://linear.app/kajabi/issue/DSS-164/clean-up-unused-pdstableselect-event-on-pds-table)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

**Test Configuration**:

- Pine versions: 3.17.0
- OS: macOS
- Browsers: N/A
- Screen readers: N/A
- Misc: Verified `pdsTableSelectAll` and `pdsTableRowSelected` events are unaffected. Confirmed zero references in kajabi-products.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes