### PR TITLE
fix(pds-button): fix empty icon slot wrapper spacing

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -218,10 +218,7 @@
 .pds-button__icon {
   display: inline-flex;
 
-  // Hide slot wrapper when no content is slotted to prevent empty flex gap space.
-  // Named slots (start/end) are always rendered in the shadow DOM so the browser
-  // can project light DOM content reliably regardless of render timing.
-  &:not(:has(::slotted(*))) {
+  &--empty {
     display: none;
   }
 }

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -158,11 +158,11 @@ export class PdsButton {
 
 
   private handleStartSlotChange = (event: Event) => {
-    this.hasStartContent = (event.target as HTMLSlotElement).assignedNodes().length > 0;
+    this.hasStartContent = (event.target as HTMLSlotElement).assignedElements({ flatten: true }).length > 0;
   };
 
   private handleEndSlotChange = (event: Event) => {
-    this.hasEndContent = (event.target as HTMLSlotElement).assignedNodes().length > 0;
+    this.hasEndContent = (event.target as HTMLSlotElement).assignedElements({ flatten: true }).length > 0;
   };
 
   private handleClick = (ev: Event) => {

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, h, Listen, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Host, h, Listen, Prop, State } from '@stencil/core';
 import { hasShadowDom } from '../../utils/utils';
 
 import { caretDown, addCircle } from '@pine-ds/icons/icons';
@@ -99,6 +99,9 @@ export class PdsButton {
    */
   @Prop() variant: 'primary' | 'secondary' | 'tertiary' | 'accent' | 'disclosure' | 'destructive' | 'unstyled' | 'filter' = 'primary';
 
+  @State() hasStartContent = false;
+  @State() hasEndContent = false;
+
   @Event() pdsClick: EventEmitter<Event>;
 
   /**
@@ -153,6 +156,14 @@ export class PdsButton {
     }
   }
 
+
+  private handleStartSlotChange = (event: Event) => {
+    this.hasStartContent = (event.target as HTMLSlotElement).assignedNodes().length > 0;
+  };
+
+  private handleEndSlotChange = (event: Event) => {
+    this.hasEndContent = (event.target as HTMLSlotElement).assignedNodes().length > 0;
+  };
 
   private handleClick = (ev: Event) => {
     if (this.loading) {
@@ -223,8 +234,9 @@ export class PdsButton {
     }
 
     // Always render the start slot so slotted content is projected reliably.
-    // CSS hides the wrapper when no content is slotted (prevents empty gap space).
-    return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="start" /></span>;
+    // The --empty class hides the wrapper when no content is slotted (prevents empty gap space).
+    const startClasses = `pds-button__icon${this.hasStartContent ? '' : ' pds-button__icon--empty'}${this.loading ? ' pds-button__icon--hidden' : ''}`;
+    return <span class={startClasses}><slot name="start" onSlotchange={this.handleStartSlotChange} /></span>;
   }
 
   private renderEndContent() {
@@ -239,8 +251,9 @@ export class PdsButton {
     }
 
     // Always render the end slot so slotted content is projected reliably.
-    // CSS hides the wrapper when no content is slotted (prevents empty gap space).
-    return <span class={`pds-button__icon ${this.loading ? 'pds-button__icon--hidden' : ''}`}><slot name="end" /></span>;
+    // The --empty class hides the wrapper when no content is slotted (prevents empty gap space).
+    const endClasses = `pds-button__icon${this.hasEndContent ? '' : ' pds-button__icon--empty'}${this.loading ? ' pds-button__icon--hidden' : ''}`;
+    return <span class={endClasses}><slot name="end" onSlotchange={this.handleEndSlotChange} /></span>;
   }
 
   render() {

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -224,6 +224,8 @@ describe('pds-button', () => {
     `);
   });
 
+  // Note: Snapshot still shows --empty on slot wrappers because newSpecPage does not
+  // fire slotchange events. The "slot empty class" suite below covers that behavior.
   it('renders a leading icon', async () => {
     const { root } = await newSpecPage({
       components: [PdsButton],
@@ -247,6 +249,7 @@ describe('pds-button', () => {
     `);
   });
 
+  // Note: See above — newSpecPage doesn't fire slotchange, so --empty persists in snapshot.
   it('renders a trailing icon', async () => {
     const { root } = await newSpecPage({
       components: [PdsButton],
@@ -664,7 +667,7 @@ describe('pds-button', () => {
       // Simulate slotchange since newSpecPage doesn't fire it automatically
       const slotchangeEvent = new Event('slotchange');
       Object.defineProperty(slotchangeEvent, 'target', {
-        value: { assignedNodes: () => [document.createElement('pds-icon')] },
+        value: { assignedElements: () => [document.createElement('pds-icon')] },
       });
       startSlot?.dispatchEvent(slotchangeEvent);
       await page.waitForChanges();
@@ -684,7 +687,7 @@ describe('pds-button', () => {
       // Simulate slotchange since newSpecPage doesn't fire it automatically
       const slotchangeEvent = new Event('slotchange');
       Object.defineProperty(slotchangeEvent, 'target', {
-        value: { assignedNodes: () => [document.createElement('pds-icon')] },
+        value: { assignedElements: () => [document.createElement('pds-icon')] },
       });
       endSlot?.dispatchEvent(slotchangeEvent);
       await page.waitForChanges();

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -13,11 +13,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -35,11 +35,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--accent" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -57,11 +57,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--tertiary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -79,11 +79,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--small" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -101,11 +101,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--micro" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -123,7 +123,7 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--small pds-button--icon-only" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
@@ -145,7 +145,7 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--micro pds-button--icon-only" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
@@ -167,11 +167,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--unstyled" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -189,11 +189,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button" disabled>
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -212,11 +212,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -234,11 +234,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -257,11 +257,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -285,7 +285,7 @@ describe('pds-button', () => {
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -305,14 +305,14 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button aria-busy="true" aria-live="polite" class="pds-button pds-button--primary pds-button--loading" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon pds-button__icon--hidden"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty pds-button__icon--hidden"><slot name="start"></slot></span>
               <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
               <span class="pds-button__loader">
                 <pds-loader is-loading size="var(--pine-font-size-body-2xl)" variant="spinner" exportparts="loader-svg">Loading...</pds-loader>
               </span>
-              <span class="pds-button__icon pds-button__icon--hidden"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty pds-button__icon--hidden"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -373,11 +373,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </button>
         </mock:shadow-root>
@@ -413,7 +413,7 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <button class="pds-button pds-button--primary pds-button--icon-only" part="button" type="button">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text pds-button__text--hidden" part="button-text">
                 <slot></slot>
               </span>
@@ -435,11 +435,11 @@ describe('pds-button', () => {
         <mock:shadow-root>
           <a class="pds-button pds-button--primary" part="button" href="https://example.com" target="_blank">
             <div class="pds-button__content" part="button-content">
-              <span class="pds-button__icon"><slot name="start"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="start"></slot></span>
               <span class="pds-button__text" part="button-text">
                 <slot></slot>
               </span>
-              <span class="pds-button__icon"><slot name="end"></slot></span>
+              <span class="pds-button__icon pds-button__icon--empty"><slot name="end"></slot></span>
             </div>
           </a>
         </mock:shadow-root>
@@ -636,6 +636,60 @@ describe('pds-button', () => {
       expect(filterIcon).toBeTruthy();
       expect(filterIcon?.getAttribute('icon')).toBe(addCircle);
       expect(anchor?.href).toContain('/test');
+    });
+  });
+
+  describe('slot empty class', () => {
+    it('applies --empty class to start and end slot wrappers when no content is slotted', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsButton],
+        html: `<pds-button>Click me</pds-button>`,
+      });
+
+      const iconSpans = root?.shadowRoot?.querySelectorAll('.pds-button__icon');
+      iconSpans?.forEach((span) => {
+        expect(span.classList.contains('pds-button__icon--empty')).toBe(true);
+      });
+    });
+
+    it('does not apply --empty class to start slot wrapper when start content is slotted', async () => {
+      const page = await newSpecPage({
+        components: [PdsButton],
+        html: `<pds-button><pds-icon slot="start" name="favorite"></pds-icon>Click me</pds-button>`,
+      });
+
+      const startSlot = page.root?.shadowRoot?.querySelector('slot[name="start"]');
+      const startWrapper = startSlot?.parentElement;
+
+      // Simulate slotchange since newSpecPage doesn't fire it automatically
+      const slotchangeEvent = new Event('slotchange');
+      Object.defineProperty(slotchangeEvent, 'target', {
+        value: { assignedNodes: () => [document.createElement('pds-icon')] },
+      });
+      startSlot?.dispatchEvent(slotchangeEvent);
+      await page.waitForChanges();
+
+      expect(startWrapper?.classList.contains('pds-button__icon--empty')).toBe(false);
+    });
+
+    it('does not apply --empty class to end slot wrapper when end content is slotted', async () => {
+      const page = await newSpecPage({
+        components: [PdsButton],
+        html: `<pds-button>Click me<pds-icon slot="end" name="favorite"></pds-icon></pds-button>`,
+      });
+
+      const endSlot = page.root?.shadowRoot?.querySelector('slot[name="end"]');
+      const endWrapper = endSlot?.parentElement;
+
+      // Simulate slotchange since newSpecPage doesn't fire it automatically
+      const slotchangeEvent = new Event('slotchange');
+      Object.defineProperty(slotchangeEvent, 'target', {
+        value: { assignedNodes: () => [document.createElement('pds-icon')] },
+      });
+      endSlot?.dispatchEvent(slotchangeEvent);
+      await page.waitForChanges();
+
+      expect(endWrapper?.classList.contains('pds-button__icon--empty')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Description

Fixes extra padding/spacing on buttons when no icon is slotted into the start/end slots.

PR #668 fixed a race condition by always rendering the `<slot name="start">` and `<slot name="end">` wrappers, using CSS `:has(::slotted(*))` to hide them when empty. However, `:has(::slotted(*))` has unreliable cross-browser support (particularly Safari). When the selector doesn't match, the empty `.pds-button__icon` spans remain `display: inline-flex`, and the parent's `gap` creates visible spacing where none should exist.

This replaces the CSS `:has()` approach with `slotchange` event handlers that toggle a `--empty` CSS class, following the existing pattern used in `pds-input`.

Fixes [DSS-167](https://linear.app/kajabi/issue/DSS-167/extra-paddingspacing-on-top-bar-menu-buttons)

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="1023" height="63" alt="Screenshot 2026-02-17 at 9 49 41 AM" src="https://github.com/user-attachments/assets/e31bcfcf-ba30-4a2b-ae8d-830a46357fff" />|<img width="1014" height="63" alt="Screenshot 2026-02-17 at 9 49 04 AM" src="https://github.com/user-attachments/assets/5d305bdd-87cc-4893-b8aa-2f50231f1288" />|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes