### PR TITLE
fix(pds-table-row): fix checkbox double-fire and z-index bleed-through

### DIFF
--- a/libs/core/src/components/pds-table/pds-table-row/pds-table-row.tsx
+++ b/libs/core/src/components/pds-table/pds-table-row/pds-table-row.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Host, h, Event, EventEmitter, Prop, State } from '@stencil/core';
 
+import { CheckboxChangeEventDetail } from '../../pds-checkbox/checkbox-interface';
 import { closest } from '../../../utils/closest';
 
 @Component({
@@ -40,8 +41,8 @@ export class PdsTableRow {
    */
   @Event() pdsTableRowSelected: EventEmitter<{ rowIndex: number; isSelected: boolean; }>;
 
-  private handleClick = () => {
-    this.isSelected = !this.isSelected; // Toggle the selected state
+  private handleCheckboxChange = (event: CustomEvent<CheckboxChangeEventDetail>) => {
+    this.isSelected = event.detail.checked;
     this.handleSelect(this.isSelected);
   }
 
@@ -196,7 +197,7 @@ export class PdsTableRow {
           <pds-table-cell part={this.tableRef.fixedColumn ? 'checkbox-cell' : 'checkbox-cell'} class={this.tableRef.selectable ? 'has-checkbox' : ''} >
             <pds-checkbox
               componentId={this.generateUniqueId()}
-              onClick={this.handleClick}
+              onPdsCheckboxChange={this.handleCheckboxChange}
               indeterminate={this.indeterminate}
               label={"Select Row"}
               hideLabel={true}

--- a/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.e2e.ts
+++ b/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.e2e.ts
@@ -19,7 +19,7 @@ describe('pds-table-row', () => {
     `);
 
     const row = await page.find('pds-table-row');
-    const checkbox = await page.find('pds-table-row >>> pds-checkbox');
+    const checkbox = await page.find('pds-table-row >>> pds-checkbox >>> input');
 
     await checkbox.click();
     await page.waitForChanges();
@@ -41,7 +41,7 @@ describe('pds-table-row', () => {
     `);
 
     const row = await page.find('pds-table-row');
-    const checkbox = await page.find('pds-table-row >>> pds-checkbox');
+    const checkbox = await page.find('pds-table-row >>> pds-checkbox >>> input');
 
     const pdsTableSelectSpy = await row.spyOnEvent('pdsTableRowSelected');
 

--- a/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.spec.tsx
+++ b/libs/core/src/components/pds-table/pds-table-row/test/pds-table-row.spec.tsx
@@ -33,7 +33,10 @@ describe('pds-table-row', () => {
     const row = page.root?.querySelector('pds-table-row');
     const checkbox = row?.shadowRoot?.querySelector('pds-checkbox') as HTMLElement;
 
-    checkbox.click();
+    checkbox.dispatchEvent(new CustomEvent('pdsCheckboxChange', {
+      detail: { checked: true, value: '' },
+      bubbles: true,
+    }));
     await page.waitForChanges();
 
     expect(row?.classList.contains('is-selected')).toBe(true);
@@ -55,7 +58,7 @@ describe('pds-table-row', () => {
     expect(cell?.classList.contains('is-fixed')).toBe(true);
   });
 
-  it('emits pdsTableRowSelected event when isSelected is set', async () => {
+  it('clears indeterminate when checkbox changes', async () => {
     const page = await newSpecPage({
       components: [PdsTable, PdsTableBody, PdsTableRow],
       html: `
@@ -70,8 +73,10 @@ describe('pds-table-row', () => {
     const row = page.root?.querySelector('pds-table-row');
     const checkbox = row?.shadowRoot?.querySelector('pds-checkbox') as HTMLElement;
 
-
-    checkbox.click();
+    checkbox.dispatchEvent(new CustomEvent('pdsCheckboxChange', {
+      detail: { checked: false, value: '' },
+      bubbles: true,
+    }));
     await page.waitForChanges();
 
     expect((row as HTMLPdsTableRowElement).indeterminate).toBe(false);

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -6,6 +6,7 @@
   border-radius: inherit;
   box-sizing: border-box;
   display: table;
+  isolation: isolate;
   width: 100%;
 }
 


### PR DESCRIPTION
# Description

Fixes two issues with `pds-table` selectable tables, reported from Kajabi Products (Media Library index page with selectable `DataTableComponent`).

### 1. Checkbox double-fire (`pds-table-row`)

The `pdsTableRowSelected` event's `detail.isSelected` property is unreliable. When clicking a checkbox, the event sometimes fires twice in the same synchronous tick — first with `isSelected: true`, then immediately with `isSelected: false` — even though the user only checked the box.

**Root cause:** In `pds-table-row.tsx`, the checkbox was wired with `onClick` on the `pds-checkbox` element. Inside `pds-checkbox`'s shadow DOM, a `<label htmlFor="X">` wraps `<input id="X">`. When a click lands on the `<label>` (not directly on the `<input>`), the browser's label activation algorithm dispatches a synthetic click on the input, causing the `onClick` handler to fire **twice**. The handler toggled `isSelected` via `!this.isSelected`, so it toggled to `true` then immediately back to `false`.

This was intermittent because it depended on whether the click hit the native `<input>` element directly (one event, correct) or the `<label>` area (two events, broken).

**Fix:** Switch from `onClick` to `onPdsCheckboxChange` on the internal `pds-checkbox`. The `pdsCheckboxChange` event fires exactly once per interaction (from the native input's `onChange`). Reads `event.detail.checked` directly instead of toggling with `!this.isSelected`.

### 2. Z-index bleed-through (`pds-table`)

Sticky checkbox cells in `pds-table-row` and `pds-table-head` use `z-index: var(--pine-z-index-raised)` which resolves to `1000`. When a consuming application has a fixed header with a lower z-index (e.g. `901`), the sticky checkbox cells and toolbar elements render on top of the header when the page is scrolled.

**Fix:** Add `isolation: isolate` to the `pds-table` `:host` styles. This creates a stacking context that scopes all internal z-indices so they don't compete with page-level elements. Internal stacking (sticky cells above regular cells, fixed columns, scroll shadows) continues to work correctly within the table's own stacking context.

Fixes DSS-168

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [x] tested manually

**Test Configuration**:

- Pine versions: local dev build linked to Kajabi Products
- OS: macOS
- Browsers: Chrome
- Tested on: Kajabi Products Media Library index page with selectable DataTableComponent

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes