### PR TITLE
fix(pds-combobox): add part=combobox to wrapper for external styling

### DIFF
--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -1604,7 +1604,7 @@ export class PdsCombobox implements BasePdsProps {
     const triggerClass = `pds-combobox__button-trigger pds-combobox__button-trigger--${this.triggerVariant}`;
     return (
       <Host>
-        <div class="pds-combobox" tabIndex={-1} onFocusout={this.onComboboxFocusOut}>
+        <div class="pds-combobox" tabIndex={-1} onFocusout={this.onComboboxFocusOut} part="combobox">
           {this.label && (
             <label htmlFor={this.componentId} class="pds-combobox__label">
               <span class={this.hideLabel ? 'visually-hidden' : ''}>{this.label}</span>

--- a/libs/core/src/components/pds-combobox/readme.md
+++ b/libs/core/src/components/pds-combobox/readme.md
@@ -86,6 +86,7 @@ Type: `Promise<void>`
 | ------------------ | ----------- |
 | `"button-trigger"` |             |
 | `"chip-trigger"`   |             |
+| `"combobox"`       |             |
 | `"input"`          |             |
 
 

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -22,7 +22,7 @@ describe('pds-combobox', () => {
     expect(root).toEqualHtml(`
       <pds-combobox component-id="test-combobox">
         <mock:shadow-root>
-          <div class="pds-combobox" tabindex="-1">
+          <div class="pds-combobox" tabindex="-1" part="combobox">
             <div class="pds-combobox__input-wrapper" style="width: fit-content;">
               <input aria-autocomplete="list" aria-controls="pds-combobox-listbox" aria-disabled="false" aria-expanded="false" autocomplete="off" class="pds-combobox__input" id="test-combobox" part="input" role="combobox" type="text" value="" />
               <pds-icon aria-hidden="true" class="pds-combobox__input-icon" icon="enlarge"></pds-icon>
@@ -1619,6 +1619,16 @@ describe('pds-combobox', () => {
   });
 
   describe('Accessibility', () => {
+    it('renders combobox wrapper with proper CSS part', async () => {
+      const { root } = await newSpecPage({
+        components: [PdsCombobox],
+        html: `<pds-combobox component-id="test-combobox"></pds-combobox>`,
+      });
+
+      const comboboxWrapper = root?.shadowRoot?.querySelector('.pds-combobox');
+      expect(comboboxWrapper?.getAttribute('part')).toBe('combobox');
+    });
+
     it('renders with proper CSS parts for external styling', async () => {
       const { root } = await newSpecPage({
         components: [PdsCombobox],


### PR DESCRIPTION
# Description

Fixes [DSS-171](https://linear.app/kajabi/issue/DSS-171/add-partcombobox-to-pds-combobox-wrapper-for-external-styling)

Adds `part="combobox"` to the pds-combobox root wrapper so consumers can target it with `::part(combobox)` for external styling (e.g. layout or focus ring). Input, button-trigger, and chip-trigger already expose parts; this completes the public parts API for the combobox container.

- **Component:** `part="combobox"` on the root `.pds-combobox` div in `pds-combobox.tsx`
- **Tests:** Updated default render snapshot to include `part="combobox"` and added an Accessibility test that asserts the wrapper has the part

No new dependencies. No documentation update required (readme is auto-generated from JSDoc; part is discoverable in markup).

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests — `pds-combobox.spec.tsx`: default render `toEqualHtml` and new test "renders combobox wrapper with proper CSS part"
- [ ] e2e tests
- [x] accessibility tests — CSS parts covered in Accessibility describe block
- [ ] tested manually
- [ ] other:

**Test Configuration:**

- Pine versions: (current)
- OS: (yours)
- Browsers: N/A for spec tests
- Screen readers: N/A
- Misc: `npx nx run @pine-ds/core:test --testPathPattern="pds-combobox.spec"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR