### PR TITLE
style(pds-multiselect): align trigger height to 36px and font-weight …

### DIFF
--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -1,6 +1,4 @@
 :host {
-  --pds-multiselect-trigger-min-height: 36px;
-
   display: block;
 }
 
@@ -44,7 +42,7 @@
   gap: var(--pine-dimension-xs);
   justify-content: space-between;
   letter-spacing: var(--pine-letter-spacing);
-  min-height: var(--pds-multiselect-trigger-min-height);
+  min-height: var(--pine-dimension-450);
   padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
   position: relative;
   text-align: start;

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -1,4 +1,6 @@
 :host {
+  --pds-multiselect-trigger-min-height: 36px;
+
   display: block;
 }
 
@@ -38,11 +40,11 @@
   border-radius: var(--pine-dimension-125);
   cursor: pointer;
   display: flex;
-  font: var(--pine-typography-body);
+  font: var(--pine-typography-body-medium);
   gap: var(--pine-dimension-xs);
   justify-content: space-between;
   letter-spacing: var(--pine-letter-spacing);
-  min-height: var(--pine-dimension-550);
+  min-height: var(--pds-multiselect-trigger-min-height);
   padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
   position: relative;
   text-align: start;


### PR DESCRIPTION
# Description

Fixes [DSS-172](https://linear.app/kajabi/issue/DSS-172/align-pds-multiselect-trigger-to-36px-height-and-font-weight-500)

Aligns the pds-multiselect trigger with buttons and dropdown triggers: 36px height and font-weight 500 (medium) for consistent filter bar and form UI.

- Trigger min-height: `var(--pine-dimension-550)` → `var(--pds-multiselect-trigger-min-height)` (default 36px), matching pds-select.
- Trigger font: `var(--pine-typography-body)` → `var(--pine-typography-body-medium)` for font-weight 500, matching pds-combobox and other dropdown-style triggers.

Fixes [LINEAR-TICKET-ID]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) / visual consistency
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] tested manually (Storybook – multiselect trigger height and font weight)
- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] other:

**Test Configuration**:
- Pine versions: current
- OS: [your OS]
- Browsers: [e.g. Chrome]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR