### PR TITLE
fix(pds-button): add reflect to disabled prop and guard slotted disab…

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -719,7 +719,7 @@ export namespace Components {
           * Determines the button's disabled state.
           * @defaultValue false
          */
-        "disabled"?: boolean;
+        "disabled": boolean;
         /**
           * Prompts the user to save the linked URL instead of navigating to it. It can be used without a value to download with the default filename, or with a string value to suggest a specific filename for the download. Only applies when href is set.
          */

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -40,7 +40,7 @@ export class PdsButton {
    * Determines the button's disabled state.
    * @defaultValue false
    */
-  @Prop() disabled? = false;
+  @Prop({ reflect: true }) disabled: boolean = false;
 
   /**
    * Determines if the button should take up the full width of its container.

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -182,10 +182,10 @@ describe('pds-button', () => {
   it('renders disabled button', async () => {
     const {root} = await newSpecPage({
       components: [PdsButton],
-      html: `<pds-button disabled="true"></pds-button>`,
+      html: `<pds-button disabled></pds-button>`,
     });
     expect(root).toEqualHtml(`
-      <pds-button disabled="true" aria-disabled="true" variant="primary">
+      <pds-button disabled aria-disabled="true" variant="primary">
         <mock:shadow-root>
           <button class="pds-button pds-button--primary" part="button" type="button" disabled>
             <div class="pds-button__content" part="button-content">
@@ -199,6 +199,18 @@ describe('pds-button', () => {
         </mock:shadow-root>
       </pds-button>
     `);
+  });
+
+  it('does not set disabled or aria-disabled when disabled prop is not set', async () => {
+    const page = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button></pds-button>`,
+    });
+
+    expect(page.root?.hasAttribute('disabled')).toBe(false);
+    expect(page.root?.getAttribute('aria-disabled')).toBe(null);
+    const button = page.root?.shadowRoot?.querySelector('button');
+    expect(button?.hasAttribute('disabled')).toBe(false);
   });
 
   it('renders with id when prop is set', async () => {

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
@@ -54,8 +54,11 @@
 }
 
 // Disabled state for raw elements (using attribute selectors, not pseudo-classes)
+// ::slotted([disabled]) is an attribute-presence selector — it matches even when
+// disabled="false" is set as a string (e.g. by React on custom elements). The
+// :not([disabled="false"]) guard ensures only a truly-disabled attribute applies.
 ::slotted([aria-disabled="true"]),
-::slotted([disabled]) {
+::slotted([disabled]:not([disabled="false"])) {
   cursor: not-allowed;
   opacity: 0.5;
   pointer-events: none;


### PR DESCRIPTION
# Description

Fixes [DSS-180](https://linear.app/kajabi/issue/DSS-180/fix-pds-button-stuck-in-disabled-state-when-disabledfalse-is-set-by)

  Fixes two interacting issues that caused `pds-button` to become stuck in a disabled visual state when used as a slotted element inside `pds-dropdown-menu`.

  **Root cause:**

  1. `pds-dropdown-menu.scss` used `::slotted([disabled])`, which is a CSS attribute-presence selector. It matches any element that has a `disabled` attribute regardless of its value — including `disabled="false"` as a string set by React or
  other frameworks on custom elements.

  2. `pds-button` was missing `reflect: true` on its `disabled` prop (and lacked an explicit `boolean` type), so Stencil did not manage the DOM attribute's lifecycle. This allowed `disabled="false"` to linger on the host element after a
  framework rendered it.

  **Fixes:**

  - Updates `::slotted([disabled])` to `::slotted([disabled]:not([disabled="false"]))` so the disabled visual styles are not applied when the attribute value is explicitly the string `"false"`.
  - Adds `reflect: true` and explicit `boolean` type to `pds-button`'s `disabled` prop, matching the same fix already applied to `pds-dropdown-menu-item` in v3.16.2 (#666).

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  # How Has This Been Tested?

  - [x] unit tests
  - [x] tested manually

  Updated the disabled button snapshot test to use the boolean attribute form (no value), which is the correct reflected form. Added a test asserting that a non-disabled button has no `disabled` attribute and no `aria-disabled` on the host.

  **Test Configuration**:
  - Pine version: 3.18.0

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing tests pass locally with my changes