### PR TITLE
fix(pds-input): prevent prefix padding shift on focus

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -29,6 +29,7 @@ export class PdsInput {
   private focusedValue?: string | number | null;
   private originalPdsInput?: EventEmitter<InputInputEventDetail>;
   private internals?: ElementInternals;
+  private resizeObserver?: ResizeObserver;
 
   @Element() el!: HTMLPdsInputElement;
 
@@ -219,6 +220,22 @@ export class PdsInput {
    */
   @State() hasFocus = false;
 
+  private observeAddonResize() {
+    if (typeof ResizeObserver === 'undefined') return;
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.updateAddonWidths();
+    });
+
+    if (this.prefixEl) {
+      this.resizeObserver.observe(this.prefixEl);
+    }
+
+    if (this.suffixEl) {
+      this.resizeObserver.observe(this.suffixEl);
+    }
+  }
+
   private updateAddonWidths() {
     requestAnimationFrame(() => {
       if (this.prefixEl) {
@@ -314,15 +331,16 @@ export class PdsInput {
     }
   }
 
+  disconnectedCallback() {
+    this.resizeObserver?.disconnect();
+  }
+
   componentDidLoad() {
     this.debounceChanged();
     this.updateAddonWidths();
+    this.observeAddonResize();
     // Set initial form value
     this.updateFormValue();
-  }
-
-  componentDidUpdate() {
-    this.updateAddonWidths();
   }
 
   @Watch('debounce')

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -329,6 +329,12 @@ export class PdsInput {
     if (this.el.attachInternals && !this.internals) {
       this.internals = this.el.attachInternals();
     }
+
+    // Re-establish ResizeObserver on reconnection (refs exist after first render)
+    if (this.prefixEl || this.suffixEl) {
+      this.updateAddonWidths();
+      this.observeAddonResize();
+    }
   }
 
   disconnectedCallback() {

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -30,6 +30,7 @@ export class PdsInput {
   private originalPdsInput?: EventEmitter<InputInputEventDetail>;
   private internals?: ElementInternals;
   private resizeObserver?: ResizeObserver;
+  private hasLoaded = false;
 
   @Element() el!: HTMLPdsInputElement;
 
@@ -223,6 +224,9 @@ export class PdsInput {
   private observeAddonResize() {
     if (typeof ResizeObserver === 'undefined') return;
 
+    // Disconnect existing observer before creating a new one
+    this.resizeObserver?.disconnect();
+
     this.resizeObserver = new ResizeObserver(() => {
       this.updateAddonWidths();
     });
@@ -330,8 +334,9 @@ export class PdsInput {
       this.internals = this.el.attachInternals();
     }
 
-    // Re-establish ResizeObserver on reconnection (refs exist after first render)
-    if (this.prefixEl || this.suffixEl) {
+    // Re-establish ResizeObserver after DOM reconnection
+    // Only run if component has already loaded (refs are available)
+    if (this.hasLoaded && !this.resizeObserver) {
       this.updateAddonWidths();
       this.observeAddonResize();
     }
@@ -339,9 +344,11 @@ export class PdsInput {
 
   disconnectedCallback() {
     this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
   }
 
   componentDidLoad() {
+    this.hasLoaded = true;
     this.debounceChanged();
     this.updateAddonWidths();
     this.observeAddonResize();

--- a/libs/core/src/components/pds-input/test/pds-input.e2e.ts
+++ b/libs/core/src/components/pds-input/test/pds-input.e2e.ts
@@ -140,6 +140,39 @@ describe('pds-input', () => {
     expect(await component.getAttribute('has-action')).toBe('true');
   });
 
+  it('does not shift prefix padding on focus', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-input component-id="test-prefix" label="Search" hide-label>
+        <pds-icon name="search" slot="prefix"></pds-icon>
+      </pds-input>
+    `);
+
+    // Wait for icon to fully render
+    await page.waitForChanges();
+
+    const input = await page.find('pds-input >>> input');
+
+    // Get the padding before focus
+    const paddingBefore = await page.evaluate(() => {
+      const input = document.querySelector('pds-input')?.shadowRoot?.querySelector('input');
+      return input ? getComputedStyle(input).paddingInlineStart : '';
+    });
+
+    // Focus the input
+    await input.focus();
+    await page.waitForChanges();
+
+    // Get the padding after focus
+    const paddingAfter = await page.evaluate(() => {
+      const input = document.querySelector('pds-input')?.shadowRoot?.querySelector('input');
+      return input ? getComputedStyle(input).paddingInlineStart : '';
+    });
+
+    // Padding should remain the same after focus
+    expect(paddingBefore).toBe(paddingAfter);
+  });
+
   it('applies highlight styling when highlight prop is set', async () => {
     const page = await newE2EPage();
     await page.setContent('<pds-input highlight value="test"></pds-input>');

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -666,20 +666,31 @@ describe('pds-input', () => {
     }
   });
 
-  it('should not recalculate addon widths on focus', async () => {
-    const page = await newSpecPage({
-      components: [PdsInput],
-      html: `
-        <pds-input component-id="field-1">
-          <div slot="prefix">Prefix Content</div>
-        </pds-input>
-      `
+  describe('ResizeObserver', () => {
+    beforeAll(() => {
+      global.ResizeObserver = jest.fn(() => ({
+        observe: jest.fn(),
+        disconnect: jest.fn(),
+        unobserve: jest.fn(),
+      })) as any;
     });
 
-    const component = page.rootInstance;
-    const root = page.root;
+    afterAll(() => {
+      delete (global as any).ResizeObserver;
+    });
 
-    if (root?.shadowRoot) {
+    it('should not recalculate addon widths on focus', async () => {
+      const page = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1">
+            <div slot="prefix">Prefix Content</div>
+          </pds-input>
+        `
+      });
+
+      const component = page.rootInstance;
+      const root = page.root;
       const prefixEl = root.shadowRoot.querySelector('.pds-input__prefix');
 
       // Mock offsetWidth and set initial width
@@ -687,15 +698,14 @@ describe('pds-input', () => {
       component.updateAddonWidths();
       await new Promise(resolve => requestAnimationFrame(resolve));
 
-      const initialWidth = root.style.getPropertyValue('--prefix-width');
-      expect(initialWidth).toBe('100px');
+      expect(root.style.getPropertyValue('--prefix-width')).toBe('100px');
 
       // Spy on updateAddonWidths to ensure focus doesn't trigger it
       const updateSpy = jest.spyOn(component, 'updateAddonWidths');
 
       // Trigger focus on the native input
       const nativeInput = root.shadowRoot.querySelector('input');
-      nativeInput?.dispatchEvent(new Event('focus'));
+      nativeInput.dispatchEvent(new Event('focus'));
       await page.waitForChanges();
 
       // updateAddonWidths should not have been called by the focus-triggered re-render
@@ -703,50 +713,43 @@ describe('pds-input', () => {
 
       // Prefix width should remain unchanged
       expect(root.style.getPropertyValue('--prefix-width')).toBe('100px');
-    }
-  });
-
-  it('should clean up ResizeObserver on disconnect', async () => {
-    const page = await newSpecPage({
-      components: [PdsInput],
-      html: `
-        <pds-input component-id="field-1">
-          <div slot="prefix">Prefix Content</div>
-        </pds-input>
-      `
     });
 
-    const component = page.rootInstance;
+    it('should clean up ResizeObserver on disconnect', async () => {
+      const page = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1">
+            <div slot="prefix">Prefix Content</div>
+          </pds-input>
+        `
+      });
 
-    // If ResizeObserver is available in the test env, verify cleanup
-    if (component.resizeObserver) {
+      const component = page.rootInstance;
+
+      expect(component.resizeObserver).toBeDefined();
       const disconnectSpy = jest.spyOn(component.resizeObserver, 'disconnect');
       component.disconnectedCallback();
       expect(disconnectSpy).toHaveBeenCalled();
-    }
-  });
-
-  it('should re-establish ResizeObserver on reconnection', async () => {
-    const page = await newSpecPage({
-      components: [PdsInput],
-      html: `
-        <pds-input component-id="field-1">
-          <div slot="prefix">Prefix Content</div>
-        </pds-input>
-      `
+      expect(component.resizeObserver).toBeUndefined();
     });
 
-    const component = page.rootInstance;
-    const root = page.root;
+    it('should re-establish ResizeObserver on reconnection', async () => {
+      const page = await newSpecPage({
+        components: [PdsInput],
+        html: `
+          <pds-input component-id="field-1">
+            <div slot="prefix">Prefix Content</div>
+          </pds-input>
+        `
+      });
 
-    // Ensure component is loaded and observer is set up
-    await page.waitForChanges();
-
-    if (root?.shadowRoot && typeof ResizeObserver !== 'undefined') {
+      const component = page.rootInstance;
+      const root = page.root;
       const prefixEl = root.shadowRoot.querySelector('.pds-input__prefix');
       Object.defineProperty(prefixEl, 'offsetWidth', { value: 100 });
 
-      // Simulate disconnection
+      // Simulate disconnect
       component.disconnectedCallback();
       expect(component.resizeObserver).toBeUndefined();
 
@@ -754,17 +757,14 @@ describe('pds-input', () => {
       const observeSpy = jest.spyOn(component, 'observeAddonResize');
       const updateSpy = jest.spyOn(component, 'updateAddonWidths');
 
-      // Simulate reconnection (prefixEl ref still exists from prior render)
+      // Simulate reconnection
       component.connectedCallback();
       await page.waitForChanges();
 
-      // Both methods should be called on reconnection
       expect(observeSpy).toHaveBeenCalled();
       expect(updateSpy).toHaveBeenCalled();
-
-      // Observer should be re-established
       expect(component.resizeObserver).toBeDefined();
-    }
+    });
   });
 
   describe('action slot', () => {

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -726,6 +726,38 @@ describe('pds-input', () => {
     }
   });
 
+  it('should re-establish ResizeObserver on reconnection', async () => {
+    const page = await newSpecPage({
+      components: [PdsInput],
+      html: `
+        <pds-input component-id="field-1">
+          <div slot="prefix">Prefix Content</div>
+        </pds-input>
+      `
+    });
+
+    const component = page.rootInstance;
+    const root = page.root;
+
+    if (root?.shadowRoot) {
+      const prefixEl = root.shadowRoot.querySelector('.pds-input__prefix');
+      Object.defineProperty(prefixEl, 'offsetWidth', { value: 100 });
+
+      // Simulate disconnect
+      component.disconnectedCallback();
+
+      // Spy on observeAddonResize to verify reconnection restores it
+      const observeSpy = jest.spyOn(component, 'observeAddonResize');
+      const updateSpy = jest.spyOn(component, 'updateAddonWidths');
+
+      // Simulate reconnection (prefixEl ref still exists from prior render)
+      component.connectedCallback();
+
+      expect(observeSpy).toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalled();
+    }
+  });
+
   describe('action slot', () => {
     it('renders action slot content when provided', async () => {
       const { root } = await newSpecPage({

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -739,22 +739,31 @@ describe('pds-input', () => {
     const component = page.rootInstance;
     const root = page.root;
 
-    if (root?.shadowRoot) {
+    // Ensure component is loaded and observer is set up
+    await page.waitForChanges();
+
+    if (root?.shadowRoot && typeof ResizeObserver !== 'undefined') {
       const prefixEl = root.shadowRoot.querySelector('.pds-input__prefix');
       Object.defineProperty(prefixEl, 'offsetWidth', { value: 100 });
 
-      // Simulate disconnect
+      // Simulate disconnection
       component.disconnectedCallback();
+      expect(component.resizeObserver).toBeUndefined();
 
-      // Spy on observeAddonResize to verify reconnection restores it
+      // Spy on methods to verify reconnection restores observer
       const observeSpy = jest.spyOn(component, 'observeAddonResize');
       const updateSpy = jest.spyOn(component, 'updateAddonWidths');
 
       // Simulate reconnection (prefixEl ref still exists from prior render)
       component.connectedCallback();
+      await page.waitForChanges();
 
+      // Both methods should be called on reconnection
       expect(observeSpy).toHaveBeenCalled();
       expect(updateSpy).toHaveBeenCalled();
+
+      // Observer should be re-established
+      expect(component.resizeObserver).toBeDefined();
     }
   });
 

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -666,6 +666,66 @@ describe('pds-input', () => {
     }
   });
 
+  it('should not recalculate addon widths on focus', async () => {
+    const page = await newSpecPage({
+      components: [PdsInput],
+      html: `
+        <pds-input component-id="field-1">
+          <div slot="prefix">Prefix Content</div>
+        </pds-input>
+      `
+    });
+
+    const component = page.rootInstance;
+    const root = page.root;
+
+    if (root?.shadowRoot) {
+      const prefixEl = root.shadowRoot.querySelector('.pds-input__prefix');
+
+      // Mock offsetWidth and set initial width
+      Object.defineProperty(prefixEl, 'offsetWidth', { value: 100 });
+      component.updateAddonWidths();
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      const initialWidth = root.style.getPropertyValue('--prefix-width');
+      expect(initialWidth).toBe('100px');
+
+      // Spy on updateAddonWidths to ensure focus doesn't trigger it
+      const updateSpy = jest.spyOn(component, 'updateAddonWidths');
+
+      // Trigger focus on the native input
+      const nativeInput = root.shadowRoot.querySelector('input');
+      nativeInput?.dispatchEvent(new Event('focus'));
+      await page.waitForChanges();
+
+      // updateAddonWidths should not have been called by the focus-triggered re-render
+      expect(updateSpy).not.toHaveBeenCalled();
+
+      // Prefix width should remain unchanged
+      expect(root.style.getPropertyValue('--prefix-width')).toBe('100px');
+    }
+  });
+
+  it('should clean up ResizeObserver on disconnect', async () => {
+    const page = await newSpecPage({
+      components: [PdsInput],
+      html: `
+        <pds-input component-id="field-1">
+          <div slot="prefix">Prefix Content</div>
+        </pds-input>
+      `
+    });
+
+    const component = page.rootInstance;
+
+    // If ResizeObserver is available in the test env, verify cleanup
+    if (component.resizeObserver) {
+      const disconnectSpy = jest.spyOn(component.resizeObserver, 'disconnect');
+      component.disconnectedCallback();
+      expect(disconnectSpy).toHaveBeenCalled();
+    }
+  });
+
   describe('action slot', () => {
     it('renders action slot content when provided', async () => {
       const { root } = await newSpecPage({

--- a/package-lock.json
+++ b/package-lock.json
@@ -3017,6 +3017,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3306,6 +3307,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3340,6 +3342,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3374,6 +3377,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6079,6 +6083,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -6121,6 +6126,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6142,6 +6148,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6163,6 +6170,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6184,6 +6192,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6205,6 +6214,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6226,6 +6236,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6247,6 +6258,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6268,6 +6280,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6289,6 +6302,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6310,6 +6324,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6331,6 +6346,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6352,6 +6368,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6373,6 +6390,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6514,7 +6532,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.56.0",
@@ -6528,7 +6547,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.34.9",
@@ -6568,7 +6588,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.56.0",
@@ -6582,7 +6603,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.56.0",
@@ -6596,7 +6618,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.56.0",
@@ -6610,7 +6633,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.34.9",
@@ -6650,7 +6674,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.56.0",
@@ -6664,7 +6689,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.56.0",
@@ -6678,7 +6704,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.56.0",
@@ -6692,7 +6719,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.56.0",
@@ -6706,7 +6734,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.56.0",
@@ -6720,7 +6749,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.56.0",
@@ -6734,7 +6764,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.34.9",
@@ -6774,7 +6805,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.56.0",
@@ -6788,7 +6820,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.34.9",
@@ -6815,7 +6848,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.56.0",
@@ -6829,7 +6863,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.34.9",
@@ -7730,6 +7765,95 @@
         "node": ">=6"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -7855,6 +7979,14 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -12855,6 +12987,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -13492,6 +13625,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13509,6 +13643,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13526,6 +13661,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13543,6 +13679,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13560,6 +13697,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13577,6 +13715,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13594,6 +13733,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13611,6 +13751,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13628,6 +13769,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13645,6 +13787,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13662,6 +13805,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13679,6 +13823,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13696,6 +13841,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13713,6 +13859,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13730,6 +13877,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13747,6 +13895,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13764,6 +13913,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13781,6 +13931,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13798,6 +13949,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13815,6 +13967,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13832,6 +13985,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13849,6 +14003,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -21179,6 +21334,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -22867,7 +23033,8 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -25861,7 +26028,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27115,6 +27281,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sass": "1.97.3"
       }
@@ -27132,6 +27299,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27149,6 +27317,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27166,6 +27335,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27183,6 +27353,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27200,6 +27371,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27217,6 +27389,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27234,6 +27407,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27251,6 +27425,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27268,6 +27443,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27285,6 +27461,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27302,6 +27479,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27319,6 +27497,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27336,6 +27515,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27353,6 +27533,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27370,6 +27551,7 @@
         "!linux",
         "!win32"
       ],
+      "peer": true,
       "dependencies": {
         "sass": "1.97.3"
       }
@@ -27387,6 +27569,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -27404,6 +27587,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -31080,6 +31264,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31097,6 +31282,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31114,6 +31300,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31131,6 +31318,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31148,6 +31336,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31165,6 +31354,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31182,6 +31372,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31199,6 +31390,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31216,6 +31408,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31233,6 +31426,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31250,6 +31444,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31267,6 +31462,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31284,6 +31480,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31301,6 +31498,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31318,6 +31516,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31335,6 +31534,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31352,6 +31552,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31369,6 +31570,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31386,6 +31588,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31403,6 +31606,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31420,6 +31624,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31437,6 +31642,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31454,6 +31660,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -31470,7 +31677,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.56.0",
@@ -31484,7 +31692,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.56.0",
@@ -31498,7 +31707,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.56.0",
@@ -31512,7 +31722,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.56.0",
@@ -31526,7 +31737,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.56.0",
@@ -31540,7 +31752,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.56.0",
@@ -31554,7 +31767,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.56.0",
@@ -31568,7 +31782,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/vite/node_modules/esbuild": {
       "version": "0.21.5",


### PR DESCRIPTION
# Description

When a `pds-input` has a prefix icon (e.g., `<pds-icon name="search" slot="prefix">`), the input padding visually jumps on first focus. This happens because `componentDidUpdate` recalculates prefix/suffix widths on every state change — including focus. If the icon SVG hadn't fully rendered during the initial measurement, the padding snaps to a different value when focus triggers a re-render.

The fix replaces the `componentDidUpdate` width recalculation with a `ResizeObserver` that only fires when the prefix/suffix elements actually change size. This ensures accurate measurement without unnecessary recalculation on focus, blur, or value changes.

Fixes [DSS-195](https://linear.app/kajabi/issue/DSS-195/input-padding-shifts-on-first-focus-with-prefix-icon)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests

**Test Configuration**:

- Pine versions: 3.21.1
- OS: macOS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to `pds-input` layout measurement, guarded for environments without `ResizeObserver`. Main risk is missed width updates if observer lifecycle/slot changes aren’t covered, but added unit/e2e tests mitigate this.
> 
> **Overview**
> Fixes a `pds-input` focus-time padding jump by replacing `componentDidUpdate`-driven prefix/suffix width recalculation with a `ResizeObserver` that updates CSS vars only when addon elements actually resize, plus proper setup/teardown on connect/disconnect.
> 
> Adds targeted unit and e2e coverage to ensure prefix padding remains stable on focus and that the observer is cleaned up and re-established correctly. Updates `package-lock.json` with peer metadata adjustments and new dev test dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48509de5fb911dbbab854e686df496ebe32606b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->