### PR TITLE
feat(css-parts): expose inner button elements as CSS shadow parts

### DIFF
--- a/libs/core/src/components/pds-alert/pds-alert.tsx
+++ b/libs/core/src/components/pds-alert/pds-alert.tsx
@@ -133,7 +133,7 @@ export class PdsAlert {
             </pds-box>
 
             {this.dismissible && (
-              <button class="pds-alert__dismiss" type="button" aria-label="Dismiss alert" onClick={this.handleCloseClick}>
+              <button class="pds-alert__dismiss" type="button" part="dismiss" aria-label="Dismiss alert" onClick={this.handleCloseClick}>
                 <pds-icon icon="remove" size="var(--pds-alert-icon-size)" aria-hidden="true" color="var(--pds-alert-color-dismiss)" />
               </button>
             )}

--- a/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
+++ b/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
@@ -123,7 +123,7 @@ describe('pds-alert', () => {
                   </pds-text>
                 </div>
               </pds-box>
-              <button aria-label="Dismiss alert" class="pds-alert__dismiss" type="button">
+              <button aria-label="Dismiss alert" class="pds-alert__dismiss" part="dismiss" type="button">
                 <pds-icon aria-hidden="true" color="var(--pds-alert-color-dismiss)" icon="remove" size="var(--pds-alert-icon-size)"></pds-icon>
               </button>
             </pds-box>

--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -98,7 +98,7 @@ export class PdsAvatar {
     return (
       this.dropdown
         ?
-        <button class="pds-avatar__button" type="button" aria-label="Avatar dropdown trigger">
+        <button class="pds-avatar__button" type="button" part="button" aria-label="Avatar dropdown trigger">
         {this.renderAssetWrapper()}
         </button>
         :

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -159,7 +159,7 @@ describe('pds-avatar', () => {
     expect(page.root).toEqualHtml(`
       <pds-avatar class="pds-avatar" dropdown="true" size="lg" variant="customer">
         <mock:shadow-root>
-          <button aria-label="Avatar dropdown trigger" class="pds-avatar__button" type="button">
+          <button aria-label="Avatar dropdown trigger" class="pds-avatar__button" part="button" type="button">
             <div part="asset-wrapper" style="height: 56px; width: 56px;">
               <pds-icon color="var(--pine-color-brand)" icon="${userFilled}" size="33.53%"></pds-icon>
             </div>

--- a/libs/core/src/components/pds-chip/pds-chip.tsx
+++ b/libs/core/src/components/pds-chip/pds-chip.tsx
@@ -131,7 +131,7 @@ export class PdsChip {
     const showDot = this.sentiment === 'brand' ? false : this.dot;
 
     const chipContent = isDropdown ? (
-      <button class="pds-chip__button" type="button">
+      <button class="pds-chip__button" type="button" part="button">
         {this.icon && <pds-icon icon={this.icon} size={this.iconSize} aria-hidden="true"></pds-icon>}
         {showDot && <i class="pds-chip__dot" aria-hidden="true"></i>}
         <slot></slot>

--- a/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
+++ b/libs/core/src/components/pds-chip/test/pds-chip.spec.tsx
@@ -197,7 +197,7 @@ describe('pds-chip', () => {
     expect(page.root).toEqualHtml(`
     <pds-chip class="pds-chip pds-chip--sm pds-chip--dropdown pds-chip--neutral" size="sm" variant="dropdown">
       <mock:shadow-root>
-        <button class="pds-chip__button" type="button">
+        <button class="pds-chip__button" part="button" type="button">
           <slot></slot>
           <pds-icon icon="${downSmall}" size="10px" aria-hidden="true"></pds-icon>
         </button>
@@ -244,7 +244,7 @@ describe('pds-chip', () => {
     expect(page.root).toEqualHtml(`
     <pds-chip class="pds-chip pds-chip--neutral pds-chip--dropdown" variant="dropdown">
       <mock:shadow-root>
-        <button class="pds-chip__button" type="button">
+        <button class="pds-chip__button" part="button" type="button">
           <slot></slot>
           <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>
         </button>
@@ -280,7 +280,7 @@ describe('pds-chip', () => {
     expect(page.root).toEqualHtml(`
     <pds-chip class="pds-chip pds-chip--neutral pds-chip--dropdown" icon="archive" variant="dropdown">
       <mock:shadow-root>
-        <button class="pds-chip__button" type="button">
+        <button class="pds-chip__button" part="button" type="button">
           <pds-icon icon="archive" size="12px" aria-hidden="true"></pds-icon>
           <slot></slot>
           <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>
@@ -372,7 +372,7 @@ describe('pds-chip', () => {
     expect(page.root).toEqualHtml(`
     <pds-chip class="pds-chip pds-chip--neutral pds-chip--dropdown" variant="dropdown" dot="true">
       <mock:shadow-root>
-        <button class="pds-chip__button" type="button">
+        <button class="pds-chip__button" part="button" type="button">
           <i class="pds-chip__dot" aria-hidden="true"></i>
           <slot></slot>
           <pds-icon icon="${downSmall}" size="12px" aria-hidden="true"></pds-icon>

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu-item/pds-dropdown-menu-item.tsx
@@ -128,6 +128,7 @@ export class PdsDropdownMenuItem implements BasePdsProps {
         }}
         tabIndex={this.disabled ? -1 : 0}
         type="button"
+        part="button"
         onKeyDown={this.handleKeyDown}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -1195,6 +1195,7 @@ export class PdsMultiselect {
             <button
               ref={el => (this.triggerEl = el)}
               type="button"
+              part="trigger"
               class={{
                 'pds-multiselect__trigger': true,
                 'pds-multiselect__trigger--open': this.isOpen,

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
@@ -75,7 +75,6 @@ export class PdsTab {
       <Host variant={this.variant} slot="tabs" index={this.index}>
         <button
           role="tab"
-          part="tab"
           id={this.parentComponentId + "__" + this.name}
           aria-controls={this.parentComponentId + "__" + this.name + "-panel"}
           tabindex={this.disabled ? "-1" : (this.selected ? "0" : "-1")}

--- a/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tab/pds-tab.tsx
@@ -75,6 +75,7 @@ export class PdsTab {
       <Host variant={this.variant} slot="tabs" index={this.index}>
         <button
           role="tab"
+          part="tab"
           id={this.parentComponentId + "__" + this.name}
           aria-controls={this.parentComponentId + "__" + this.name + "-panel"}
           tabindex={this.disabled ? "-1" : (this.selected ? "0" : "-1")}

--- a/libs/core/src/components/pds-toast/pds-toast.tsx
+++ b/libs/core/src/components/pds-toast/pds-toast.tsx
@@ -146,6 +146,7 @@ export class PdsToast {
           {this.dismissible && (
             <button
               type="button"
+              part="dismiss"
               class="pds-toast__button"
               onClick={() => {
                 this.dismiss();

--- a/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
+++ b/libs/core/src/components/pds-toast/test/pds-toast.spec.tsx
@@ -14,7 +14,7 @@ describe('pds-toast', () => {
             <span class="pds-toast__message">
               <slot></slot>
             </span>
-            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+            <button aria-label="Dismiss message" class="pds-toast__button" part="dismiss" type="button">
               <pds-icon name="remove"></pds-icon>
             </button>
           </div>
@@ -36,7 +36,7 @@ describe('pds-toast', () => {
             <span class="pds-toast__message">
               <slot></slot>
             </span>
-            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+            <button aria-label="Dismiss message" class="pds-toast__button" part="dismiss" type="button">
               <pds-icon name="remove"></pds-icon>
             </button>
           </div>
@@ -62,7 +62,7 @@ describe('pds-toast', () => {
             <span class="pds-toast__message">
               <slot></slot>
             </span>
-            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+            <button aria-label="Dismiss message" class="pds-toast__button" part="dismiss" type="button">
               <pds-icon name="remove"></pds-icon>
             </button>
           </div>
@@ -83,7 +83,7 @@ describe('pds-toast', () => {
             <span class="pds-toast__message">
               <slot></slot>
             </span>
-            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+            <button aria-label="Dismiss message" class="pds-toast__button" part="dismiss" type="button">
               <pds-icon name="remove"></pds-icon>
             </button>
           </div>
@@ -127,7 +127,7 @@ describe('pds-toast', () => {
             <span class="pds-toast__message">
               <slot></slot>
             </span>
-            <button aria-label="Dismiss message" class="pds-toast__button" type="button">
+            <button aria-label="Dismiss message" class="pds-toast__button" part="dismiss" type="button">
               <pds-icon name="remove"></pds-icon>
             </button>
           </div>


### PR DESCRIPTION
## Summary

Adds \`part\` attributes to button elements that were missing them across 6 components, enabling consumers to target them with \`::part()\` for layout and style overrides.

| Component | Element | Part name |
|---|---|---|
| \`pds-multiselect\` | Trigger button | \`trigger\` |
| \`pds-chip\` | Dropdown variant trigger | \`button\` |
| \`pds-dropdown-menu-item\` | Menu item button | \`button\` |
| \`pds-avatar\` | Dropdown trigger button | \`button\` |
| \`pds-alert\` | Dismiss button | \`dismiss\` |
| \`pds-toast\` | Dismiss button | \`dismiss\` |

> **Note:** \`pds-tab\` was initially included but reverted — it uses \`shadow: false\` so \`::part()\` selectors have no effect there.

## Motivation

Components using Shadow DOM are isolated from external stylesheets unless they explicitly expose elements via \`::part()\`. Several components had inner \`<button>\` elements with no part attribute, making it impossible for consumers to apply layout or style overrides without hacking the shadow DOM. This is a purely additive change — no existing behavior is affected.

\`pds-combobox\` already sets the precedent with \`part="button-trigger"\`, \`part="input"\`, and \`part="chip-trigger"\`.

## Test plan

- [ ] Verify each \`::part()\` selector can be targeted in a consumer stylesheet
- [ ] Verify no visual regressions in existing component stories
- [ ] Verify interactive behavior (click, focus, disabled states) is unchanged for all components