### PR TITLE
fix(pds-input): add text-overflow ellipsis to input field

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -235,7 +235,9 @@
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-input-field-min-height);
   min-width: var(--pine-dimension-none);
+  overflow: hidden;
   padding: var(--pds-input-padding-y) var(--pds-input-padding-x);
+  text-overflow: ellipsis;
   transition: border-color 0.2s ease;
   width: 100%;
 


### PR DESCRIPTION
# Description

Adds `overflow: hidden` and `text-overflow: ellipsis` to `.pds-input__field` so that long placeholder text (e.g. "Search in Very Long Saved View Name") truncates with "..." instead of being clipped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code