### PR TITLE
style(pds-input): add text-overflow ellipsis to pds-input placeholder text

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -235,9 +235,7 @@
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-input-field-min-height);
   min-width: var(--pine-dimension-none);
-  overflow: hidden;
   padding: var(--pds-input-padding-y) var(--pds-input-padding-x);
-  text-overflow: ellipsis;
   transition: border-color 0.2s ease;
   width: 100%;
 
@@ -281,6 +279,10 @@
 
   &::placeholder {
     color: var(--pds-input-placeholder-color);
+  }
+
+  &:placeholder-shown {
+    text-overflow: ellipsis;
   }
 
   .has-error & {

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -235,7 +235,9 @@
   letter-spacing: var(--pine-letter-spacing);
   min-height: var(--pds-input-field-min-height);
   min-width: var(--pine-dimension-none);
+  overflow: hidden;
   padding: var(--pds-input-padding-y) var(--pds-input-padding-x);
+  text-overflow: ellipsis;
   transition: border-color 0.2s ease;
   width: 100%;
 


### PR DESCRIPTION
# Description

Adds `text-overflow: ellipsis` to `.pds-input__field` using the `:placeholder-shown` pseudo-class so that long placeholder text (e.g. "Search in Very Long Saved View Name") truncates with "..." instead of being clipped. The styles only apply when the placeholder is visible, so typed values continue to scroll normally.

## Type of change

- [x] Style change (non-breaking CSS change)

# How Has This Been Tested?

- [x] tested manually

**Test Configuration**:

- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code