### PR TITLE
feat(pds-sortable): add disabled prop to prevent sorting

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -1832,6 +1832,11 @@ export namespace Components {
          */
         "componentId": string;
         /**
+          * Determines whether sorting is disabled.
+          * @defaultValue false
+         */
+        "disabled": boolean;
+        /**
           * Deternines whether `sortable` items should be divided with border.
           * @default false
          */
@@ -4925,6 +4930,11 @@ declare namespace LocalJSX {
           * A unique identifier used for the sortable container `id` attribute.
          */
         "componentId": string;
+        /**
+          * Determines whether sorting is disabled.
+          * @defaultValue false
+         */
+        "disabled"?: boolean;
         /**
           * Deternines whether `sortable` items should be divided with border.
           * @default false

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -105,6 +105,29 @@ When `dividers` is set to `true`, a border will display between items.
   </pds-sortable>
 </DocCanvas>
 
+### Disabled
+
+When `disabled` is set to `true`, sorting is prevented and items appear dimmed with a `not-allowed` cursor.
+
+<DocCanvas display="block" mdxSource={{
+  react: `<PdsSortable disabled border dividers componentId="disabled">
+  <PdsSortableItem>Item 1</PdsSortableItem>
+  <PdsSortableItem>Item 2</PdsSortableItem>
+  <PdsSortableItem>Item 3</PdsSortableItem>
+</PdsSortable>`,
+  webComponent: `<pds-sortable disabled border dividers component-id="disabled">
+  <pds-sortable-item>Item 1</pds-sortable-item>
+  <pds-sortable-item>Item 2</pds-sortable-item>
+  <pds-sortable-item>Item 3</pds-sortable-item>
+</pds-sortable>
+`}}>
+  <pds-sortable disabled border dividers component-id="disabled">
+    <pds-sortable-item>Item 1</pds-sortable-item>
+    <pds-sortable-item>Item 2</pds-sortable-item>
+    <pds-sortable-item>Item 3</pds-sortable-item>
+  </pds-sortable>
+</DocCanvas>
+
 ### Handle
 
 When `show-handle` is set to `true` on a `pds-sortable-item`, a handle icon will be displayed within an item.

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
@@ -49,12 +49,11 @@
 
   // styles when sortable is disabled
   .pds-sortable--disabled & {
-    cursor: default;
+    cursor: not-allowed;
     opacity: 0.5;
-    pointer-events: none;
 
     .pds-sortable-item__handle {
-      cursor: default;
+      cursor: not-allowed;
     }
   }
 }

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
@@ -59,10 +59,16 @@
 }
 
 :host(.pds-sortable-item):hover {
-  background-color: var(--pine-color-background-container-hover);
+  .pds-sortable--disabled & {
+    background-color: transparent;
+  }
 
-  pds-icon {
-    color: var(--pine-color-info)
+  .pds-sortable:not(.pds-sortable--disabled) & {
+    background-color: var(--pine-color-background-container-hover);
+
+    pds-icon {
+      color: var(--pine-color-info)
+    }
   }
 }
 

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.scss
@@ -46,6 +46,17 @@
       cursor: grab;
     }
   }
+
+  // styles when sortable is disabled
+  .pds-sortable--disabled & {
+    cursor: default;
+    opacity: 0.5;
+    pointer-events: none;
+
+    .pds-sortable-item__handle {
+      cursor: default;
+    }
+  }
 }
 
 :host(.pds-sortable-item):hover {

--- a/libs/core/src/components/pds-sortable/pds-sortable.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable.tsx
@@ -34,7 +34,7 @@ export class PdsSortable {
   @Prop() componentId!: string;
 
   /**
-   * Deternines whether `sortable` items should be divided with border.
+   * Determines whether `sortable` items should be divided with border.
    */
   @Prop({ reflect: true }) dividers = false;
 

--- a/libs/core/src/components/pds-sortable/pds-sortable.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable.tsx
@@ -23,7 +23,7 @@ export class PdsSortable {
   @Prop({ reflect: true }) border = false;
 
   /**
-   * Determines whether sorting is disabled.
+   * Determines whether or not the sortable is disabled.
    * @defaultValue false
    */
   @Prop({ reflect: true }) disabled = false;

--- a/libs/core/src/components/pds-sortable/pds-sortable.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Host, h, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
 import type { SortableEvent } from 'sortablejs';
 import { SortableType } from './sortable-interface';
 import Sortable from 'sortablejs';
@@ -23,6 +23,12 @@ export class PdsSortable {
   @Prop({ reflect: true }) border = false;
 
   /**
+   * Determines whether sorting is disabled.
+   * @defaultValue false
+   */
+  @Prop({ reflect: true }) disabled = false;
+
+  /**
    * A unique identifier used for the sortable container `id` attribute.
    */
   @Prop() componentId!: string;
@@ -37,11 +43,22 @@ export class PdsSortable {
    */
   @Prop() handleType: 'handle' | 'row' = 'row';
 
+  private sortableInstance: InstanceType<typeof Sortable>;
+
+  @Watch('disabled')
+  handleDisabledChange() {
+    this.sortableInstance?.option('disabled', this.disabled);
+  }
+
   private classNames() {
     const classNames = ['pds-sortable'];
 
     if (this.border) {
       classNames.push('pds-sortable--bordered');
+    }
+
+    if (this.disabled) {
+      classNames.push('pds-sortable--disabled');
     }
 
     if (this.dividers) {
@@ -59,6 +76,7 @@ export class PdsSortable {
 
     let sortableOptions: SortableType = {
       animation: 150,
+      disabled: this.disabled,
       ghostClass: 'pds-sortable-item--ghost',
       dragClass: 'pds-sortable-item--drag',
       onEnd: (evt) => {
@@ -73,7 +91,7 @@ export class PdsSortable {
       };
     }
 
-    Sortable.create(this.el as HTMLElement, sortableOptions);
+    this.sortableInstance = Sortable.create(this.el as HTMLElement, sortableOptions);
   }
 
   render() {

--- a/libs/core/src/components/pds-sortable/readme.md
+++ b/libs/core/src/components/pds-sortable/readme.md
@@ -11,6 +11,7 @@
 | -------------------------- | -------------- | ------------------------------------------------------------------- | ------------------- | ----------- |
 | `border`                   | `border`       | Determines whether `sortable` should have a border.                 | `boolean`           | `false`     |
 | `componentId` _(required)_ | `component-id` | A unique identifier used for the sortable container `id` attribute. | `string`            | `undefined` |
+| `disabled`                 | `disabled`     | Determines whether sorting is disabled.                             | `boolean`           | `false`     |
 | `dividers`                 | `dividers`     | Deternines whether `sortable` items should be divided with border.  | `boolean`           | `false`     |
 | `handleType`               | `handle-type`  | Determines the grabbable area for the `pds-sortable-item`.          | `"handle" \| "row"` | `'row'`     |
 

--- a/libs/core/src/components/pds-sortable/sortable-interface.ts
+++ b/libs/core/src/components/pds-sortable/sortable-interface.ts
@@ -2,6 +2,7 @@ import type { SortableEvent } from 'sortablejs';
 
 export interface SortableType {
   animation: number;
+  disabled: boolean;
   ghostClass: string;
   dragClass: string;
   onEnd: (evt: SortableEvent) => void;

--- a/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
+++ b/libs/core/src/components/pds-sortable/stories/pds-sortable.stories.js
@@ -9,21 +9,21 @@ export default {
 };
 
 const BaseTemplate = (args) => html`
-<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?disabled=${args.disabled} ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item>Item 1</pds-sortable-item>
   <pds-sortable-item>Item 2</pds-sortable-item>
   <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>`;
 
 const HandleTemplate = (args) => html`
-<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?disabled=${args.disabled} ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item>Item 1</pds-sortable-item>
   <pds-sortable-item>Item 2</pds-sortable-item>
   <pds-sortable-item>Item 3</pds-sortable-item>
 </pds-sortable>`;
 
 const ActionsTemplate = (args) => html`
-<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?disabled=${args.disabled} ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item enable-actions>
     <div>Item 1</div>
     <div slot="sortable-item-actions">
@@ -45,7 +45,7 @@ const ActionsTemplate = (args) => html`
 </pds-sortable>`;
 
 const FullDemoTemplate = (args) => html`
-<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?dividers=${args.dividers} handle-type="${args.handleType}">
+<pds-sortable ?border=${args.border} component-id="${args.componentId}" ?disabled=${args.disabled} ?dividers=${args.dividers} handle-type="${args.handleType}">
   <pds-sortable-item enable-actions>
     <div>
       <div><strong>Item 1</strong></div>
@@ -79,6 +79,7 @@ export const Default = BaseTemplate.bind();
 Default.args = {
   componentId: 'default',
   border: false,
+  disabled: false,
   dividers: false,
   handleType: 'row',
 };
@@ -87,7 +88,17 @@ export const Bordered = BaseTemplate.bind();
 Bordered.args = {
   componentId: 'bordered',
   border: true,
+  disabled: false,
   dividers: false,
+  handleType: 'row',
+};
+
+export const Disabled = BaseTemplate.bind();
+Disabled.args = {
+  componentId: 'disabled',
+  border: true,
+  disabled: true,
+  dividers: true,
   handleType: 'row',
 };
 
@@ -95,6 +106,7 @@ export const Dividers = BaseTemplate.bind();
 Dividers.args = {
   componentId: 'dividers',
   border: false,
+  disabled: false,
   dividers: true,
   handleType: 'row',
 };
@@ -103,6 +115,7 @@ export const Handle = HandleTemplate.bind();
 Handle.args = {
   componentId: 'handle',
   border: false,
+  disabled: false,
   dividers: false,
   handleType: 'handle',
 };
@@ -111,6 +124,7 @@ export const Actions = ActionsTemplate.bind();
 Actions.args = {
   componentId: 'actions',
   border: false,
+  disabled: false,
   dividers: false,
   handleType: 'row',
 };
@@ -119,6 +133,7 @@ export const FullDemo = FullDemoTemplate.bind();
 FullDemo.args = {
   componentId: 'demo',
   border: true,
+  disabled: false,
   dividers: true,
   handleType: 'row',
 };

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
@@ -69,7 +69,7 @@ describe('pds-sortable', () => {
     expect(updatedOrder).not.toEqual(initialOrder);
   });
 
-  it('does not reorder items when disabled', async () => {
+  it('renders with disabled class when disabled prop is set', async () => {
     const page = await newE2EPage();
 
     await page.setContent(`
@@ -79,31 +79,8 @@ describe('pds-sortable', () => {
         <pds-sortable-item>Item 3</pds-sortable-item>
       </pds-sortable>`);
 
-    let items = await page.findAll('.pds-sortable-item');
-    const items2 = await page.$$('.pds-sortable-item');
-
-    const initialOrder = await Promise.all(items.map(async (item) => (await item.textContent).trim()));
-
-    const item1 = items2[0];
-    const item2 = items2[1];
-
-    const item1BoundingBox = (await item1.boundingBox()) as any;
-    const item2BoundingBox = (await item2.boundingBox()) as any;
-
-    await page.setDragInterception(true);
-
-    await page.mouse.dragAndDrop(
-      { x: item1BoundingBox.x + 5, y: item1BoundingBox.y + 5 },
-      { x: item2BoundingBox.x + 5, y: item2BoundingBox.y + 5 }
-    );
-
-    await new Promise(resolve => setTimeout(resolve, 300));
-    await page.waitForChanges();
-
-    items = await page.findAll('.pds-sortable-item');
-
-    const updatedOrder = await Promise.all(items.map(async (item) => (await item.textContent).trim()));
-
-    expect(updatedOrder).toEqual(initialOrder);
+    const element = await page.find('pds-sortable');
+    expect(element).toHaveClass('pds-sortable--disabled');
+    expect(element).toHaveAttribute('disabled');
   });
 });

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
@@ -68,4 +68,42 @@ describe('pds-sortable', () => {
 
     expect(updatedOrder).not.toEqual(initialOrder);
   });
+
+  it('does not reorder items when disabled', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <pds-sortable component-id="test-disabled" disabled>
+        <pds-sortable-item>Item 1</pds-sortable-item>
+        <pds-sortable-item>Item 2</pds-sortable-item>
+        <pds-sortable-item>Item 3</pds-sortable-item>
+      </pds-sortable>`);
+
+    let items = await page.findAll('.pds-sortable-item');
+    const items2 = await page.$$('.pds-sortable-item');
+
+    const initialOrder = await Promise.all(items.map(async (item) => (await item.textContent).trim()));
+
+    const item1 = items2[0];
+    const item2 = items2[1];
+
+    const item1BoundingBox = (await item1.boundingBox()) as any;
+    const item2BoundingBox = (await item2.boundingBox()) as any;
+
+    await page.setDragInterception(true);
+
+    await page.mouse.dragAndDrop(
+      { x: item1BoundingBox.x + 5, y: item1BoundingBox.y + 5 },
+      { x: item2BoundingBox.x + 5, y: item2BoundingBox.y + 5 }
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await page.waitForChanges();
+
+    items = await page.findAll('.pds-sortable-item');
+
+    const updatedOrder = await Promise.all(items.map(async (item) => (await item.textContent).trim()));
+
+    expect(updatedOrder).toEqual(initialOrder);
+  });
 });

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.spec.tsx
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.spec.tsx
@@ -49,4 +49,17 @@ describe('pds-sortable', () => {
       <pds-sortable class="pds-sortable pds-sortable--handle-type-handle" handle-type="handle">Content</pds-sortable>
     `);
   });
+
+  it('renders with disabled class when disabled prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsSortable],
+      html: `<pds-sortable disabled>Content</pds-sortable>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <pds-sortable class="pds-sortable pds-sortable--disabled pds-sortable--handle-type-row" disabled="">
+        Content
+      </pds-sortable>
+    `);
+  });
 });


### PR DESCRIPTION
# Description

Fixes [DSS-196](https://linear.app/kajabi/issue/DSS-196/add-disable-attribute-support-to-pds-sortable)

Adds a `disabled` prop to `<pds-sortable>` that prevents items from being reordered. When disabled, the SortableJS instance disables drag interactions, items appear dimmed, and cursor styles update to indicate the non-interactive state.

The prop supports runtime toggling via a `@Watch` handler, so consumers can dynamically enable/disable sorting based on application state (e.g., disallowing reordering when list items are in an invalid state).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] unit tests
- [x] e2e tests
- [x] tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes drag/drop behavior by wiring a new `disabled` prop into the underlying SortableJS instance and styling, which could affect existing consumers’ interactions and runtime toggling.
> 
> **Overview**
> `pds-sortable` now supports a **new `disabled` prop** that disables SortableJS drag interactions (including runtime toggling via a `@Watch` handler) and applies a `pds-sortable--disabled` class.
> 
> When disabled, `pds-sortable-item` styling is updated to *dim items*, switch cursors to `not-allowed`, and suppress hover highlighting. Docs, Storybook examples, generated typings/README, and unit/e2e tests are updated to cover the disabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1884a0de4e9a50890183256c7dc0aff7a41e1e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->