### PR TITLE
chore: add pre-push lockfile sync validation

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,6 +22,8 @@ pre-push:
   commands:
     validate-branch:
       run: npx validate-branch-name
+    verify-lockfile:
+      run: node scripts/verify-lockfile-sync.cjs
 
 commit-msg:
   commands:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "setup": "npm install",
     "start": "npx nx run-many -t start",
     "stencil.generate": "npx nx run @pine-ds/core:generate",
-    "test.all": "npx nx run-many --target=test"
+    "test.all": "npx nx run-many --target=test",
+    "verify-lockfile": "node scripts/verify-lockfile-sync.cjs"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/scripts/verify-lockfile-sync.cjs
+++ b/scripts/verify-lockfile-sync.cjs
@@ -97,9 +97,10 @@ if (lockfile.lockfileVersion !== 3) {
 
 const workspaces = getWorkspacePackages(rootPkg);
 
-// False negative guard
-if (workspaces.length === 0) {
-  console.error('No workspace packages found. Check that package.json "workspaces" is configured correctly.');
+// False negative guard — root is always included, so length must be > 1
+// to confirm workspace packages were actually discovered
+if (workspaces.length <= 1) {
+  console.error('No workspace packages found (only root). Check that package.json "workspaces" is configured correctly.');
   process.exit(1);
 }
 

--- a/scripts/verify-lockfile-sync.cjs
+++ b/scripts/verify-lockfile-sync.cjs
@@ -33,7 +33,8 @@ function getWorkspacePackages(rootPkg) {
   const packages = [{ key: '', dir: ROOT }]; // root package
 
   for (const pattern of patterns) {
-    // Patterns are simple globs like "apps/*" and "libs/*"
+    // Only supports single-level globs (e.g., "apps/*", "libs/*").
+    // Multi-level globs (e.g., "packages/**") would need a glob library.
     const baseDir = path.join(ROOT, pattern.replace('/*', ''));
     if (!fs.existsSync(baseDir)) continue;
 

--- a/scripts/verify-lockfile-sync.cjs
+++ b/scripts/verify-lockfile-sync.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies that package-lock.json is in sync with all package.json files
+ * in the npm workspaces monorepo.
+ *
+ * Checks:
+ *   1. Lockfile exists and is valid JSON with lockfileVersion 3
+ *   2. Every workspace package.json has a corresponding lockfile entry
+ *   3. Dependency specifiers match exactly between package.json and lockfile
+ *
+ * Usage: node scripts/verify-lockfile-sync.cjs
+ * Exit codes: 0 = in sync, 1 = out of sync or error
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+function readJSON(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    console.error(`Error reading ${filePath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function getWorkspacePackages(rootPkg) {
+  const patterns = rootPkg.workspaces || [];
+  const packages = [{ key: '', dir: ROOT }]; // root package
+
+  for (const pattern of patterns) {
+    // Patterns are simple globs like "apps/*" and "libs/*"
+    const baseDir = path.join(ROOT, pattern.replace('/*', ''));
+    if (!fs.existsSync(baseDir)) continue;
+
+    const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const pkgJsonPath = path.join(baseDir, entry.name, 'package.json');
+      if (!fs.existsSync(pkgJsonPath)) continue;
+
+      // Lockfile uses POSIX forward-slash paths (e.g., "libs/core")
+      const key = pattern.replace('/*', '') + '/' + entry.name;
+      packages.push({ key, dir: path.join(baseDir, entry.name) });
+    }
+  }
+
+  return packages;
+}
+
+function compareDeps(pkgDeps, lockDeps, pkgName, field) {
+  const errors = [];
+  const pkgEntries = pkgDeps || {};
+  const lockEntries = lockDeps || {};
+
+  for (const [dep, range] of Object.entries(pkgEntries)) {
+    if (!(dep in lockEntries)) {
+      errors.push(`  ${pkgName} > ${field} > ${dep}: in package.json ("${range}") but missing from lockfile`);
+    } else if (lockEntries[dep] !== range) {
+      errors.push(`  ${pkgName} > ${field} > ${dep}: package.json has "${range}" but lockfile has "${lockEntries[dep]}"`);
+    }
+  }
+
+  for (const [dep] of Object.entries(lockEntries)) {
+    if (!(dep in pkgEntries)) {
+      errors.push(`  ${pkgName} > ${field} > ${dep}: in lockfile but missing from package.json`);
+    }
+  }
+
+  return errors;
+}
+
+// --- Main ---
+
+const rootPkg = readJSON(path.join(ROOT, 'package.json'));
+const lockfilePath = path.join(ROOT, 'package-lock.json');
+
+if (!fs.existsSync(lockfilePath)) {
+  console.error('package-lock.json not found. Run "npm install" to generate it.');
+  process.exit(1);
+}
+
+const lockfile = readJSON(lockfilePath);
+
+// Lockfile version guard
+if (lockfile.lockfileVersion !== 3) {
+  console.error(
+    `Expected lockfileVersion 3, found ${lockfile.lockfileVersion}.\n` +
+    'This script requires npm 7+ lockfile format. Regenerate with: npm install'
+  );
+  process.exit(1);
+}
+
+const workspaces = getWorkspacePackages(rootPkg);
+
+// False negative guard
+if (workspaces.length === 0) {
+  console.error('No workspace packages found. Check that package.json "workspaces" is configured correctly.');
+  process.exit(1);
+}
+
+const allErrors = [];
+
+for (const { key, dir } of workspaces) {
+  const pkg = readJSON(path.join(dir, 'package.json'));
+  const lockEntry = lockfile.packages[key];
+  const displayName = key || '(root)';
+
+  if (!lockEntry) {
+    allErrors.push(`  ${displayName}: missing from lockfile packages map`);
+    continue;
+  }
+
+  for (const field of DEP_FIELDS) {
+    const errors = compareDeps(pkg[field], lockEntry[field], displayName, field);
+    allErrors.push(...errors);
+  }
+}
+
+if (allErrors.length > 0) {
+  console.error('Lockfile is out of sync with package.json:\n');
+  allErrors.forEach(e => console.error(e));
+  console.error('\nRun "npm install" to regenerate the lockfile, then commit it.');
+  process.exit(1);
+}
+
+console.log(`Lockfile sync verified (${workspaces.length} packages checked).`);


### PR DESCRIPTION
Fixes [DSS-198](https://linear.app/kajabi/issue/DSS-198/add-pre-push-lockfile-sync-validation-hook)

# Description

Adds a pre-push hook that validates `package-lock.json` is in sync with all workspace `package.json` files before allowing a push. This prevents the lockfile mismatch CI failures we've been experiencing.

The validation script (`scripts/verify-lockfile-sync.cjs`) compares dependency specifiers between each workspace package.json and the lockfile's `packages` map. Runs in ~60ms with zero external dependencies.

Includes guards for:
- Lockfile version (must be v3, exits with clear error otherwise)
- False negatives (errors if zero packages are found, preventing silent passes from broken lookup logic)

To skip the hook during rebase/merge flows: `LEFTHOOK=0 git push`

Also adds `npm run verify-lockfile` for manual/CI use.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] other: Manual verification (see steps below)

**Steps to test locally:**

1. Pull the branch and run `npx lefthook install` to sync hooks

2. **Test passing case** — from a clean state:
   ```
   node scripts/verify-lockfile-sync.cjs
   ```
   Expected: `Lockfile sync verified (4 packages checked).`

3. **Test failing case** — add a fake dependency to any workspace package.json:
   ```
   # In libs/core/package.json, add "fake-dep": "^1.0.0" to dependencies
   node scripts/verify-lockfile-sync.cjs
   ```
   Expected: Error listing the mismatch with remediation instructions.
   Then restore the file: `git checkout -- libs/core/package.json`

4. **Test hook integration** — run the pre-push hook directly:
   ```
   npx lefthook run pre-push
   ```
   Expected: Both `validate-branch` and `verify-lockfile` pass.

5. **Test the escape hatch** — for rebase/merge flows:
   ```
   LEFTHOOK=0 git push
   ```
   This skips all hooks (lefthook built-in behavior).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a local/CI guardrail script and a pre-push hook, with no runtime/product code changes. Main risk is false positives/negatives in workspace discovery or dependency field comparison blocking pushes.
> 
> **Overview**
> Adds a new pre-push `lefthook` step (`verify-lockfile`) that blocks pushes when `package-lock.json` is not in sync with workspace `package.json` dependency specifiers.
> 
> Introduces `scripts/verify-lockfile-sync.cjs` (and `npm run verify-lockfile`) to validate lockfile presence/version and compare `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` for each discovered workspace entry against the lockfile `packages` map, failing with actionable errors on mismatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66da936989901c27bd9745e3ec35be0e005f1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->