### PR TITLE
feat(pds-multiselect): support disabled individual options

### DIFF
--- a/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
+++ b/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
@@ -740,6 +740,49 @@ Call the `clear()` method to programmatically reset all selections, clear the se
   </div>
 </DocCanvas>
 
+### Disabled Options
+
+Individual options can be disabled using the `disabled` attribute on `<option>` elements, or by setting `disabled: true` on items in the `options` prop. Disabled options are rendered as non-interactive and visually muted — they cannot be selected via click or keyboard navigation. Disabling an `<optgroup>` propagates to all its child options.
+
+<DocCanvas
+  mdxSource={{
+    webComponent: `<pds-multiselect
+  component-id="disabled-options-select"
+  label="Products"
+  placeholder="Select products..."
+>
+  <option value="ec-1">Classical Guitar Learning Path</option>
+  <option value="ec-2" disabled>Piano Lessons (unavailable)</option>
+  <option value="ec-3">Music Theory 101</option>
+  <option value="cc-1" disabled>Spring Bootcamp 2025 (sold out)</option>
+  <option value="cc-2">Fall Workshop Series</option>
+</pds-multiselect>`,
+    react: `<PdsMultiselect
+  componentId="disabled-options-select"
+  label="Products"
+  placeholder="Select products..."
+>
+  <option value="ec-1">Classical Guitar Learning Path</option>
+  <option value="ec-2" disabled>Piano Lessons (unavailable)</option>
+  <option value="ec-3">Music Theory 101</option>
+  <option value="cc-1" disabled>Spring Bootcamp 2025 (sold out)</option>
+  <option value="cc-2">Fall Workshop Series</option>
+</PdsMultiselect>`,
+  }}
+>
+  <pds-multiselect
+    component-id="disabled-options-select"
+    label="Products"
+    placeholder="Select products..."
+  >
+    <option value="ec-1">Classical Guitar Learning Path</option>
+    <option value="ec-2" disabled>Piano Lessons (unavailable)</option>
+    <option value="ec-3">Music Theory 101</option>
+    <option value="cc-1" disabled>Spring Bootcamp 2025 (sold out)</option>
+    <option value="cc-2">Fall Workshop Series</option>
+  </pds-multiselect>
+</DocCanvas>
+
 ### Grouped Options
 
 Use `<optgroup>` elements in the slot to organize options under labeled group headers. Groups are rendered as non-interactive uppercase headings that collapse automatically when search filters out all items in a group.

--- a/libs/core/src/components/pds-multiselect/multiselect-interface.ts
+++ b/libs/core/src/components/pds-multiselect/multiselect-interface.ts
@@ -1,6 +1,8 @@
 export interface MultiselectOption {
   id: string | number;
   text: string;
+  /** When `true`, the option is rendered as non-interactive and cannot be selected. */
+  disabled?: boolean;
   /**
    * Optional section label for grouped rendering (with `options` prop or parsed slots).
    * Options that share a `group` value must be contiguous in the array; non-contiguous

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -208,9 +208,14 @@
     width: 100%;
   }
 
-  &:hover,
-  &.pds-multiselect__option--highlighted {
+  &:hover:not(.pds-multiselect__option--disabled),
+  &.pds-multiselect__option--highlighted:not(.pds-multiselect__option--disabled) {
     background: var(--pine-color-background-muted);
+  }
+
+  &.pds-multiselect__option--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
   }
 
   &:focus-visible {

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -1039,7 +1039,8 @@ export class PdsMultiselect {
     this.toggleOption(option);
   };
 
-  private handleOptionMouseEnter = (index: number) => () => {
+  private handleOptionMouseEnter = (index: number, option: MultiselectOption) => () => {
+    if (option.disabled) return;
     this.highlightedIndex = index;
   };
 
@@ -1112,7 +1113,7 @@ export class PdsMultiselect {
         aria-label={isCreateOption ? `Create new tag: ${option.text}` : undefined}
         data-index={index}
         onMouseDown={this.handleOptionMouseDown(option)}
-        onMouseEnter={this.handleOptionMouseEnter(index)}
+        onMouseEnter={this.handleOptionMouseEnter(index, option)}
       >
         {isCreateOption ? (
           <pds-box class="pds-multiselect__create-option" align-items="center" gap="xs">

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -834,11 +834,12 @@ export class PdsMultiselect {
 
       case 'ArrowUp': {
         e.preventDefault();
-        let prevIndex = this.highlightedIndex - 1;
-        while (prevIndex >= 0 && filteredOptions[prevIndex]?.disabled) {
+        // Clamp to 0 so ArrowUp from uninitialised state (-1) still lands on the first option
+        let prevIndex = Math.max(this.highlightedIndex - 1, 0);
+        while (prevIndex > 0 && filteredOptions[prevIndex]?.disabled) {
           prevIndex--;
         }
-        if (prevIndex >= 0) {
+        if (!filteredOptions[prevIndex]?.disabled) {
           this.highlightedIndex = prevIndex;
           this.scrollOptionIntoView();
         }

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -834,7 +834,8 @@ export class PdsMultiselect {
 
       case 'ArrowUp': {
         e.preventDefault();
-        // Clamp to 0 so ArrowUp from uninitialised state (-1) still lands on the first option
+        // Clamp to 0 so ArrowUp from uninitialised state (-1) attempts the first option;
+        // stays at -1 if that option is disabled.
         let prevIndex = Math.max(this.highlightedIndex - 1, 0);
         while (prevIndex > 0 && filteredOptions[prevIndex]?.disabled) {
           prevIndex--;

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -409,11 +409,14 @@ export class PdsMultiselect {
 
     slot.assignedElements({ flatten: true }).forEach(el => {
       if (el.tagName === 'OPTGROUP') {
-        const groupLabel = (el as HTMLOptGroupElement).label;
-        el.querySelectorAll('option').forEach((opt: HTMLOptionElement) => {
+        const optgroup = el as HTMLOptGroupElement;
+        const groupLabel = optgroup.label;
+        const groupDisabled = optgroup.disabled;
+        optgroup.querySelectorAll('option').forEach((opt: HTMLOptionElement) => {
           const option: MultiselectOption = {
             id: opt.value,
             text: opt.textContent?.trim() || opt.value,
+            disabled: opt.disabled || groupDisabled || undefined,
           };
           if (groupLabel) {
             option.group = groupLabel;
@@ -425,6 +428,7 @@ export class PdsMultiselect {
         options.push({
           id: opt.value,
           text: opt.textContent?.trim() || opt.value,
+          disabled: opt.disabled || undefined,
         });
       }
     });
@@ -815,17 +819,31 @@ export class PdsMultiselect {
     const filteredOptions = this.getFilteredOptions();
 
     switch (e.key) {
-      case 'ArrowDown':
+      case 'ArrowDown': {
         e.preventDefault();
-        this.highlightedIndex = Math.min(this.highlightedIndex + 1, filteredOptions.length - 1);
-        this.scrollOptionIntoView();
+        let nextIndex = this.highlightedIndex + 1;
+        while (nextIndex < filteredOptions.length && filteredOptions[nextIndex]?.disabled) {
+          nextIndex++;
+        }
+        if (nextIndex < filteredOptions.length) {
+          this.highlightedIndex = nextIndex;
+          this.scrollOptionIntoView();
+        }
         break;
+      }
 
-      case 'ArrowUp':
+      case 'ArrowUp': {
         e.preventDefault();
-        this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
-        this.scrollOptionIntoView();
+        let prevIndex = this.highlightedIndex - 1;
+        while (prevIndex >= 0 && filteredOptions[prevIndex]?.disabled) {
+          prevIndex--;
+        }
+        if (prevIndex >= 0) {
+          this.highlightedIndex = prevIndex;
+          this.scrollOptionIntoView();
+        }
         break;
+      }
 
       case 'Enter':
         e.preventDefault();
@@ -966,6 +984,8 @@ export class PdsMultiselect {
   }
 
   private toggleOption(option: MultiselectOption) {
+    if (option.disabled) return;
+
     // Handle create option
     if (option.isCreateOption) {
       // Prevent multiple create calls while one is in-flight
@@ -1070,6 +1090,7 @@ export class PdsMultiselect {
   private renderOption(option: MultiselectOption, index: number, valueArray: string[]) {
     const isSelected = valueArray.includes(String(option.id));
     const isCreateOption = option.isCreateOption;
+    const isDisabled = option.disabled;
     const isHighlighted = index === this.highlightedIndex && !isCreateOption;
     const optionId = `${this.componentId}-option-${index}`;
     const isCreateDisabled = isCreateOption && this.creating;
@@ -1083,11 +1104,11 @@ export class PdsMultiselect {
           'pds-multiselect__option--highlighted': isHighlighted,
           'pds-multiselect__option--selected': isSelected,
           'pds-multiselect__option--create': isCreateOption,
-          'pds-multiselect__option--disabled': isCreateDisabled,
+          'pds-multiselect__option--disabled': isDisabled || isCreateDisabled,
         }}
         role="option"
         aria-selected={isSelected ? 'true' : 'false'}
-        aria-disabled={isCreateDisabled ? 'true' : undefined}
+        aria-disabled={isDisabled || isCreateDisabled ? 'true' : undefined}
         aria-label={isCreateOption ? `Create new tag: ${option.text}` : undefined}
         data-index={index}
         onMouseDown={this.handleOptionMouseDown(option)}
@@ -1103,6 +1124,7 @@ export class PdsMultiselect {
             componentId={`${this.componentId}-checkbox-${index}`}
             checked={isSelected}
             label={option.text}
+            disabled={isDisabled}
             style={{ pointerEvents: 'none' }}
           />
         )}

--- a/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
+++ b/libs/core/src/components/pds-multiselect/stories/pds-multiselect.stories.js
@@ -229,6 +229,37 @@ export const Disabled = {
   `,
 };
 
+export const DisabledOptions = {
+  args: {
+    componentId: 'multiselect-disabled-options',
+    label: 'Products',
+    placeholder: 'Select products...',
+    value: [],
+  },
+  render: (args, { updateArgs } = {}) => html`
+    <pds-multiselect
+      component-id="${args.componentId}"
+      label="${args.label}"
+      placeholder="${args.placeholder}"
+      .value=${args.value}
+      @pdsMultiselectChange=${(e) => updateArgs?.({ value: e.detail.values })}
+    >
+      <option value="ec-1">Classical Guitar Learning Path</option>
+      <option value="ec-2" disabled>Piano Lessons (unavailable)</option>
+      <option value="ec-3">Music Theory 101</option>
+      <option value="cc-1" disabled>Spring Bootcamp 2025 (sold out)</option>
+      <option value="cc-2">Fall Workshop Series</option>
+    </pds-multiselect>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: 'Individual options can be disabled using the `disabled` attribute on `<option>` elements, or by setting `disabled: true` on items in the `options` prop. Disabled options are non-interactive and visually muted.',
+      },
+    },
+  },
+};
+
 export const HiddenLabel = {
   args: {
     componentId: 'multiselect-hidden-label',

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -1559,6 +1559,27 @@ describe('pds-multiselect', () => {
       expect(opts[0].disabled).toBe(true);
       expect(opts[1].disabled).toBe(true);
     });
+
+    it('does not set highlightedIndex when hovering a disabled option', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Enabled' },
+        { id: '2', text: 'Disabled', disabled: true },
+      ];
+      page.rootInstance.isOpen = true;
+      page.rootInstance.highlightedIndex = 0;
+      await page.waitForChanges();
+
+      // Hovering a disabled option should not change highlightedIndex
+      page.rootInstance.handleOptionMouseEnter(1, { id: '2', text: 'Disabled', disabled: true })();
+      await page.waitForChanges();
+
+      expect(page.rootInstance.highlightedIndex).toBe(0);
+    });
   });
 
 });

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -1401,4 +1401,164 @@ describe('pds-multiselect', () => {
     });
   });
 
+  describe('disabled options', () => {
+    it('renders a disabled option with aria-disabled and disabled class', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Enabled Option' },
+        { id: '2', text: 'Disabled Option', disabled: true },
+      ];
+      page.rootInstance.isOpen = true;
+      await page.waitForChanges();
+
+      const options = page.root.shadowRoot.querySelectorAll('.pds-multiselect__option');
+      expect(options[1].classList.contains('pds-multiselect__option--disabled')).toBe(true);
+      expect(options[1].getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('passes disabled prop to pds-checkbox for disabled options', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Disabled Option', disabled: true },
+      ];
+      page.rootInstance.isOpen = true;
+      await page.waitForChanges();
+
+      const checkbox = page.root.shadowRoot.querySelector('pds-checkbox');
+      // Stencil sets boolean props as empty-string attributes on mock elements
+      expect(checkbox.hasAttribute('disabled')).toBe(true);
+    });
+
+    it('does not select a disabled option when clicked', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Disabled Option', disabled: true },
+      ];
+      page.rootInstance.isOpen = true;
+      await page.waitForChanges();
+
+      const valueBefore = [...page.rootInstance.value];
+      page.rootInstance.toggleOption({ id: '1', text: 'Disabled Option', disabled: true });
+      await page.waitForChanges();
+
+      expect(page.rootInstance.value).toEqual(valueBefore);
+    });
+
+    it('skips disabled options on ArrowDown', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Disabled', disabled: true },
+        { id: '2', text: 'Enabled' },
+      ];
+      page.rootInstance.isOpen = true;
+      page.rootInstance.highlightedIndex = -1;
+      await page.waitForChanges();
+
+      const input = page.root.shadowRoot.querySelector('.pds-multiselect__search-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      await page.waitForChanges();
+
+      // Should skip index 0 (disabled) and land on index 1
+      expect(page.rootInstance.highlightedIndex).toBe(1);
+    });
+
+    it('skips disabled options on ArrowUp', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Enabled' },
+        { id: '2', text: 'Disabled', disabled: true },
+        { id: '3', text: 'Enabled 2' },
+      ];
+      page.rootInstance.isOpen = true;
+      page.rootInstance.highlightedIndex = 2;
+      await page.waitForChanges();
+
+      const input = page.root.shadowRoot.querySelector('.pds-multiselect__search-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      await page.waitForChanges();
+
+      // Should skip index 1 (disabled) and land on index 0
+      expect(page.rootInstance.highlightedIndex).toBe(0);
+    });
+
+    it('parses disabled attribute from slotted <option> elements', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      const makeOption = (value: string, text: string, disabled = false) => {
+        const opt = document.createElement('option') as HTMLOptionElement;
+        opt.value = value;
+        opt.textContent = text;
+        opt.disabled = disabled;
+        return opt;
+      };
+
+      const mockSlot = {
+        assignedElements: () => [
+          makeOption('1', 'Enabled Option'),
+          makeOption('2', 'Disabled Option', true),
+        ],
+      };
+
+      jest.spyOn(page.rootInstance.el.shadowRoot!, 'querySelector').mockReturnValue(mockSlot as any);
+      page.rootInstance.updateOptionsFromSlot();
+
+      const opts = page.rootInstance.internalOptions;
+      expect(opts[0].disabled).toBeFalsy();
+      expect(opts[1].disabled).toBe(true);
+    });
+
+    it('propagates disabled from <optgroup disabled> to all child options', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      const makeOption = (value: string, text: string) => {
+        const opt = document.createElement('option') as HTMLOptionElement;
+        opt.value = value;
+        opt.textContent = text;
+        return opt;
+      };
+
+      const optgroup = document.createElement('optgroup') as HTMLOptGroupElement;
+      optgroup.label = 'Locked Group';
+      optgroup.disabled = true;
+      optgroup.appendChild(makeOption('1', 'Option A'));
+      optgroup.appendChild(makeOption('2', 'Option B'));
+      optgroup.querySelectorAll = (() => optgroup.children) as typeof optgroup.querySelectorAll;
+
+      const mockSlot = { assignedElements: () => [optgroup] };
+      jest.spyOn(page.rootInstance.el.shadowRoot!, 'querySelector').mockReturnValue(mockSlot as any);
+      page.rootInstance.updateOptionsFromSlot();
+
+      const opts = page.rootInstance.internalOptions;
+      expect(opts.length).toBe(2);
+      expect(opts[0].disabled).toBe(true);
+      expect(opts[1].disabled).toBe(true);
+    });
+  });
+
 });

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -1501,6 +1501,49 @@ describe('pds-multiselect', () => {
       expect(page.rootInstance.highlightedIndex).toBe(0);
     });
 
+    it('ArrowUp from initial state (-1) highlights the first enabled option', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Enabled' },
+        { id: '2', text: 'Enabled 2' },
+      ];
+      page.rootInstance.isOpen = true;
+      page.rootInstance.highlightedIndex = -1;
+      await page.waitForChanges();
+
+      const input = page.root.shadowRoot.querySelector('.pds-multiselect__search-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      await page.waitForChanges();
+
+      expect(page.rootInstance.highlightedIndex).toBe(0);
+    });
+
+    it('ArrowUp from initial state skips disabled first option', async () => {
+      const page = await newSpecPage({
+        components: [PdsMultiselect],
+        html: `<pds-multiselect component-id="test"></pds-multiselect>`,
+      });
+
+      page.rootInstance.internalOptions = [
+        { id: '1', text: 'Disabled', disabled: true },
+        { id: '2', text: 'Enabled' },
+      ];
+      page.rootInstance.isOpen = true;
+      page.rootInstance.highlightedIndex = -1;
+      await page.waitForChanges();
+
+      const input = page.root.shadowRoot.querySelector('.pds-multiselect__search-input');
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      await page.waitForChanges();
+
+      // Index 0 is disabled so highlightedIndex should not change
+      expect(page.rootInstance.highlightedIndex).toBe(-1);
+    });
+
     it('parses disabled attribute from slotted <option> elements', async () => {
       const page = await newSpecPage({
         components: [PdsMultiselect],


### PR DESCRIPTION
# Description

Adds support for disabling individual options in `pds-multiselect`, closing the last remaining gap with Sage's `SelectDropdown`. This PR stacks on top of #705 (grouped options support).

A disabled option (`disabled: true` on `MultiselectOption`, or `<option disabled>` in the slot) is rendered as non-interactive and visually muted. An `<optgroup disabled>` propagates `disabled: true` to all its child options — matching native `<select>` behavior.

## Changes

- `MultiselectOption` interface: adds `disabled?: boolean` field
- `updateOptionsFromSlot()`: reads `opt.disabled` on flat `<option>` elements; propagates `optgroup.disabled` to children
- `toggleOption()`: early-return guard for disabled options
- `handleSearchInputKeyDown()`: ArrowDown/ArrowUp skip disabled options
- `renderOption()`: applies `pds-multiselect__option--disabled` class, `aria-disabled="true"`, and passes `disabled` to `pds-checkbox`
- SCSS: hover/highlight suppressed for disabled options; `cursor: not-allowed` + `opacity: 0.5`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually (Storybook)

**Test Configuration**:

- OS: macOS
- Browsers: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes input interaction and keyboard navigation behavior in `pds-multiselect`, which could affect selection/UX and accessibility expectations. Scope is contained to option rendering/parsing with solid unit test coverage.
> 
> **Overview**
> Adds first-class support for *disabled individual options* in `pds-multiselect` via a new `MultiselectOption.disabled` flag and by parsing `disabled` from slotted `<option>` elements (including propagation from `<optgroup disabled>`).
> 
> Disabled options are now non-interactive: selection is blocked, hover/highlight styling is suppressed, `aria-disabled` is set, and keyboard navigation skips disabled entries; Storybook/docs examples and a new unit-test suite cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c23803fe75c235d52b9cd0adb234685841fbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->