### PR TITLE
chore: add dependabot manifest cleaner workflow

### DIFF
--- a/.github/workflows/dependabot-manifest-cleaner.yml
+++ b/.github/workflows/dependabot-manifest-cleaner.yml
@@ -1,0 +1,59 @@
+name: Dependabot Manifest Cleaner
+
+# Dependabot is configured with versioning-strategy: lockfile-only, but has
+# recently been observed updating package.json manifests as well (see PR #709).
+# This workflow detects and reverts those manifest changes, keeping only the
+# intended lockfile (package-lock.json) updates.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  clean-manifest-changes:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect manifest changes
+        id: detect
+        run: |
+          MANIFESTS=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | grep -E '(^|/)package\.json$' || true)
+
+          if [ -n "$MANIFESTS" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Manifest files changed by Dependabot:"
+            echo "$MANIFESTS"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No manifest changes found — nothing to do"
+          fi
+
+      - name: Revert manifest changes
+        if: steps.detect.outputs.found == 'true'
+        run: |
+          git config user.name "DSS Automation Bot"
+          git config user.email "dev+github-bot@kajabi.com"
+
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | grep -E '(^|/)package\.json$' \
+            | while read -r file; do
+                git checkout "origin/${{ github.base_ref }}" -- "$file"
+                echo "Reverted: $file"
+              done
+
+          if git diff --staged --quiet; then
+            echo "Nothing staged — manifests already match base, skipping commit"
+          else
+            git commit -m "chore: revert dependabot manifest changes (lockfile-only update)"
+            git push
+          fi

--- a/.github/workflows/dependabot-manifest-cleaner.yml
+++ b/.github/workflows/dependabot-manifest-cleaner.yml
@@ -8,25 +8,47 @@ name: Dependabot Manifest Cleaner
 on:
   pull_request:
     types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to clean manifest changes from'
+        required: true
+        type: string
 
 jobs:
   clean-manifest-changes:
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
+      - name: Resolve PR refs
+        id: refs
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            PR_DATA=$(gh pr view ${{ inputs.pr_number }} --repo ${{ github.repository }} --json headRefName,baseRefName)
+            HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
+            BASE_REF=$(echo "$PR_DATA" | jq -r '.baseRefName')
+          else
+            HEAD_REF="${{ github.head_ref }}"
+            BASE_REF="${{ github.base_ref }}"
+          fi
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.refs.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Detect manifest changes
         id: detect
         run: |
-          MANIFESTS=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+          MANIFESTS=$(git diff --name-only "origin/${{ steps.refs.outputs.base_ref }}...HEAD" \
             | grep -E '(^|/)package\.json$' || true)
 
           if [ -n "$MANIFESTS" ]; then
@@ -44,10 +66,10 @@ jobs:
           git config user.name "DSS Automation Bot"
           git config user.email "dev+github-bot@kajabi.com"
 
-          git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+          git diff --name-only "origin/${{ steps.refs.outputs.base_ref }}...HEAD" \
             | grep -E '(^|/)package\.json$' \
             | while read -r file; do
-                git checkout "origin/${{ github.base_ref }}" -- "$file"
+                git checkout "origin/${{ steps.refs.outputs.base_ref }}" -- "$file"
                 echo "Reverted: $file"
               done
 


### PR DESCRIPTION
# Description

Adds a GitHub Actions workflow that detects and reverts unintended `package.json` manifest changes in Dependabot PRs. Dependabot is configured with `versioning-strategy: lockfile-only` but has recently been observed updating manifest files as well (see #709). This workflow removes those changes, keeping only the intended `package-lock.json` updates.

The workflow can also be dispatched manually against any PR number via `workflow_dispatch`, for cases where it needs to be run retroactively.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [x] other: logic verified by code review — workflow triggers on Dependabot PRs, diffs manifest files against base, restores changed `package.json` files to base branch versions, and commits/pushes only when changes are detected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code