### PR TITLE
fix(release): pin origin remote to PAT to bypass branch protection

### DIFF
--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -35,6 +35,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
+      KAJABI_CI_GH_TOKEN:
+        required: true
 
   workflow_dispatch:
     inputs:
@@ -153,6 +155,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.KAJABI_CI_GH_TOKEN }}
+
+      - name: Pin origin remote to PAT identity
+        run: git remote set-url origin "https://x-access-token:${KAJABI_CI_GH_TOKEN}@github.com/${{ github.repository }}.git"
+        env:
+          KAJABI_CI_GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
 
       - name: Get Latest
         run: git pull
@@ -217,7 +225,7 @@ jobs:
         if: ${{ inputs.version == '' }}
         run: npx nx release --yes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
       ### Steps below are used for releasing a specified version type (major, minor, patch, etc.)
@@ -225,7 +233,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: npx nx release ${{ inputs.version }} --preid ${{ inputs.preid }} --yes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 


### PR DESCRIPTION
# Description

Ports the fix from [ds-tokens#38](https://github.com/Kajabi/ds-tokens/pull/38) to Pine's release workflow.

The previous release run failed at the `nx release` push step with:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
Changes must be made through a pull request.
```

The org-level "Protect default branch" ruleset requires PRs and lists the `bots` team (which includes `kajabi-ci`) as a bypass actor. `actions/checkout@v4` persists credentials via a helper file under `$RUNNER_TEMP` rather than an inline `extraheader` — so `nx release`'s subsequent `git push` was falling back to the `github-actions[bot]` token, which is not a bypass actor.

## Fix

Three changes to the `release` job in `schedule-release.yml`:

1. **Checkout with PAT** — adds `token: KAJABI_CI_GH_TOKEN` to the release job's `actions/checkout` step so the initial clone authenticates as the bot PAT.
2. **Pin origin remote** — adds a step immediately after checkout that rewrites the `origin` remote URL to embed the PAT directly, guaranteeing every subsequent `git push` (including the one inside `nx release`) authenticates as the PAT bypass actor.
3. **GH_TOKEN → PAT** — changes `GH_TOKEN: GITHUB_TOKEN` to `GH_TOKEN: KAJABI_CI_GH_TOKEN` in both release steps so the GitHub API calls (tag creation, release notes) also use the PAT identity.
4. **workflow_call secrets** — declares `KAJABI_CI_GH_TOKEN` as a required secret in the `workflow_call` trigger so callers must pass it through.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Mirrors the exact fix verified in ds-tokens#38. Will be confirmed on the next release run.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions release workflow to use a PAT for checkout, remote URL auth, and `nx release` GitHub operations; mistakes could break releases or inadvertently widen write access via the token.
> 
> **Overview**
> Updates the `schedule-release.yml` release job to authenticate Git operations with a new required `KAJABI_CI_GH_TOKEN` secret.
> 
> The workflow now checks out with the PAT, rewrites `origin` to embed the PAT so downstream `git push` calls use the bypass actor, and switches `nx release` to use the PAT for `GH_TOKEN` instead of `GITHUB_TOKEN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973171be515a376ef73354fdcf9835b1c4c1b7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->