### PR TITLE
chore(ci): pin npm version across all CI jobs and release env

### DIFF
--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -15,7 +15,8 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: '.nvmrc'

--- a/.github/workflows/actions/build-doc-components/action.yml
+++ b/.github/workflows/actions/build-doc-components/action.yml
@@ -15,7 +15,8 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: '.nvmrc'

--- a/.github/workflows/actions/build-react/action.yml
+++ b/.github/workflows/actions/build-react/action.yml
@@ -15,7 +15,8 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: '.nvmrc'

--- a/.github/workflows/actions/setup-node-with-pinned-npm/action.yml
+++ b/.github/workflows/actions/setup-node-with-pinned-npm/action.yml
@@ -1,0 +1,36 @@
+name: 'Set up Node.js with pinned npm'
+description: 'Runs actions/setup-node then installs the npm version from package.json packageManager.'
+
+inputs:
+  node-version:
+    description: 'Node.js version (omit or leave empty when using only node-version-file).'
+    required: false
+    default: ''
+  node-version-file:
+    description: 'File with Node version (e.g. .nvmrc).'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js (explicit version)
+      if: ${{ inputs.node-version != '' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Set up Node.js (version file only)
+      if: ${{ inputs.node-version == '' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Pin npm to package.json packageManager
+      shell: bash
+      run: |
+        NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
+        echo "Pinning npm to ${NPM_VERSION}"
+        npm install -g "npm@${NPM_VERSION}"
+        npm --version

--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -18,6 +18,14 @@ runs:
       with:
         node-version-file: '.nvmrc'
 
+    - name: Pin npm to the version declared in package.json (packageManager)
+      shell: bash
+      run: |
+        NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
+        echo "Pinning npm to ${NPM_VERSION}"
+        npm install -g "npm@${NPM_VERSION}"
+        npm --version
+
     - name: Verify NPM Cache
       shell: bash
       run: npm cache verify

--- a/.github/workflows/actions/setup/action.yml
+++ b/.github/workflows/actions/setup/action.yml
@@ -13,18 +13,10 @@ runs:
       run: git pull
       shell: bash
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version-file: '.nvmrc'
-
-    - name: Pin npm to the version declared in package.json (packageManager)
-      shell: bash
-      run: |
-        NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
-        echo "Pinning npm to ${NPM_VERSION}"
-        npm install -g "npm@${NPM_VERSION}"
-        npm --version
 
     - name: Verify NPM Cache
       shell: bash

--- a/.github/workflows/actions/test-lint/action.yml
+++ b/.github/workflows/actions/test-lint/action.yml
@@ -15,7 +15,8 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/actions/test-spec/action.yml
+++ b/.github/workflows/actions/test-spec/action.yml
@@ -15,7 +15,8 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -166,18 +166,10 @@ jobs:
         run: git pull
         shell: bash
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Node.js (pinned npm)
+        uses: ./.github/workflows/actions/setup-node-with-pinned-npm
         with:
           node-version-file: '.nvmrc'
-
-      - name: Pin npm to the version declared in package.json (packageManager)
-        shell: bash
-        run: |
-          NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
-          echo "Pinning npm to ${NPM_VERSION}"
-          npm install -g "npm@${NPM_VERSION}"
-          npm --version
 
       - name: Verify NPM Cache
         shell: bash

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -171,6 +171,14 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Pin npm to the version declared in package.json (packageManager)
+        shell: bash
+        run: |
+          NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
+          echo "Pinning npm to ${NPM_VERSION}"
+          npm install -g "npm@${NPM_VERSION}"
+          npm --version
+
       - name: Verify NPM Cache
         shell: bash
         run: npm cache verify

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "engines": {
     "node": ">= 16"
   },
+  "packageManager": "npm@10.8.2",
   "scripts": {
     "build.all": "npx nx run-many --target=build",
     "commit": "npx cz",


### PR DESCRIPTION
# Description

Follow-up to #731 (self-heal lockfile after release). #731 ships the safety net
that catches a broken release lockfile. This PR addresses the suspected root
cause: npm version drift between local dev, CI build jobs, and the release
environment.

## Why this is needed

Release commit 6b773e58 rewrote `package-lock.json` in a way that `npm ci`
rejects — stripping 89 `peer: true` markers and the transitive deps flagged as
peer + optional. The pattern matches a known npm CLI bug
([npm/cli#8690](https://github.com/npm/cli/issues/8690)) where certain npm
versions incorrectly handle the `peer: true` flag on optional dependencies.

Even if the bug isn't the exact cause, the symptom is the same: different npm
versions across our environments produce different lockfile shapes, and `npm ci`
is strict enough to reject the mismatch.

## Fix

Pin npm via two coordinated mechanisms with a single source of truth:

1. **`packageManager` field in `package.json`** — declares the canonical npm
   version (`npm@10.8.2`) in one place. Contributors using corepack will pick
   this up automatically; others can read it.
2. **Workflow setup step** — in both the shared `actions/setup` composite
   action (used by `build-core`, `build-react`, `build-doc-components`) and
   the standalone `release` job's Node setup, a new step reads
   `packageManager` from `package.json` and runs `npm install -g npm@<version>`
   immediately after `actions/setup-node@v4`. This is the actual enforcement
   — the `packageManager` field alone is metadata, not a runtime pin for npm.

Result: every job that runs `npm install`, `npm ci`, or `nx release` does so
with npm 10.8.2. Bumping the pinned version means changing one line in
`package.json`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Validated YAML for both `actions/setup/action.yml` and
  `schedule-release.yml` (parses with `js-yaml`).
- [x] Validated `package.json` as JSON; new `packageManager` field is read
  correctly by `node -p "require('./package.json').packageManager"`.
- [ ] other: The pinning takes effect on every workflow run after merge. If
  the CI runner's bundled npm is already 10.8.2 (Node 22 ships with 10.8.x),
  the `npm install -g` step is effectively a no-op. If it's a different
  version, this is where the divergence is collapsed.

# Relationship to #731

- #731 is the safety net: even if drift occurs, the release won't ship a
  broken lockfile.
- This PR is the root-cause fix: drift shouldn't occur in the first place.

If both ship, the self-heal step in #731 should rarely (ideally never) fire.
When it does, that's a real signal worth investigating, not background noise.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI and release workflows; while conceptually simple, it can break builds/releases if the pinned npm install step fails or `packageManager` is misconfigured.
> 
> **Overview**
> Standardizes npm versions across CI by introducing a new composite action, `setup-node-with-pinned-npm`, which runs `actions/setup-node@v4` and then installs the npm version declared in `package.json`’s new `packageManager` field.
> 
> Updates the shared build/test composite actions and the `schedule-release.yml` release job to use this pinned setup step instead of calling `actions/setup-node@v4` directly, reducing lockfile drift from npm version differences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b44cf36546d3702dc9cfe08ed552f693d8713105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->