### PR TITLE
docs: add ADR log with 5 backfilled records

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ git rebase main
 
 The branch can now be pushed. When creating your pull request, please fill out the template with as much info as necessary, including before and after screenshots. Please tag `Kajabi/dss-devs` to notify the Design System team. Our standards require at least two accepted reviews before merging.
 
+## Architecture Decisions
+
+Significant, long-lived decisions are recorded as [Architecture Decision Records](./docs/adr/README.md) under `docs/adr/`. Read the index before proposing changes that reshape architecture, lock in conventions, or trade off something material — and add a new ADR in the same PR if your change qualifies.
+
 ## Troubleshooting
 
 Sometimes, the development environment will experience rendering issues while hot reloading. In most cases, this can be fixed by re-running the `npm run start` command. For any cases where this doesn't resolve the issue, please feel free to reach out to the team for support.

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,31 @@
+# NNNN. Short title (imperative)
+
+- **Status:** Proposed | Accepted | Superseded by ADR-NNNN | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** @github-handle, @github-handle
+
+## Context
+
+What pressure, constraint, or question prompted the decision? Keep it to the facts that mattered when the decision was made — don't editorialize.
+
+## Decision
+
+What did we choose? State it as a single clear sentence first; expand if needed.
+
+## Consequences
+
+What do we accept by choosing this? Include both:
+
+- **Positive** — what gets easier or better.
+- **Negative / accepted costs** — what gets harder, what we lose, what risk we now own.
+
+## Alternatives considered
+
+Bullet the realistic options that were on the table and one-line each on why they lost. If an alternative was never seriously considered, leave it out.
+
+- **Option A** — rejected because …
+- **Option B** — rejected because …
+
+## References
+
+Links to PRs, issues, Linear tickets, Slack threads, prior art, or external docs.

--- a/docs/adr/0001-externalized-token-package.md
+++ b/docs/adr/0001-externalized-token-package.md
@@ -1,8 +1,8 @@
 # 0001. Externalize design tokens to `@kajabi-ui/styles`
 
-- **Status:** Accepted
+- **Status:** Accepted (retrospective)
 - **Date:** 2026-05-15
-- **Deciders:** @Kajabi/dss-devs
+- **Maintainers:** @Kajabi/dss-devs
 
 ## Context
 

--- a/docs/adr/0001-externalized-token-package.md
+++ b/docs/adr/0001-externalized-token-package.md
@@ -1,0 +1,38 @@
+# 0001. Externalize design tokens to `@kajabi-ui/styles`
+
+- **Status:** Accepted
+- **Date:** 2026-05-15
+- **Deciders:** @Kajabi/dss-devs
+
+## Context
+
+Pine's tokens (color, spacing, typography, radius, border, box-shadow, z-index) are consumed by Pine web components AND by non-Pine surfaces inside Kajabi (legacy Rails views, marketing pages, internal tooling). Embedding the token source set inside `libs/core/` would tie token releases to component releases and force every non-Pine consumer to depend on the full component bundle.
+
+## Decision
+
+Design tokens are authored and released from an external package, **`@kajabi-ui/styles`** (versioned independently in the sibling `ds-tokens` repo). Pine consumes it as a regular npm dependency and re-exports the CSS variables via `libs/core/src/global/styles/`.
+
+## Consequences
+
+**Positive**
+
+- Non-Pine consumers can adopt tokens without pulling Pine components.
+- Token releases ship on their own cadence; component PRs don't block on token changes.
+- The `stylelint-plugin-pine-semantic-tokens.cjs` plugin loads its mappings from `@kajabi-ui/styles/lint-mappings`, keeping lint enforcement and the token source in lockstep.
+
+**Negative / accepted costs**
+
+- Two-repo workflow for any change that spans tokens and components.
+- Pine cannot unilaterally add or rename a token — requires a `ds-tokens` release first.
+- Local development against in-flight token changes needs `npm link` or path overrides.
+
+## Alternatives considered
+
+- **In-repo tokens under `libs/tokens/`** — rejected because it forces all non-Pine consumers to depend on the Pine monorepo's release cycle.
+- **Tokens authored in Figma only, generated to Pine on build** — rejected because we still need a canonical source-of-truth package for consumers and lint mappings.
+
+## References
+
+- `libs/core/src/global/styles/app.scss` (consumes `@kajabi-ui/styles`)
+- `libs/core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs` (loads `@kajabi-ui/styles/lint-mappings`)
+- Sibling repo: `Kajabi/ds-tokens`

--- a/docs/adr/0002-stencil-and-nx-monorepo.md
+++ b/docs/adr/0002-stencil-and-nx-monorepo.md
@@ -1,8 +1,8 @@
 # 0002. Stencil.js components in an Nx monorepo
 
-- **Status:** Accepted
+- **Status:** Accepted (retrospective)
 - **Date:** 2026-05-15
-- **Deciders:** @Kajabi/dss-devs
+- **Maintainers:** @Kajabi/dss-devs
 
 ## Context
 

--- a/docs/adr/0002-stencil-and-nx-monorepo.md
+++ b/docs/adr/0002-stencil-and-nx-monorepo.md
@@ -6,26 +6,27 @@
 
 ## Context
 
-Pine ships UI primitives that need to work in framework-agnostic contexts (legacy Kajabi Rails surfaces, marketing pages, third-party embeds) **and** in modern React apps. The repo also holds a React wrapper package, a Figma Code Connect package, a compositions package, and a doc-components package — distinct deliverables that share build tooling, lint configuration, and release cadence.
+Pine ships UI primitives that need to work in framework-agnostic contexts (legacy Kajabi Rails surfaces, marketing pages, third-party embeds) **and** in modern React apps. The repo also holds a React wrapper package (`libs/react/`), doc-components (`libs/doc-components/`), Figma Code Connect sources (`libs/figma/`), and Stencil build outputs under `libs/compositions/` — distinct deliverables that share workspace tooling, lint configuration, and release cadence.
 
 ## Decision
 
-Component primitives are authored as **Stencil.js** web components (`libs/core/`). The repo is structured as an **Nx monorepo** so that `core`, `react`, `compositions`, `compositions-react`, `doc-components`, and `figma` can be built, tested, linted, and released through a single shared toolchain with task caching and dependency-graph awareness.
+Component primitives are authored as **Stencil.js** web components (`libs/core/`). The repo is structured as an **Nx monorepo** so the published packages — **`@pine-ds/core`**, **`@pine-ds/react`**, and **`@pine-ds/doc-components`** — share cached `build`, `test`, and `lint` targets with dependency-graph awareness. `libs/figma/` is Code Connect source (wired via root `figma.config.json`, not an Nx project). `libs/compositions/` and `libs/compositions-react/` hold Stencil build artifacts, not versioned npm packages.
 
 ## Consequences
 
 **Positive**
 
 - One implementation of each component runs everywhere the browser does — no framework lock-in for consumers.
-- Nx provides cached `build`, `test`, `lint`, and `e2e` targets across packages; CI is fast.
+- Nx provides cached `build`, `test`, and `lint` targets on the published packages; CI is fast.
 - React wrappers are generated from Stencil output, keeping API parity automatic.
-- Per-package CHANGELOGs and independent versioning let `react` ship without bumping `core` for cosmetic-only changes.
+- Per-package CHANGELOGs (`libs/core`, `libs/react`, `libs/doc-components`) document package-level changes; `nx release` versions them together on a shared semver.
 
 **Negative / accepted costs**
 
 - Stencil's runtime carries some overhead vs. hand-rolled web components or a pure React library.
 - Shadow DOM styling requires CSS Shadow Parts / `::part()` for consumer overrides — a learning-curve item for non-Pine contributors.
 - Nx orchestration adds a layer of abstraction over plain npm/yarn workspaces.
+- Spec and e2e tests run through `@pine-ds/core` only; `react` and `doc-components` do not expose separate e2e targets.
 
 ## Alternatives considered
 

--- a/docs/adr/0002-stencil-and-nx-monorepo.md
+++ b/docs/adr/0002-stencil-and-nx-monorepo.md
@@ -1,0 +1,40 @@
+# 0002. Stencil.js components in an Nx monorepo
+
+- **Status:** Accepted
+- **Date:** 2026-05-15
+- **Deciders:** @Kajabi/dss-devs
+
+## Context
+
+Pine ships UI primitives that need to work in framework-agnostic contexts (legacy Kajabi Rails surfaces, marketing pages, third-party embeds) **and** in modern React apps. The repo also holds a React wrapper package, a Figma Code Connect package, a compositions package, and a doc-components package — distinct deliverables that share build tooling, lint configuration, and release cadence.
+
+## Decision
+
+Component primitives are authored as **Stencil.js** web components (`libs/core/`). The repo is structured as an **Nx monorepo** so that `core`, `react`, `compositions`, `compositions-react`, `doc-components`, and `figma` can be built, tested, linted, and released through a single shared toolchain with task caching and dependency-graph awareness.
+
+## Consequences
+
+**Positive**
+
+- One implementation of each component runs everywhere the browser does — no framework lock-in for consumers.
+- Nx provides cached `build`, `test`, `lint`, and `e2e` targets across packages; CI is fast.
+- React wrappers are generated from Stencil output, keeping API parity automatic.
+- Per-package CHANGELOGs and independent versioning let `react` ship without bumping `core` for cosmetic-only changes.
+
+**Negative / accepted costs**
+
+- Stencil's runtime carries some overhead vs. hand-rolled web components or a pure React library.
+- Shadow DOM styling requires CSS Shadow Parts / `::part()` for consumer overrides — a learning-curve item for non-Pine contributors.
+- Nx orchestration adds a layer of abstraction over plain npm/yarn workspaces.
+
+## Alternatives considered
+
+- **Plain React component library** — rejected because legacy Kajabi surfaces are not React-driven; we'd need to maintain a second implementation for them.
+- **Lit + Rollup, no monorepo** — rejected because it would push the React wrapper, Figma mapping, and doc-components packages out of band; we'd lose shared tooling.
+- **Pure CSS framework (Bootstrap-style)** — rejected because we need encapsulated, scriptable component behavior (accessibility wiring, focus management, controlled state).
+
+## References
+
+- `nx.json`, `package.json` (workspaces)
+- `libs/core/stencil.config.ts`
+- `libs/react/rollup.config.mjs`

--- a/docs/adr/0003-pine-custom-lint-plugins.md
+++ b/docs/adr/0003-pine-custom-lint-plugins.md
@@ -1,0 +1,51 @@
+# 0003. Custom Pine lint plugins enforce semantic-token usage
+
+- **Status:** Accepted
+- **Date:** 2026-05-15
+- **Deciders:** @Kajabi/dss-devs
+
+## Context
+
+Two recurring failure modes were caught only in code review:
+
+1. New components shipped with hardcoded color values (`#1a1a1a`, `rgba(0,0,0,0.5)`), which break tokenized theming and dark-mode parity.
+2. Components used **core** tokens (`--pine-grey-150`) directly instead of **semantic** tokens (`--pine-color-surface-secondary`), so a token-level theme switch couldn't reach them.
+
+Stylelint's built-in rules can't express "prefer this token over that one" with the precision Pine needs. We also wanted the suggestion to name the closest valid semantic alternative, not just reject the input.
+
+## Decision
+
+Ship **custom Stylelint plugins** under `libs/core/lint-plugins/`:
+
+- `stylelint-plugin-pine-colors.cjs` — `pine-design-system/no-hardcoded-colors`
+- `stylelint-plugin-pine-semantic-tokens.cjs` — `pine-design-system/prefer-semantic-tokens`
+- `eslint-plugin-pine-colors.cjs` — ESLint counterpart for TS/TSX strings
+
+Token mappings are loaded from `@kajabi-ui/styles/lint-mappings` (see ADR-0001) so the rules stay in lockstep with the upstream token source.
+
+## Consequences
+
+**Positive**
+
+- Hardcoded colors and core-token misuse fail CI, not human review.
+- Dark-mode rollout (see ADR-0005) becomes mechanical — semantic tokens already encode light/dark variants.
+- New contributors get immediate, named suggestions instead of generic "don't do that."
+
+**Negative / accepted costs**
+
+- Pine-only lint rules are not shareable with consumer apps without extracting them to a separate plugin package.
+- The plugin loader has to handle three resolution paths (published package, monorepo `node_modules`, sibling `ds-tokens` checkout).
+- Adding a new core token also requires a lint-mapping update in `@kajabi-ui/styles`.
+
+## Alternatives considered
+
+- **Generic `stylelint-declaration-strict-value`** — rejected because it can ban literals but can't suggest the right token.
+- **Code review and JSDoc-based reminders** — tried, didn't scale; violations slipped through.
+- **Codemod / one-time migration** — would fix existing code but not prevent regressions in new code.
+
+## References
+
+- `libs/core/lint-plugins/stylelint-plugin-pine-colors.cjs`
+- `libs/core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs`
+- ADR-0001 (externalized tokens)
+- ADR-0005 (dark mode via semantic tokens)

--- a/docs/adr/0003-pine-custom-lint-plugins.md
+++ b/docs/adr/0003-pine-custom-lint-plugins.md
@@ -1,8 +1,8 @@
 # 0003. Custom Pine lint plugins enforce semantic-token usage
 
-- **Status:** Accepted
+- **Status:** Accepted (retrospective)
 - **Date:** 2026-05-15
-- **Deciders:** @Kajabi/dss-devs
+- **Maintainers:** @Kajabi/dss-devs
 
 ## Context
 

--- a/docs/adr/0003-pine-custom-lint-plugins.md
+++ b/docs/adr/0003-pine-custom-lint-plugins.md
@@ -15,11 +15,12 @@ Stylelint's built-in rules can't express "prefer this token over that one" with 
 
 ## Decision
 
-Ship **custom Stylelint plugins** under `libs/core/lint-plugins/`:
+Ship **custom Stylelint plugins** under `libs/core/lint-plugins/` and enforce them in CI:
 
 - `stylelint-plugin-pine-colors.cjs` — `pine-design-system/no-hardcoded-colors`
 - `stylelint-plugin-pine-semantic-tokens.cjs` — `pine-design-system/prefer-semantic-tokens`
-- `eslint-plugin-pine-colors.cjs` — ESLint counterpart for TS/TSX strings
+
+An **`eslint-plugin-pine-colors.cjs`** counterpart for TS/TSX strings also lives in that directory but is **not wired into ESLint today** (see `libs/core/lint-plugins/README.md`).
 
 Token mappings are loaded from `@kajabi-ui/styles/lint-mappings` (see ADR-0001) so the rules stay in lockstep with the upstream token source.
 
@@ -27,12 +28,13 @@ Token mappings are loaded from `@kajabi-ui/styles/lint-mappings` (see ADR-0001) 
 
 **Positive**
 
-- Hardcoded colors and core-token misuse fail CI, not human review.
+- Hardcoded colors and core-token misuse in **SCSS** fail CI via Stylelint, not human review.
 - Dark-mode rollout (see ADR-0005) becomes mechanical — semantic tokens already encode light/dark variants.
 - New contributors get immediate, named suggestions instead of generic "don't do that."
 
 **Negative / accepted costs**
 
+- Hardcoded colors in **TS/TSX** strings are not blocked until the ESLint plugin is enabled.
 - Pine-only lint rules are not shareable with consumer apps without extracting them to a separate plugin package.
 - The plugin loader has to handle three resolution paths (published package, monorepo `node_modules`, sibling `ds-tokens` checkout).
 - Adding a new core token also requires a lint-mapping update in `@kajabi-ui/styles`.
@@ -47,5 +49,7 @@ Token mappings are loaded from `@kajabi-ui/styles/lint-mappings` (see ADR-0001) 
 
 - `libs/core/lint-plugins/stylelint-plugin-pine-colors.cjs`
 - `libs/core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs`
+- `libs/core/lint-plugins/eslint-plugin-pine-colors.cjs` (not enabled)
+- `libs/core/lint-plugins/README.md`
 - ADR-0001 (externalized tokens)
 - ADR-0005 (dark mode via semantic tokens)

--- a/docs/adr/0004-mcp-server-delivery.md
+++ b/docs/adr/0004-mcp-server-delivery.md
@@ -1,0 +1,45 @@
+# 0004. Ship a Pine MCP server for AI tooling
+
+- **Status:** Accepted
+- **Date:** 2026-05-15
+- **Deciders:** @Kajabi/dss-devs
+
+## Context
+
+Engineers and designers at Kajabi increasingly draft UI through AI tools (Claude Code, Claude Desktop, Cursor, VSCode Copilot). Without a structured information source, those tools hallucinate Pine props, invent component names that don't exist, and produce code that fails lint on first run. Storybook MDX and the Figma file are not directly consumable by the agents.
+
+## Decision
+
+Ship a **Pine MCP server** hosted at `pine-mcp.netlify.app/mcp`. It exposes:
+
+- Component discovery (list of `pds-*` components, props, events, slots)
+- Design-token lookup (semantic and core)
+- Code-generation validation
+
+Setup docs live in `libs/core/src/stories/resources/mcp.docs.mdx`. A dedicated Slack channel (`#dss-pine-mcp`) handles community questions.
+
+## Consequences
+
+**Positive**
+
+- AI-generated Pine code is dramatically more likely to compile, lint, and match canonical patterns on the first attempt.
+- The MCP server is a single integration point — adding a new IDE/agent is a config change for the consumer, not a Pine team lift.
+- Doubles as a Level-5 "Public Design System" deliverable (the maturity model rates MCP servers as a top-tier capability).
+
+**Negative / accepted costs**
+
+- Pine team now operates an externally-hosted service (Netlify), not just an npm package.
+- Schema drift risk — the MCP server has to stay in sync with the Stencil `components.d.ts` and token releases. Owned via the build pipeline.
+- Auth/quotas/abuse — currently public; revisit if traffic warrants.
+
+## Alternatives considered
+
+- **Static rules in each agent's prompt** — rejected because each consumer would maintain their own; drift inevitable.
+- **Generated `AGENTS.md` only** — kept (`AGENTS.md` at repo root) but insufficient on its own; agents still need queryable runtime knowledge of props and tokens.
+- **OpenAPI doc only** — rejected; MCP is the emerging standard for tool-augmented agents.
+
+## References
+
+- `libs/core/src/stories/resources/mcp.docs.mdx`
+- `AGENTS.md`
+- Slack: `#dss-pine-mcp`

--- a/docs/adr/0004-mcp-server-delivery.md
+++ b/docs/adr/0004-mcp-server-delivery.md
@@ -1,8 +1,8 @@
 # 0004. Ship a Pine MCP server for AI tooling
 
-- **Status:** Accepted
+- **Status:** Accepted (retrospective)
 - **Date:** 2026-05-15
-- **Deciders:** @Kajabi/dss-devs
+- **Maintainers:** @Kajabi/dss-devs
 
 ## Context
 
@@ -28,9 +28,9 @@ Setup docs live in `libs/core/src/stories/resources/mcp.docs.mdx`. A dedicated S
 
 **Negative / accepted costs**
 
-- Pine team now operates an externally-hosted service (Netlify), not just an npm package.
-- Schema drift risk — the MCP server has to stay in sync with the Stencil `components.d.ts` and token releases. Owned via the build pipeline.
-- Auth/quotas/abuse — currently public; revisit if traffic warrants.
+- Pine surface now includes an externally-hosted endpoint in addition to the npm packages.
+- Schema drift risk — the MCP server needs to stay in sync with the Stencil `components.d.ts` and token releases.
+- Auth/quotas/abuse — revisit if traffic warrants.
 
 ## Alternatives considered
 

--- a/docs/adr/0005-dark-mode-via-semantic-tokens.md
+++ b/docs/adr/0005-dark-mode-via-semantic-tokens.md
@@ -1,0 +1,50 @@
+# 0005. Roll out dark mode via incremental semantic-token migration
+
+- **Status:** Accepted
+- **Date:** 2026-05-15
+- **Deciders:** @Kajabi/dss-devs
+
+## Context
+
+Dark mode was first attempted on a feature branch (`feat/add-dark-mode`, last touched 2025-11-21 with a `fix: remove temp dark mode styles` commit). That approach — implement dark mode as one large feature branch — produced a stale, hard-to-rebase delta and was abandoned. The team needed a strategy that:
+
+1. Doesn't block on a single massive merge.
+2. Surfaces parity gaps mechanically rather than by review.
+3. Lets dark-mode-ready components ship as soon as they're done.
+
+## Decision
+
+Adopt a **per-component, semantic-token-led migration**:
+
+1. Every component that uses **semantic tokens** (e.g., `--pine-color-text-primary`) inherits dark mode automatically, because the token resolves differently under `[data-theme="dark"]`.
+2. The `pine-design-system/prefer-semantic-tokens` lint rule (see ADR-0003) blocks core-token usage in new SCSS and is being applied component-by-component to existing SCSS.
+3. Each migrated component lands as a small `style(pds-name): adopt … dark-mode-aware tokens` PR. Example: PR #725, `style(pds-chip): adopt chip-namespaced dark-mode-aware text tokens`.
+
+No global dark-mode launch — readiness is per-component, tracked in `libs/core/src/stories/resources/component-status.docs.mdx` (once landed).
+
+## Consequences
+
+**Positive**
+
+- No big-bang merge; rollback risk per PR is small.
+- Lint enforces the rule; new components are born dark-mode-ready.
+- Designers can validate dark mode component-by-component in Storybook.
+
+**Negative / accepted costs**
+
+- The Pine surface is "partially dark-mode" for an extended period — consuming apps need to know which components are ready.
+- Token authoring in `@kajabi-ui/styles` (ADR-0001) has to keep up: every component that needs a namespaced dark variant requires a token addition first.
+- The previous feature branch (`feat/add-dark-mode`) is left stale rather than deleted, in case anything in it is still useful as reference.
+
+## Alternatives considered
+
+- **Single feature-branch landing** — tried, produced the stale branch above; rejected.
+- **`prefers-color-scheme` media query only, no token rework** — rejected because it would couple Pine to OS theme and can't support per-app override or sub-brand themes.
+- **Ship dark mode as a separate `@pine-ds/dark` overlay package** — rejected because consumers would have to import two packages and reason about precedence.
+
+## References
+
+- `libs/core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs`
+- Recent migration PRs: #725 (pds-chip), #620 (pds-alert link hover)
+- ADR-0001 (externalized tokens)
+- ADR-0003 (lint plugins)

--- a/docs/adr/0005-dark-mode-via-semantic-tokens.md
+++ b/docs/adr/0005-dark-mode-via-semantic-tokens.md
@@ -1,8 +1,8 @@
 # 0005. Roll out dark mode via incremental semantic-token migration
 
-- **Status:** Accepted
+- **Status:** Accepted (retrospective)
 - **Date:** 2026-05-15
-- **Deciders:** @Kajabi/dss-devs
+- **Maintainers:** @Kajabi/dss-devs
 
 ## Context
 
@@ -18,7 +18,7 @@ Adopt a **per-component, semantic-token-led migration**:
 
 1. Every component that uses **semantic tokens** (e.g., `--pine-color-text-primary`) inherits dark mode automatically, because the token resolves differently under `[data-theme="dark"]`.
 2. The `pine-design-system/prefer-semantic-tokens` lint rule (see ADR-0003) blocks core-token usage in new SCSS and is being applied component-by-component to existing SCSS.
-3. Each migrated component lands as a small `style(pds-name): adopt … dark-mode-aware tokens` PR. Example: PR #725, `style(pds-chip): adopt chip-namespaced dark-mode-aware text tokens`.
+3. Each migrated component lands as a small `style(pds-name): adopt … dark-mode-aware tokens` PR. Example: commit `6cf3324e`, `style(pds-chip): adopt chip-namespaced dark-mode-aware text tokens`.
 
 No global dark-mode launch — readiness is per-component, tracked in `libs/core/src/stories/resources/component-status.docs.mdx` (once landed).
 
@@ -45,6 +45,6 @@ No global dark-mode launch — readiness is per-component, tracked in `libs/core
 ## References
 
 - `libs/core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs`
-- Recent migration PRs: #725 (pds-chip), #620 (pds-alert link hover)
+- Recent migration commits: `6cf3324e` (pds-chip namespaced dark-mode tokens), `ed4a457f` (pds-alert link hover)
 - ADR-0001 (externalized tokens)
 - ADR-0003 (lint plugins)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,46 @@
+# Architecture Decision Records
+
+This directory records significant decisions made about the Pine Design System — *why* the codebase looks the way it does, not just *what* it does.
+
+## Why ADRs?
+
+Several long-lived choices in Pine (externalized token package, custom lint plugins, MCP delivery, dark-mode strategy) are not obvious from reading the code. Without a record, the same decisions get re-litigated whenever a new contributor or stakeholder asks "why?".
+
+## Format
+
+We use a lightweight [MADR](https://adr.github.io/madr/) variant. Each ADR is a single short Markdown file capturing:
+
+1. **Context** — what problem or pressure prompted the decision
+2. **Decision** — what we chose
+3. **Consequences** — what we accept by choosing it (good and bad)
+4. **Alternatives considered** — what we rejected and why
+
+See [`0000-template.md`](./0000-template.md).
+
+## Index
+
+| # | Title | Status |
+| --- | --- | --- |
+| [0001](./0001-externalized-token-package.md) | Externalize design tokens to `@kajabi-ui/styles` | Accepted |
+| [0002](./0002-stencil-and-nx-monorepo.md) | Stencil.js components in an Nx monorepo | Accepted |
+| [0003](./0003-pine-custom-lint-plugins.md) | Custom Pine lint plugins enforce semantic-token usage | Accepted |
+| [0004](./0004-mcp-server-delivery.md) | Ship a Pine MCP server for AI tooling | Accepted |
+| [0005](./0005-dark-mode-via-semantic-tokens.md) | Roll out dark mode via semantic-token migration | Accepted |
+
+## When to write a new ADR
+
+Write one when a change:
+
+- Reshapes architecture (new package, new platform target, new build system)
+- Locks in a long-lived convention (lint rule, naming pattern, theming strategy)
+- Trades off something material (perf vs. ergonomics, ownership vs. autonomy)
+- Will be expensive to reverse later
+
+Smaller code-level decisions belong in commit messages and PR descriptions, not here.
+
+## Process
+
+1. Copy `0000-template.md` to `NNNN-short-kebab-title.md` (next available number).
+2. Draft in the same PR that implements the decision (or in a separate "Proposed" PR if you want discussion first).
+3. Add the row to the Index above.
+4. Mark as **Accepted** when the PR merges. Use **Superseded by ADR-NNNN** when a later ADR replaces it; keep the old file for the record.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,11 +21,13 @@ See [`0000-template.md`](./0000-template.md).
 
 | # | Title | Status |
 | --- | --- | --- |
-| [0001](./0001-externalized-token-package.md) | Externalize design tokens to `@kajabi-ui/styles` | Accepted |
-| [0002](./0002-stencil-and-nx-monorepo.md) | Stencil.js components in an Nx monorepo | Accepted |
-| [0003](./0003-pine-custom-lint-plugins.md) | Custom Pine lint plugins enforce semantic-token usage | Accepted |
-| [0004](./0004-mcp-server-delivery.md) | Ship a Pine MCP server for AI tooling | Accepted |
-| [0005](./0005-dark-mode-via-semantic-tokens.md) | Roll out dark mode via semantic-token migration | Accepted |
+| [0001](./0001-externalized-token-package.md) | Externalize design tokens to `@kajabi-ui/styles` | Accepted (retrospective) |
+| [0002](./0002-stencil-and-nx-monorepo.md) | Stencil.js components in an Nx monorepo | Accepted (retrospective) |
+| [0003](./0003-pine-custom-lint-plugins.md) | Custom Pine lint plugins enforce semantic-token usage | Accepted (retrospective) |
+| [0004](./0004-mcp-server-delivery.md) | Ship a Pine MCP server for AI tooling | Accepted (retrospective) |
+| [0005](./0005-dark-mode-via-semantic-tokens.md) | Roll out dark mode via semantic-token migration | Accepted (retrospective) |
+
+ADRs 0001–0005 were authored retrospectively to capture decisions already in the codebase. The **Maintainers** field on each names the team that owns the area today, not the original deciders.
 
 ## When to write a new ADR
 


### PR DESCRIPTION
# Description

Establishes `docs/adr/` as the home for Architecture Decision Records, with a lightweight MADR template and five backfilled ADRs covering long-lived choices that aren't obvious from the code:

- **ADR-0001** — Externalized token package (`@kajabi-ui/styles`)
- **ADR-0002** — Stencil.js components in an Nx monorepo
- **ADR-0003** — Custom Pine lint plugins enforce semantic-token usage
- **ADR-0004** — Pine MCP server delivery (`pine-mcp.netlify.app`)
- **ADR-0005** — Dark mode via incremental semantic-token migration

Links the index from `CONTRIBUTING.md` so new contributors find it before re-litigating settled decisions.

This is part of a near-term design-system maturity push (**Level 4 — Decisions Management** gap). No code or behavior changes — pure documentation.

Fixes #(no-issue)

## Where this lives

- **In repo:** [`docs/adr/README.md`](./docs/adr/README.md) (start here)
- **Contributor entry point:** `CONTRIBUTING.md` → Architecture Decisions
- **Not** on the Storybook/docs site — maintainer/contributor documentation (same tier as `CONTRIBUTING.md` / `AGENTS.md`)

## Why now

Closes the **Decisions Management** gap from the design-system maturity assessment: a durable record of *why* Pine is built this way, so we stop re-litigating settled architecture in every large PR.

## Retrospective ADRs

ADRs 0001–0005 are marked **Accepted (retrospective)**. They document decisions already reflected in the codebase, not new choices in this PR. **Maintainers** names the owning team today, not original deciders.

## Review focus

Please sanity-check that each ADR's claims match the repo (paths, package names, Nx projects, lint/CI behavior). This PR does not change runtime behavior — accuracy of the historical record is the main review bar.

## After merge

New long-lived decisions (architecture, conventions, material tradeoffs) should add an ADR in the **same PR** that implements them, using `docs/adr/0000-template.md` and a row in the README index.

## Type of change

- [x] This change requires a documentation update (it _is_ the documentation update)

# How Has This Been Tested?

N/A — markdown-only addition under `docs/adr/` and a 4-line link added to `CONTRIBUTING.md`. Verified locally that the index renders and inter-ADR links resolve.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: n/a
- OS: macOS
- Browsers: n/a
- Screen readers: n/a
- Misc: documentation-only

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR (N/A — no UI changes)

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding ADR guidance and historical records; no runtime, build, or lint behavior is modified.
> 
> **Overview**
> Adds a new `docs/adr/` section to capture long-lived architectural decisions, including an ADR **template** (`0000-template.md`), an **index** (`docs/adr/README.md`), and five **retrospective** ADRs (`0001`–`0005`) documenting existing choices (tokens externalization, Nx/Stencil structure, custom lint plugins, MCP server delivery, and dark-mode strategy).
> 
> Updates `CONTRIBUTING.md` to point contributors to the ADR index and to encourage adding a new ADR alongside PRs that make material architectural or convention-setting changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8c113d8acc466577b69a7f17bd8dd48e2c9d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->