### PR TITLE
chore(ci): add size-limit budgets for core CDN bundles

### DIFF
--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Check out latest
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/actions/build-core/action.yml
+++ b/.github/workflows/actions/build-core/action.yml
@@ -51,9 +51,9 @@ runs:
       run: npx nx run @pine-ds/core:build
       shell: bash
 
-    # - name: Upload artifacts
-    #   uses: ./.github/workflows/actions/upload-archive
-    #   with:
-    #     name: pine-core-build--${{ inputs.node-version }}-${{ github.sha }}
-    #     output: libs/core/CoreBuild.zip
-    #     paths: libs/core/components libs/core/css libs/core/dist libs/core/hydrate libs/core/loader libs/core/src/components.d.ts
+    - name: Upload core dist for size-check
+      uses: ./.github/workflows/actions/upload-archive
+      with:
+        name: pine-core-dist-${{ inputs.node-version }}-${{ github.sha }}
+        output: core-dist.zip
+        paths: libs/core/dist

--- a/.github/workflows/actions/setup-node-with-pinned-npm/action.yml
+++ b/.github/workflows/actions/setup-node-with-pinned-npm/action.yml
@@ -32,5 +32,13 @@ runs:
       run: |
         NPM_VERSION=$(node -p "require('./package.json').packageManager.replace('npm@', '')")
         echo "Pinning npm to ${NPM_VERSION}"
-        npm install -g "npm@${NPM_VERSION}"
+        for attempt in 1 2 3; do
+          npm install -g "npm@${NPM_VERSION}" && break
+          if [ "$attempt" -eq 3 ]; then
+            echo "npm install -g failed after 3 attempts"
+            exit 1
+          fi
+          echo "npm install -g failed (attempt ${attempt}), retrying in $((attempt * 5))s..."
+          sleep $((attempt * 5))
+        done
         npm --version

--- a/.github/workflows/actions/size-check/action.yml
+++ b/.github/workflows/actions/size-check/action.yml
@@ -1,5 +1,5 @@
 name: 'Size Check'
-description: 'Builds core and enforces size budgets via size-limit'
+description: 'Enforces core CDN bundle size budgets via size-limit'
 
 inputs:
   node-version:
@@ -15,33 +15,37 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - uses: actions/setup-node@v4
+    - name: Set up Node.js (pinned npm)
+      uses: ./.github/workflows/actions/setup-node-with-pinned-npm
       with:
         node-version: ${{ inputs.node-version }}
+        node-version-file: '.nvmrc'
 
-    - name: Get npm cache directory
+    - name: Get NPM cache directory
       id: npm-cache-dir
       shell: bash
       run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
 
-    - name: Cache node_modules
+    - name: Cache npm
       uses: actions/cache@v4
-      id: cache-node-modules
-      env:
-        cache-name: cache-node-modules
       with:
         path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        key: ${{ runner.os }}-npm-${{ github.sha }}-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-
+          ${{ runner.os }}-npm-
 
     - name: Install Dependencies
-      if: steps.cache-node-modules.outputs.cache-hit != true
       run: npm ci
       shell: bash
 
-    - name: Build Core
-      run: npx nx run @pine-ds/core:build
+    - name: Download core dist from build-core
+      uses: actions/download-artifact@v4
+      with:
+        name: pine-core-dist-${{ inputs.node-version }}-${{ github.sha }}
+        path: /tmp/pine-core-dist
+
+    - name: Extract core dist
+      run: unzip -q -o /tmp/pine-core-dist/core-dist.zip -d .
       shell: bash
 
     - name: Run size-limit

--- a/.github/workflows/actions/size-check/action.yml
+++ b/.github/workflows/actions/size-check/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Check out latest
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/actions/size-check/action.yml
+++ b/.github/workflows/actions/size-check/action.yml
@@ -1,0 +1,49 @@
+name: 'Size Check'
+description: 'Builds core and enforces size budgets via size-limit'
+
+inputs:
+  node-version:
+    description: 'The version of node to use'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check out latest
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      id: cache-node-modules
+      env:
+        cache-name: cache-node-modules
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-
+
+    - name: Install Dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != true
+      run: npm ci
+      shell: bash
+
+    - name: Build Core
+      run: npx nx run @pine-ds/core:build
+      shell: bash
+
+    - name: Run size-limit
+      run: npx size-limit
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,16 @@ jobs:
       - uses: ./.github/workflows/actions/test-spec
         with:
           node-version: ${{ matrix.node }}
+
+  size-check:
+    needs: [build-core]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ${{ fromJSON(vars.NODE_VERSIONS) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/workflows/actions/size-check
+        with:
+          node-version: ${{ matrix.node }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         node: ${{ fromJSON(vars.NODE_VERSIONS) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/workflows/actions/size-check
         with:
           node-version: ${{ matrix.node }}

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "CDN loader (pine-core.esm.js, gzipped)",
+    "path": "libs/core/dist/pine-core/pine-core.esm.js",
+    "limit": "6 KB",
+    "gzip": true
+  },
+  {
+    "name": "CDN global CSS (pine-core.css, gzipped)",
+    "path": "libs/core/dist/pine-core/pine-core.css",
+    "limit": "6 KB",
+    "gzip": true
+  },
+  {
+    "name": "All CDN component chunks (p-*.entry.js, gzipped)",
+    "path": "libs/core/dist/pine-core/p-*.entry.js",
+    "limit": "320 KB",
+    "gzip": true
+  },
+  {
+    "name": "pds-table entry (gzipped)",
+    "path": "libs/core/dist/esm/pds-table.entry.js",
+    "limit": "5 KB",
+    "gzip": true
+  },
+  {
+    "name": "pds-modal entry (gzipped)",
+    "path": "libs/core/dist/esm/pds-modal.entry.js",
+    "limit": "5 KB",
+    "gzip": true
+  },
+  {
+    "name": "pds-combobox entry (gzipped)",
+    "path": "libs/core/dist/esm/pds-combobox.entry.js",
+    "limit": "36 KB",
+    "gzip": true
+  },
+  {
+    "name": "pds-multiselect entry (gzipped)",
+    "path": "libs/core/dist/esm/pds-multiselect.entry.js",
+    "limit": "15 KB",
+    "gzip": true
+  },
+  {
+    "name": "pds-filters entry (gzipped)",
+    "path": "libs/core/dist/esm/pds-filters.entry.js",
+    "limit": "2 KB",
+    "gzip": true
+  }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ npx nx run @pine-ds/core:build
 npm run size
 ```
 
-Use `npm run size.why` for a detailed breakdown when a budget fails.
+When a budget fails, the CLI prints each tracked file with its gzipped size and limit.
 
 ### Submitting a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,17 @@ For spec and e2e testing, run:
 npm run test.all
 ```
 
+### Bundle size budgets
+
+PR CI enforces gzipped size budgets on core CDN bundles via `size-limit`. Build core, then check budgets locally:
+
+```zsh
+npx nx run @pine-ds/core:build
+npm run size
+```
+
+Use `npm run size.why` for a detailed breakdown when a budget fails.
+
 ### Submitting a Pull Request
 
 Once the desired changes have been made, add and commit the necessary files. We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so please be sure that your commit messages adhere to these standards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@kajabi-ui/styles": "^1.2.0",
         "@nx/devkit": "20.4.6",
         "@nx/js": "20.4.6",
+        "@size-limit/file": "^11.1.6",
         "@storybook/addon-docs": "^10.1.10",
         "@swc-node/register": "~1.9.1",
         "@swc/core": "~1.15.24",
@@ -27,6 +28,7 @@
         "nx-cloud": "19.1.0",
         "prettier": "^2.6.2",
         "semver": "^7.3.8",
+        "size-limit": "^11.1.6",
         "validate-branch-name": "^1.3.0"
       },
       "engines": {
@@ -7604,6 +7606,19 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@size-limit/file": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.2.0.tgz",
+      "integrity": "sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "11.2.0"
+      }
+    },
     "node_modules/@stencil-community/eslint-plugin": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@stencil-community/eslint-plugin/-/eslint-plugin-0.8.0.tgz",
@@ -11211,6 +11226,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
@@ -18533,6 +18558,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
@@ -22805,6 +22840,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -27918,6 +27963,41 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/size-limit": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-11.2.0.tgz",
+      "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "chokidar": "^4.0.3",
+        "jiti": "^2.4.2",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.11"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/size-limit/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "start": "npx nx run-many -t start",
     "stencil.generate": "npx nx run @pine-ds/core:generate",
     "test.all": "npx nx run-many --target=test",
-    "size": "size-limit",
-    "size.why": "size-limit --why"
+    "size": "size-limit"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "setup": "npm install",
     "start": "npx nx run-many -t start",
     "stencil.generate": "npx nx run @pine-ds/core:generate",
-    "test.all": "npx nx run-many --target=test"
+    "test.all": "npx nx run-many --target=test",
+    "size": "size-limit",
+    "size.why": "size-limit --why"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
@@ -26,6 +28,7 @@
     "@kajabi-ui/styles": "^1.2.0",
     "@nx/devkit": "20.4.6",
     "@nx/js": "20.4.6",
+    "@size-limit/file": "^11.1.6",
     "@storybook/addon-docs": "^10.1.10",
     "@swc-node/register": "~1.9.1",
     "@swc/core": "~1.15.24",
@@ -38,6 +41,7 @@
     "nx-cloud": "19.1.0",
     "prettier": "^2.6.2",
     "semver": "^7.3.8",
+    "size-limit": "^11.1.6",
     "validate-branch-name": "^1.3.0"
   },
   "config": {


### PR DESCRIPTION
# Description

Adds bundle-size enforcement to PR CI. No size tracking existed before this — a regression on any of the pine-core CDN bundles could ship silently.

**What's tracked (gzipped):**

| Target | Current | Budget | Headroom |
| --- | --- | --- | --- |
| `pine-core.esm.js` (loader) | 4.45 KB | 6 KB | ~25% |
| `pine-core.css` (global) | 4.30 KB | 6 KB | ~28% |
| `p-*.entry.js` (all chunks total) | 281.39 KB | 320 KB | ~12% |
| `pds-table.entry.js` | 3.66 KB | 5 KB | ~27% |
| `pds-modal.entry.js` | 3.35 KB | 5 KB | ~33% |
| `pds-combobox.entry.js` | 32.15 KB | 36 KB | ~11% |
| `pds-multiselect.entry.js` | 12.43 KB | 15 KB | ~17% |
| `pds-filters.entry.js` | 0.48 KB | 2 KB | wide |

Baselines were measured locally against `main`. Tighten as bundles stabilize.

**New dependencies (root devDeps):**
- `size-limit@^11.1.6`
- `@size-limit/file@^11.1.6`

**New scripts** at repo root:
- `npm run size` — runs the budget check

**CI:** new composite action `.github/workflows/actions/size-check/` and a `size-check` job in `build.yml` that depends on `build-core` and runs in parallel with `test-lint` and `test-specs`.

Part of the design-system maturity push — closes the Level-5 "Performance Profiling" gap.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran `npx size-limit` locally; output matches the table above.
- Verified each path resolves against the actual Stencil build output (`libs/core/dist/`).
- Verified the composite action mirrors the existing `test-lint`/`test-spec` patterns.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: size-limit CLI

**Test Configuration**:

- Pine versions: 3.25.1 (current main)
- OS: macOS 25.3.0
- Browsers: n/a
- Screen readers: n/a
- Misc: gzipped sizes measured locally with `gzip -c`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dev-tooling only; no runtime product code changes, though failing budgets will block PRs until limits are updated or bundles shrink.
> 
> **Overview**
> Adds **gzipped bundle size budgets** for core CDN output using `size-limit`, wired into PR CI so oversized loader, CSS, chunk totals, and selected component entries fail the build.
> 
> **`.size-limit.json`** defines eight gzipped limits (loader, global CSS, all `p-*.entry.js`, and several `pds-*` ESM entries). Root **`npm run size`** runs the same check locally; **CONTRIBUTING** documents the build-then-size flow.
> 
> **CI:** `build-core` now uploads only **`libs/core/dist`** as an artifact (replacing a commented broader archive) and bumps checkout to **v6**. A new **`size-check`** composite job in **`build.yml`** (after `build-core`, matrixed like other jobs) downloads that artifact, extracts it, and runs `npx size-limit`. **`setup-node-with-pinned-npm`** retries global npm pin install up to three times on transient failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90a5a3277ec4f08c203ab6bf077633666ebd6b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

