### PR TITLE
test: add axe-core a11y assertions to e2e suite

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -96,6 +96,7 @@
     "@storybook/web-components-vite": "^10.1.10",
     "@types/jest": "^29.5.14",
     "@types/sortablejs": "^1.15.1",
+    "axe-core": "^4.10.2",
     "@typescript-eslint/eslint-plugin": "6.6.0",
     "@typescript-eslint/parser": "6.6.0",
     "@vitejs/plugin-react": "^5.1.1",

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -1,5 +1,6 @@
 import { newE2EPage } from '@stencil/core/testing';
 import { caretDown, addCircle } from '@pine-ds/icons/icons';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-button', () => {
   it('renders', async () => {
@@ -529,6 +530,33 @@ describe('pds-button', () => {
       await page.waitForChanges();
 
       expect(clickEvent).toHaveReceivedEvent();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has no axe violations with default text content', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<pds-button>Save changes</pds-button>');
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<pds-button disabled>Save changes</pds-button>');
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations as a submit button inside a form', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <form aria-label="Account settings">
+          <pds-button type="submit">Save changes</pds-button>
+        </form>
+      `);
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
     });
   });
 });

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -534,8 +534,6 @@ describe('pds-button', () => {
   });
 
   describe('accessibility', () => {
-    jest.setTimeout(30000);
-
     it('has no axe violations with default text content', async () => {
       const page = await newE2EPage();
       await page.setContent('<pds-button>Save changes</pds-button>');

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
-import { caretDown, addCircle } from '@pine-ds/icons/icons';
+import { caretDown, addCircle, favorite } from '@pine-ds/icons/icons';
 import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-button', () => {
@@ -329,7 +329,7 @@ describe('pds-button', () => {
 
     it('renders small icon-only button correctly', async () => {
       const page = await newE2EPage();
-      await page.setContent('<pds-button size="small" icon-only="true"><pds-icon slot="start" aria-hidden="true" name="favorite"></pds-icon>Small Icon</pds-button>');
+      await page.setContent(`<pds-button size="small" icon-only="true"><pds-icon slot="start" aria-hidden="true" icon="${favorite}"></pds-icon>Small Icon</pds-button>`);
 
       const component = await page.find('pds-button');
       const element = await page.find('pds-button >>> button');
@@ -340,7 +340,7 @@ describe('pds-button', () => {
 
     it('renders micro icon-only button correctly', async () => {
       const page = await newE2EPage();
-      await page.setContent('<pds-button size="micro" icon-only="true"><pds-icon slot="start" aria-hidden="true" name="favorite"></pds-icon>Micro Icon</pds-button>');
+      await page.setContent(`<pds-button size="micro" icon-only="true"><pds-icon slot="start" aria-hidden="true" icon="${favorite}"></pds-icon>Micro Icon</pds-button>`);
 
       const component = await page.find('pds-button');
       const element = await page.find('pds-button >>> button');
@@ -416,7 +416,7 @@ describe('pds-button', () => {
 
     it('tertiary variant works with icon', async () => {
       const page = await newE2EPage();
-      await page.setContent('<pds-button variant="tertiary"><pds-icon slot="start" aria-hidden="true" name="favorite"></pds-icon>Tertiary</pds-button>');
+      await page.setContent(`<pds-button variant="tertiary"><pds-icon slot="start" aria-hidden="true" icon="${favorite}"></pds-icon>Tertiary</pds-button>`);
 
       const component = await page.find('pds-button');
       const element = await page.find('pds-button >>> button');
@@ -534,6 +534,8 @@ describe('pds-button', () => {
   });
 
   describe('accessibility', () => {
+    jest.setTimeout(30000);
+
     it('has no axe violations with default text content', async () => {
       const page = await newE2EPage();
       await page.setContent('<pds-button>Save changes</pds-button>');

--- a/libs/core/src/components/pds-input/test/pds-input.e2e.ts
+++ b/libs/core/src/components/pds-input/test/pds-input.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-input', () => {
   it('renders toggle of disabled state', async () => {
@@ -207,5 +208,42 @@ describe('pds-input', () => {
 
     // Should not have highlight attribute
     expect(component).not.toHaveAttribute('highlight');
+  });
+
+  describe('accessibility', () => {
+    it('has no axe violations with a visible label', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<pds-input label="Email address" component-id="email"></pds-input>');
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations with a hidden label', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<pds-input label="Search" hide-label component-id="search"></pds-input>');
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations when disabled', async () => {
+      const page = await newE2EPage();
+      await page.setContent('<pds-input label="Email address" component-id="email" disabled></pds-input>');
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations with an error message', async () => {
+      const page = await newE2EPage();
+      await page.setContent(
+        '<pds-input label="Email" component-id="email" error-message="Enter a valid email address" invalid></pds-input>',
+      );
+      // `role-img-alt` is disabled here pending a fix on the internal error
+      // icon (it renders without an accessible name). Tracked separately;
+      // remove this override once the icon exposes a label.
+      const violations = await runAxe(page, {
+        rules: { 'role-img-alt': { enabled: false } },
+      });
+      expect(formatViolations(violations)).toBe('');
+    });
   });
 });

--- a/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
+++ b/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
@@ -120,8 +120,10 @@ describe('pds-modal', () => {
         </pds-modal>
       `);
       const modal = await page.find('pds-modal');
+      const openSpy = await page.spyOnEvent('pdsModalOpen');
       await modal.callMethod('showModal');
       await page.waitForChanges();
+      expect(openSpy).toHaveReceivedEvent();
 
       const violations = await runAxe(page);
       expect(formatViolations(violations)).toBe('');

--- a/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
+++ b/libs/core/src/components/pds-modal/test/pds-modal.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-modal', () => {
   it('renders', async () => {
@@ -90,5 +91,40 @@ describe('pds-modal', () => {
 
     const modal = await page.find('pds-modal');
     expect(await modal.getProperty('backdropDismiss')).toBe(false);
+  });
+
+  describe('accessibility', () => {
+    it('has no axe violations when closed', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-modal component-id="test-modal">
+          <div slot="header">Modal Header</div>
+          <div>Modal content</div>
+          <div slot="footer">Modal Footer</div>
+        </pds-modal>
+      `);
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
+
+    it('has no axe violations when open with header, content, and footer', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <pds-modal component-id="test-modal">
+          <h2 slot="header">Confirm action</h2>
+          <p>Are you sure you want to continue?</p>
+          <div slot="footer">
+            <pds-button variant="secondary">Cancel</pds-button>
+            <pds-button>Confirm</pds-button>
+          </div>
+        </pds-modal>
+      `);
+      const modal = await page.find('pds-modal');
+      await modal.callMethod('showModal');
+      await page.waitForChanges();
+
+      const violations = await runAxe(page);
+      expect(formatViolations(violations)).toBe('');
+    });
   });
 });

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file -- page.evaluate runs in the browser; coverage globals are unavailable there */
 import type { E2EPage } from '@stencil/core/testing';
 
 /** axe-core selector path; nested arrays represent iframe/shadow boundaries. */

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -1,5 +1,8 @@
 import type { E2EPage } from '@stencil/core/testing';
 
+/** axe-core selector path; nested arrays represent iframe/shadow boundaries. */
+export type AxeTarget = (string | string[])[];
+
 /**
  * Subset of an axe-core violation surfaced for test assertions. The shape
  * mirrors `axe.AxeResults['violations'][number]` without pulling axe-core's
@@ -12,7 +15,7 @@ export interface AxeViolation {
   help: string;
   helpUrl: string;
   nodes: Array<{
-    target: string[];
+    target: AxeTarget;
     html: string;
     failureSummary?: string;
   }>;
@@ -113,6 +116,16 @@ export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promis
 }
 
 /**
+ * Formats an axe target selector, including nested arrays for shadow DOM
+ * and iframe boundaries (axe's `UnlabelledFrameSelector` shape).
+ */
+export function formatAxeTarget(target: AxeTarget): string {
+  return target
+    .map((segment) => (Array.isArray(segment) ? segment.join(' ') : segment))
+    .join(' >> ');
+}
+
+/**
  * Formats an array of axe violations into a readable failure message for
  * use in test output. Returns an empty string when there are no
  * violations, so it can be passed directly into `expect(...).toBe('')`.
@@ -121,7 +134,7 @@ export function formatViolations(violations: AxeViolation[]): string {
   if (violations.length === 0) return '';
   return violations
     .map((v) => {
-      const targets = v.nodes.map((n) => n.target.join(' ')).join(', ');
+      const targets = v.nodes.map((n) => formatAxeTarget(n.target)).join(', ');
       return `• [${v.impact ?? 'unknown'}] ${v.id} — ${v.help}\n    ${targets}\n    ${v.helpUrl}`;
     })
     .join('\n\n');

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -102,19 +102,20 @@ export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promis
     rules: { ...defaultRules, ...(options.rules ?? {}) },
   };
 
-  // Use a string function body so Istanbul coverage instrumentation is not
-  // serialized into the browser context (cov_* globals are undefined there).
-  const violations = await page.evaluate(
-    `async (opts) => {
+  // Embed options in a string-evaluated IIFE so Istanbul does not instrument
+  // the browser-side function (cov_* globals are undefined in Puppeteer).
+  const optsJson = JSON.stringify(runOptions);
+  const violations = await page.evaluate(`
+    (async () => {
+      const opts = ${optsJson};
       const axe = window.axe;
       if (!axe) {
         throw new Error('axe-core failed to load on the page.');
       }
       const results = await axe.run(document, opts);
       return results.violations;
-    }`,
-    runOptions,
-  );
+    })()
+  `);
 
   return violations as AxeViolation[];
 }

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -31,21 +31,31 @@ export interface RunAxeOptions {
   rules?: Record<string, { enabled: boolean }>;
 }
 
-const DEFAULT_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+/**
+ * Default tag filter applied by `runAxe`. Mirrors WCAG 2.0 + 2.1 levels A
+ * and AA. Override with `{ tags: [...] }` to widen or narrow the scope.
+ */
+export const DEFAULT_AXE_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'] as const;
 
 /**
- * Page-level rules that fire on the bare HTML harness Stencil's E2E
- * provides (no <title>, no <html lang>, no landmarks, no <h1>). They are
- * not meaningful at component-scope and are disabled by default.
- * Tests can opt back in by passing `{ rules: { 'document-title': { enabled: true } } }`.
+ * Page-level axe rules that fire on the bare HTML harness Stencil's E2E
+ * provides (no `<title>`, no `<html lang>`, no landmarks, no `<h1>`).
+ * They are disabled by default because they describe document chrome,
+ * not component behavior — flagging them at component scope yields noise.
+ *
+ * Tests can opt back in for a specific case:
+ *
+ * ```ts
+ * await runAxe(page, { rules: { 'document-title': { enabled: true } } });
+ * ```
  */
-const PAGE_LEVEL_RULES = [
+export const DEFAULT_DISABLED_RULES = [
   'document-title',
   'html-has-lang',
   'landmark-one-main',
   'page-has-heading-one',
   'region',
-];
+] as const;
 
 /**
  * Injects axe-core into an active Stencil E2EPage and returns any
@@ -72,7 +82,7 @@ export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promis
 
   await page.addScriptTag({ path: axePath });
 
-  const defaultRules = PAGE_LEVEL_RULES.reduce<Record<string, { enabled: boolean }>>(
+  const defaultRules = DEFAULT_DISABLED_RULES.reduce<Record<string, { enabled: boolean }>>(
     (acc, rule) => {
       acc[rule] = { enabled: false };
       return acc;
@@ -83,7 +93,7 @@ export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promis
   const runOptions = {
     runOnly: {
       type: 'tag' as const,
-      values: options.tags ?? DEFAULT_TAGS,
+      values: options.tags ?? [...DEFAULT_AXE_TAGS],
     },
     rules: { ...defaultRules, ...(options.rules ?? {}) },
   };

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -1,0 +1,118 @@
+import type { E2EPage } from '@stencil/core/testing';
+
+/**
+ * Subset of an axe-core violation surfaced for test assertions. The shape
+ * mirrors `axe.AxeResults['violations'][number]` without pulling axe-core's
+ * full types into the component test surface.
+ */
+export interface AxeViolation {
+  id: string;
+  impact: 'minor' | 'moderate' | 'serious' | 'critical' | null;
+  description: string;
+  help: string;
+  helpUrl: string;
+  nodes: Array<{
+    target: string[];
+    html: string;
+    failureSummary?: string;
+  }>;
+}
+
+export interface RunAxeOptions {
+  /**
+   * Limits the run to rules tagged with one or more of these values.
+   * Defaults to WCAG 2.0 + 2.1 levels A and AA.
+   */
+  tags?: string[];
+
+  /**
+   * Per-rule overrides (e.g. `{ 'color-contrast': { enabled: false } }`).
+   */
+  rules?: Record<string, { enabled: boolean }>;
+}
+
+const DEFAULT_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+/**
+ * Page-level rules that fire on the bare HTML harness Stencil's E2E
+ * provides (no <title>, no <html lang>, no landmarks, no <h1>). They are
+ * not meaningful at component-scope and are disabled by default.
+ * Tests can opt back in by passing `{ rules: { 'document-title': { enabled: true } } }`.
+ */
+const PAGE_LEVEL_RULES = [
+  'document-title',
+  'html-has-lang',
+  'landmark-one-main',
+  'page-has-heading-one',
+  'region',
+];
+
+/**
+ * Injects axe-core into an active Stencil E2EPage and returns any
+ * accessibility violations found in the current document.
+ *
+ * Usage:
+ *
+ * ```ts
+ * const page = await newE2EPage();
+ * await page.setContent('<pds-button>Click me</pds-button>');
+ * const violations = await runAxe(page);
+ * expect(violations).toEqual([]);
+ * ```
+ *
+ * Component tests should assert against the returned array directly so
+ * each component can document its own baseline (zero violations is the
+ * goal; suppressions should be deliberate and commented).
+ */
+export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promise<AxeViolation[]> {
+  // Resolve axe-core's UMD bundle from node_modules at test time so we
+  // do not depend on a build step injecting it.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const axePath = require.resolve('axe-core/axe.min.js');
+
+  await page.addScriptTag({ path: axePath });
+
+  const defaultRules = PAGE_LEVEL_RULES.reduce<Record<string, { enabled: boolean }>>(
+    (acc, rule) => {
+      acc[rule] = { enabled: false };
+      return acc;
+    },
+    {},
+  );
+
+  const runOptions = {
+    runOnly: {
+      type: 'tag' as const,
+      values: options.tags ?? DEFAULT_TAGS,
+    },
+    rules: { ...defaultRules, ...(options.rules ?? {}) },
+  };
+
+  const violations = await page.evaluate(async (opts) => {
+    // axe is injected on the page via addScriptTag above.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const axe = (window as any).axe;
+    if (!axe) {
+      throw new Error('axe-core failed to load on the page.');
+    }
+    const results = await axe.run(document, opts);
+    return results.violations;
+  }, runOptions);
+
+  return violations as AxeViolation[];
+}
+
+/**
+ * Formats an array of axe violations into a readable failure message for
+ * use in test output. Returns an empty string when there are no
+ * violations, so it can be passed directly into `expect(...).toBe('')`.
+ */
+export function formatViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return '';
+  return violations
+    .map((v) => {
+      const targets = v.nodes.map((n) => n.target.join(' ')).join(', ');
+      return `• [${v.impact ?? 'unknown'}] ${v.id} — ${v.help}\n    ${targets}\n    ${v.helpUrl}`;
+    })
+    .join('\n\n');
+}

--- a/libs/core/src/utils/test/axe.ts
+++ b/libs/core/src/utils/test/axe.ts
@@ -102,16 +102,19 @@ export async function runAxe(page: E2EPage, options: RunAxeOptions = {}): Promis
     rules: { ...defaultRules, ...(options.rules ?? {}) },
   };
 
-  const violations = await page.evaluate(async (opts) => {
-    // axe is injected on the page via addScriptTag above.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const axe = (window as any).axe;
-    if (!axe) {
-      throw new Error('axe-core failed to load on the page.');
-    }
-    const results = await axe.run(document, opts);
-    return results.violations;
-  }, runOptions);
+  // Use a string function body so Istanbul coverage instrumentation is not
+  // serialized into the browser context (cov_* globals are undefined there).
+  const violations = await page.evaluate(
+    `async (opts) => {
+      const axe = window.axe;
+      if (!axe) {
+        throw new Error('axe-core failed to load on the page.');
+      }
+      const results = await axe.run(document, opts);
+      return results.violations;
+    }`,
+    runOptions,
+  );
 
   return violations as AxeViolation[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@typescript-eslint/eslint-plugin": "6.6.0",
         "@typescript-eslint/parser": "6.6.0",
         "@vitejs/plugin-react": "^5.1.1",
+        "axe-core": "^4.10.2",
         "babel-loader": "^8.2.5",
         "eslint": "^8.25.0",
         "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
# Description

Wires `axe-core` into the Stencil e2e harness so accessibility regressions fail PRs. Before this change Pine had ARIA usage and an a11y issue template but **no programmatic a11y assertions** in 39 e2e suites — a regression in `aria-haspopup` on `pds-combobox` or focus wiring on `pds-modal` would ship silently.

**What's new**

- `libs/core/src/utils/test/axe.ts` — shared `runAxe(page)` helper that injects axe-core into the E2EPage and returns violations filtered to WCAG 2.0/2.1 A+AA. Page-level rules that fire on the bare E2E harness (`document-title`, `html-has-lang`, `region`, `landmark-one-main`, `page-has-heading-one`) are disabled by default; tests can opt back in per case.
- `pds-button` — 3 a11y assertions (default, disabled, submit-in-form)
- `pds-modal` — 2 a11y assertions (closed, open with header/content/footer)
- `pds-input` — 4 a11y assertions (visible label, hidden label, disabled, error message)

Test count: **246 → 255 e2e tests** (+9).

**One known finding**

The `pds-input` error-state case temporarily disables `role-img-alt`: the internal error icon renders without an accessible name. This is a real bug — flagging it via the test comment so it's not lost, but fixing it is out of scope for this PR.

**New dependencies**

- `axe-core@^4.10.2` (libs/core devDependency)

Part of the design-system maturity push — closes the Level-3 "Accessibility built-in" gap (manual review → automated assertion).

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (component a11y guidance — follow-up)

# How Has This Been Tested?

- Ran `npx stencil test --e2e --testPathPattern=...` for each modified component and confirmed all 9 new assertions pass.
- Confirmed the helper catches real violations (initial run surfaced page-level harness issues + the `role-img-alt` finding on pds-input error state).
- Lint clean for the new helper file.

- [ ] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.25.1 (current main)
- OS: macOS 25.3.0
- Browsers: Puppeteer (default Stencil e2e runner)
- Screen readers: n/a (automated only)
- Misc: axe-core 4.10.x WCAG 2.0/2.1 A+AA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

## Follow-ups

- Fix the `pds-input` error-icon a11y finding and remove the `role-img-alt` override.
- Expand axe coverage to overlays (`pds-popover`, `pds-tooltip`, `pds-dropdown-menu`, `pds-toast`) and `pds-table`.
- Consider adding `runAxe` to the default story checks in Chromatic (when wired).

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to devDependencies and e2e test code; production bundles are unaffected aside from documenting a known input error-icon a11y gap via a test rule override.
> 
> **Overview**
> Adds **`axe-core`** as a dev dependency and a shared **`runAxe` / `formatViolations`** helper under `libs/core/src/utils/test/axe.ts` so Stencil e2e tests can assert **WCAG 2.0/2.1 A+AA** violations in the browser. The helper scopes runs to component markup by default (disables bare-harness page rules like `document-title` and `html-has-lang`) and supports per-test rule overrides.
> 
> **Nine new accessibility e2e cases** cover **`pds-button`** (default, disabled, submit-in-form), **`pds-input`** (visible/hidden label, disabled, error state), and **`pds-modal`** (closed and open with header/footer). The input error-state test temporarily disables **`role-img-alt`** with a comment pointing at an unlabeled internal error icon.
> 
> Existing **`pds-button`** icon e2e markup is updated to use the **`icon`** prop with the **`favorite`** icon import instead of **`name="favorite"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f3061c73341d92c7ad70bebe14a39a0274128ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->