### PR TITLE
ci: add Chromatic workflow and clarify release cadence

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -48,7 +48,8 @@ jobs:
         run: npx nx run @pine-ds/core:build.storybook
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v16.9.1
+        # Pin to full SHA (v16.9.1) for supply-chain security
+        uses: chromaui/action@c231f99a49d72bfcf68eca3f1ef3187f471e352b
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: libs/core

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,40 +13,57 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Fork PRs cannot use repository secrets; skip when the token is not configured yet.
+    # Fork PRs cannot use repository secrets.
     if: >-
-      ${{
-        secrets.CHROMATIC_PROJECT_TOKEN != '' &&
-        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      }}
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write
     steps:
+      - name: Check Chromatic token is configured
+        id: chromatic-token
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        run: |
+          if [ -n "$CHROMATIC_PROJECT_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "CHROMATIC_PROJECT_TOKEN is not configured; skipping Chromatic publish."
+          fi
+
       - name: Check out latest
+        if: steps.chromatic-token.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node.js (pinned npm)
+        if: steps.chromatic-token.outputs.configured == 'true'
         uses: ./.github/workflows/actions/setup-node-with-pinned-npm
         with:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
+        if: steps.chromatic-token.outputs.configured == 'true'
         run: npm ci
 
       - name: Build doc components
+        if: steps.chromatic-token.outputs.configured == 'true'
         run: npx nx run @pine-ds/doc-components:build
 
       - name: Build Stencil (Storybook consumes dist)
+        if: steps.chromatic-token.outputs.configured == 'true'
         run: npx nx run @pine-ds/core:build
 
       - name: Build Storybook static
+        if: steps.chromatic-token.outputs.configured == 'true'
         run: npx nx run @pine-ds/core:build.storybook
 
       - name: Publish to Chromatic
+        if: steps.chromatic-token.outputs.configured == 'true'
         # Pin to full SHA (v16.9.1) for supply-chain security
         uses: chromaui/action@c231f99a49d72bfcf68eca3f1ef3187f471e352b
         with:
@@ -59,8 +76,7 @@ jobs:
           # are unapproved. This keeps the workflow itself green so other
           # required checks can render their state independently.
           exitZeroOnChanges: true
-          # Main (and next): accept visual diffs into the baseline
-          # automatically. By the time something is on main it has been
-          # reviewed, so re-approving in Chromatic adds friction without
-          # catching anything new.
-          autoAcceptChanges: 'main|next'
+          # Main and next: accept visual diffs into the baseline automatically.
+          # By the time something is on main or next it has been reviewed, so
+          # re-approving in Chromatic adds friction without catching anything new.
+          autoAcceptChanges: '@(main|next)'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -50,3 +50,13 @@ jobs:
           workingDir: libs/core
           storybookBuildDir: storybook-static
           token: ${{ secrets.GITHUB_TOKEN }}
+          # PRs: do not fail the workflow on visual changes — Chromatic
+          # posts its own PR status check that blocks merge when changes
+          # are unapproved. This keeps the workflow itself green so other
+          # required checks can render their state independently.
+          exitZeroOnChanges: true
+          # Main (and next): accept visual diffs into the baseline
+          # automatically. By the time something is on main it has been
+          # reviewed, so re-approving in Chromatic adds friction without
+          # catching anything new.
+          autoAcceptChanges: main

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,52 @@
+name: Chromatic
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+concurrency:
+  group: chromatic-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Fork PRs cannot use repository secrets; skip to avoid failing checks.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out latest
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build doc components
+        run: npx nx run @pine-ds/doc-components:build
+
+      - name: Build Stencil (Storybook consumes dist)
+        run: npx nx run @pine-ds/core:build
+
+      - name: Build Storybook static
+        run: npx nx run @pine-ds/core:build.storybook
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v16.9.1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: libs/core
+          storybookBuildDir: storybook-static
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,8 +13,12 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Fork PRs cannot use repository secrets; skip to avoid failing checks.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Fork PRs cannot use repository secrets; skip when the token is not configured yet.
+    if: >-
+      ${{
+        secrets.CHROMATIC_PROJECT_TOKEN != '' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,13 +27,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up Node.js (pinned npm)
+        uses: ./.github/workflows/actions/setup-node-with-pinned-npm
         with:
           node-version-file: '.nvmrc'
-          cache: npm
-          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -64,4 +63,4 @@ jobs:
           # automatically. By the time something is on main it has been
           # reviewed, so re-approving in Chromatic adds friction without
           # catching anything new.
-          autoAcceptChanges: main
+          autoAcceptChanges: 'main|next'

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -6,9 +6,15 @@ permissions:
   contents: read
 
 on:
-  ## We will uncomment this when we settle on a deployment schedule
+  # Release cadence today is **manual / on-demand** via `workflow_dispatch` (and `workflow_call`
+  # from other automation). There is no weekly cron publish yet.
+  #
+  # When the team wants a fixed cadence (for example weekly npm publishes), uncomment and adjust:
   # schedule:
-  #  - cron: '00 04 * * 1' # 4 am UTC (9 am CST) Monday
+  #   - cron: '00 04 * * 1' # example: 4 am UTC Mondays
+  #
+  # Until then, maintainers cut versions from the default branch using the dispatch form in GitHub
+  # Actions for this workflow ("Pine Continuous Deployment").
 
   workflow_call:
     inputs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,16 @@ npm run size
 
 When a budget fails, the CLI prints each tracked file with its gzipped size and limit.
 
+### Visual regression (Chromatic)
+
+Pull requests and pushes to `main` / `next` run [Chromatic](https://www.chromatic.com/) via [`.github/workflows/chromatic.yml`](.github/workflows/chromatic.yml). The workflow publishes the static Storybook build from `libs/core/storybook-static`.
+
+Repository maintainers must add a **`CHROMATIC_PROJECT_TOKEN`** secret (from the Chromatic project for this Storybook) so the job can authenticate. Forked pull requests skip Chromatic because secrets are not available to them.
+
+### Releases
+
+`Pine Continuous Deployment` ([`.github/workflows/schedule-release.yml`](.github/workflows/schedule-release.yml)) is triggered **manually** with `workflow_dispatch` (or by another workflow via `workflow_call`). There is no scheduled npm publish cron enabled in-repo yet; see the comment block at the top of that workflow when enabling a cadence.
+
 ### Submitting a Pull Request
 
 Once the desired changes have been made, add and commit the necessary files. We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so please be sure that your commit messages adhere to these standards.


### PR DESCRIPTION
# Description

**Two related changes:**

1. **Wire up Chromatic visual regression in CI.** The `@chromatic-com/storybook` addon is already configured in `libs/core/.storybook/main.js`, but no CI workflow ran against it — so visual regressions could ship undetected. This adds `.github/workflows/chromatic.yml` that builds doc-components → Stencil → Storybook, then publishes to Chromatic on PR and push to `main`/`next`. Fork PRs are skipped because repository secrets are unavailable to them.

2. **Document the actual release cadence.** `CONTRIBUTING.md` now explains how Visual regression and Releases work, and the comment block at the top of `schedule-release.yml` is expanded to make clear that releases are **manual / on-demand** via `workflow_dispatch` (and `workflow_call`) — there is no weekly cron yet. Contributors were sometimes asking when the next release would auto-cut; this answers that.

**Required maintainer action**: add a **`CHROMATIC_PROJECT_TOKEN`** repo secret (from the Pine Chromatic project) before merging. Without it the new workflow will fail at the publish step.

Part of the design-system maturity push — closes the Level-4 "Visual regression testing" gap.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Confirmed `@chromatic-com/storybook` is already installed at `libs/core/.storybook/main.js`.
- Verified the workflow only requires a single new secret (`CHROMATIC_PROJECT_TOKEN`).
- Verified the fork-PR guard expression matches the official GitHub Actions pattern.

This PR cannot be fully exercised until the maintainer adds the secret; the first run after merge will surface any environmental issues.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually (workflow syntax review)
- [x] other: pending live CI run after secret is added

**Test Configuration**:

- Pine versions: 3.25.1 (current main)
- OS: macOS 25.3.0
- Browsers: n/a
- Screen readers: n/a
- Misc: GitHub Actions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and documentation only; no application runtime, auth, or data-path changes. Requires adding CHROMATIC_PROJECT_TOKEN for the job to run.
> 
> **Overview**
> Adds **Chromatic visual regression** to CI via a new workflow that runs on PRs and pushes to `main`/`next`. It builds doc-components, Stencil, and static Storybook, then publishes from `libs/core` when `CHROMATIC_PROJECT_TOKEN` is set; otherwise it skips gracefully. **Fork PRs** are excluded from secret use; **chromaui/action** is pinned by SHA; PR runs use `exitZeroOnChanges` while `main`/`next` use `autoAcceptChanges`.
> 
> **CONTRIBUTING** documents Chromatic setup (secret, fork behavior) and that **releases are manual** via `workflow_dispatch`/`workflow_call`, not cron. **`schedule-release.yml`** comments are expanded to match that on-demand cadence and how to enable a future schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119d545b47544569020abf7edc04b55eaf6bb517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->