### PR TITLE
docs: add per-component lifecycle status badges

### DIFF
--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-button.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge status="stable" />
 
 # Button
 

--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
 
-<StatusBadge status="stable" />
+<StatusBadge component="pds-button" />
 
 # Button
 

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
 
-<StatusBadge status="stable" />
+<StatusBadge component="pds-modal" />
 
 # Modal
 

--- a/libs/core/src/components/pds-modal/docs/pds-modal.mdx
+++ b/libs/core/src/components/pds-modal/docs/pds-modal.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-modal.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge status="stable" />
 
 # Modal
 

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-table.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge status="stable" />
 
 # Table
 

--- a/libs/core/src/components/pds-table/docs/pds-table.mdx
+++ b/libs/core/src/components/pds-table/docs/pds-table.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
 
-<StatusBadge status="stable" />
+<StatusBadge component="pds-table" />
 
 # Table
 

--- a/libs/core/src/stories/_helpers/StatusBadge.css
+++ b/libs/core/src/stories/_helpers/StatusBadge.css
@@ -37,3 +37,7 @@
 .pine-status-badge[data-status='deprecated'] {
   color: var(--pine-color-text-danger);
 }
+
+.pine-status-badge[data-status='unknown'] {
+  color: var(--pine-color-text-warning);
+}

--- a/libs/core/src/stories/_helpers/StatusBadge.css
+++ b/libs/core/src/stories/_helpers/StatusBadge.css
@@ -1,0 +1,39 @@
+.pine-status-badge {
+  align-items: center;
+  background-color: var(--pine-color-background-subtle);
+  border-radius: 999px;
+  color: var(--pine-color-text-primary);
+  display: inline-flex;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  gap: 0.5rem;
+  line-height: 1.2;
+  margin: 0 0 1rem;
+  padding: 0.25rem 0.625rem;
+}
+
+.pine-status-badge__dot {
+  background-color: currentColor;
+  border-radius: 50%;
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 0.5rem;
+  width: 0.5rem;
+}
+
+.pine-status-badge__note {
+  color: var(--pine-color-text-secondary);
+  font-weight: 400;
+}
+
+.pine-status-badge[data-status='stable'] {
+  color: var(--pine-color-text-success);
+}
+
+.pine-status-badge[data-status='beta'] {
+  color: var(--pine-color-text-warning);
+}
+
+.pine-status-badge[data-status='deprecated'] {
+  color: var(--pine-color-text-danger);
+}

--- a/libs/core/src/stories/_helpers/StatusBadge.css
+++ b/libs/core/src/stories/_helpers/StatusBadge.css
@@ -1,8 +1,12 @@
 .pine-status-badge {
+  --pine-status-badge-bg: var(--pine-color-background-subtle);
+  --pine-status-badge-fg: var(--pine-color-text-primary);
+  --pine-status-badge-dot: currentColor;
+
   align-items: center;
-  background-color: var(--pine-color-background-subtle);
+  background-color: var(--pine-status-badge-bg);
   border-radius: 999px;
-  color: var(--pine-color-text-primary);
+  color: var(--pine-status-badge-fg);
   display: inline-flex;
   font-size: 0.8125rem;
   font-weight: 500;
@@ -13,7 +17,7 @@
 }
 
 .pine-status-badge__dot {
-  background-color: currentColor;
+  background-color: var(--pine-status-badge-dot);
   border-radius: 50%;
   display: inline-block;
   flex: 0 0 auto;
@@ -22,22 +26,31 @@
 }
 
 .pine-status-badge__note {
-  color: var(--pine-color-text-secondary);
+  color: inherit;
   font-weight: 400;
+  opacity: 0.8;
 }
 
 .pine-status-badge[data-status='stable'] {
-  color: var(--pine-color-text-success);
+  --pine-status-badge-bg: var(--pine-color-success-disabled);
+  --pine-status-badge-fg: var(--pine-color-text-success);
+  --pine-status-badge-dot: var(--pine-color-success-hover);
 }
 
 .pine-status-badge[data-status='beta'] {
-  color: var(--pine-color-text-warning);
+  --pine-status-badge-bg: var(--pine-color-warning-disabled);
+  --pine-status-badge-fg: var(--pine-color-text-warning);
+  --pine-status-badge-dot: var(--pine-color-warning-hover);
 }
 
 .pine-status-badge[data-status='deprecated'] {
-  color: var(--pine-color-text-danger);
+  --pine-status-badge-bg: var(--pine-color-danger-disabled);
+  --pine-status-badge-fg: var(--pine-color-text-danger);
+  --pine-status-badge-dot: var(--pine-color-danger-hover);
 }
 
 .pine-status-badge[data-status='unknown'] {
-  color: var(--pine-color-text-warning);
+  --pine-status-badge-bg: var(--pine-color-warning-disabled);
+  --pine-status-badge-fg: var(--pine-color-text-warning);
+  --pine-status-badge-dot: var(--pine-color-warning-hover);
 }

--- a/libs/core/src/stories/_helpers/StatusBadge.tsx
+++ b/libs/core/src/stories/_helpers/StatusBadge.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import './StatusBadge.css';
+
+export type ComponentStatus = 'stable' | 'beta' | 'deprecated';
+
+export interface StatusBadgeProps {
+  /** Lifecycle label as defined in the central component-status table. */
+  status: ComponentStatus;
+  /** Optional inline note (for example: 'Replaced by `pds-property`'). */
+  note?: string;
+}
+
+const STATUS_LABELS: Record<ComponentStatus, string> = {
+  stable: 'Stable',
+  beta: 'Beta',
+  deprecated: 'Deprecated',
+};
+
+/**
+ * Renders the per-component lifecycle label that mirrors the central
+ * Resources/Component status table. Apply once at the top of each
+ * component's MDX page so consumers see stability state without
+ * navigating elsewhere.
+ *
+ * Source of truth: `libs/core/src/stories/resources/component-status.docs.mdx`.
+ * Keep this badge in sync with that table when a component is promoted
+ * or deprecated.
+ */
+export const StatusBadge: React.FC<StatusBadgeProps> = ({ status, note }) => {
+  const label = STATUS_LABELS[status];
+  return (
+    <div className="pine-status-badge" data-status={status} role="note" aria-label={`Component status: ${label}`}>
+      <span className="pine-status-badge__dot" aria-hidden="true" />
+      <span className="pine-status-badge__label">{label}</span>
+      {note !== undefined && note !== '' ? <span className="pine-status-badge__note">— {note}</span> : null}
+    </div>
+  );
+};
+
+export default StatusBadge;

--- a/libs/core/src/stories/_helpers/StatusBadge.tsx
+++ b/libs/core/src/stories/_helpers/StatusBadge.tsx
@@ -5,6 +5,9 @@ import './StatusBadge.css';
 
 export type ComponentStatus = 'stable' | 'beta' | 'deprecated';
 
+/** Display-only when manifest lookup fails or status is invalid. */
+type ResolvedStatus = ComponentStatus | 'unknown';
+
 export interface StatusBadgeProps {
   /**
    * Component tag (for example `pds-button`). When provided the badge
@@ -14,9 +17,9 @@ export interface StatusBadgeProps {
   component?: string;
 
   /**
-   * Lifecycle label override. Only used when `component` is omitted, or
-   * to force a status that differs from the central table (rare —
-   * prefer updating the JSON manifest).
+   * Lifecycle label override. Takes priority over the JSON manifest when
+   * both are set — use to force a status that differs from the central
+   * table (rare; prefer updating the JSON manifest).
    */
   status?: ComponentStatus;
 
@@ -29,13 +32,65 @@ interface ComponentEntry {
   note?: string;
 }
 
-const STATUS_LABELS: Record<ComponentStatus, string> = {
+const VALID_STATUSES: readonly ComponentStatus[] = ['stable', 'beta', 'deprecated'];
+
+const STATUS_LABELS: Record<ResolvedStatus, string> = {
   stable: 'Stable',
   beta: 'Beta',
   deprecated: 'Deprecated',
+  unknown: 'Unknown',
 };
 
 const COMPONENTS = componentStatus.components as Record<string, ComponentEntry>;
+
+function isComponentStatus(value: unknown): value is ComponentStatus {
+  return typeof value === 'string' && (VALID_STATUSES as readonly string[]).includes(value);
+}
+
+function warnDev(message: string): void {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(`[StatusBadge] ${message}`);
+  }
+}
+
+function resolveStatus(
+  component: string | undefined,
+  status: ComponentStatus | undefined,
+  entry: ComponentEntry | undefined,
+): ResolvedStatus {
+  if (status !== undefined) {
+    if (!isComponentStatus(status)) {
+      warnDev(`Invalid status prop "${status}".`);
+      return 'unknown';
+    }
+    return status;
+  }
+
+  if (entry !== undefined) {
+    if (!isComponentStatus(entry.status)) {
+      warnDev(
+        `Invalid status "${String(entry.status)}" for "${component ?? 'component'}" in component-status.json.`,
+      );
+      return 'unknown';
+    }
+    return entry.status;
+  }
+
+  if (component !== undefined) {
+    warnDev(`"${component}" is not listed in component-status.json.`);
+    return 'unknown';
+  }
+
+  return 'stable';
+}
+
+function buildAriaLabel(label: string, note: string | undefined): string {
+  if (note !== undefined && note !== '') {
+    return `Component status: ${label}. ${note}`;
+  }
+  return `Component status: ${label}`;
+}
 
 /**
  * Renders the per-component lifecycle label that mirrors the central
@@ -49,16 +104,17 @@ const COMPONENTS = componentStatus.components as Record<string, ComponentEntry>;
  */
 export const StatusBadge: React.FC<StatusBadgeProps> = ({ component, status, note }) => {
   const entry = component !== undefined ? COMPONENTS[component] : undefined;
-  const resolvedStatus: ComponentStatus = entry?.status ?? status ?? 'stable';
+  const resolvedStatus = resolveStatus(component, status, entry);
   const resolvedNote = note ?? entry?.note;
   const label = STATUS_LABELS[resolvedStatus];
+  const ariaLabel = buildAriaLabel(label, resolvedNote);
 
   return (
     <div
       className="pine-status-badge"
       data-status={resolvedStatus}
       role="note"
-      aria-label={`Component status: ${label}`}
+      aria-label={ariaLabel}
     >
       <span className="pine-status-badge__dot" aria-hidden="true" />
       <span className="pine-status-badge__label">{label}</span>
@@ -68,5 +124,3 @@ export const StatusBadge: React.FC<StatusBadgeProps> = ({ component, status, not
     </div>
   );
 };
-
-export default StatusBadge;

--- a/libs/core/src/stories/_helpers/StatusBadge.tsx
+++ b/libs/core/src/stories/_helpers/StatusBadge.tsx
@@ -1,13 +1,31 @@
 import React from 'react';
 
+import componentStatus from '../resources/component-status.json';
 import './StatusBadge.css';
 
 export type ComponentStatus = 'stable' | 'beta' | 'deprecated';
 
 export interface StatusBadgeProps {
-  /** Lifecycle label as defined in the central component-status table. */
-  status: ComponentStatus;
+  /**
+   * Component tag (for example `pds-button`). When provided the badge
+   * reads the lifecycle label from `component-status.json` so the badge
+   * and the central status table cannot drift.
+   */
+  component?: string;
+
+  /**
+   * Lifecycle label override. Only used when `component` is omitted, or
+   * to force a status that differs from the central table (rare —
+   * prefer updating the JSON manifest).
+   */
+  status?: ComponentStatus;
+
   /** Optional inline note (for example: 'Replaced by `pds-property`'). */
+  note?: string;
+}
+
+interface ComponentEntry {
+  status: ComponentStatus;
   note?: string;
 }
 
@@ -17,23 +35,36 @@ const STATUS_LABELS: Record<ComponentStatus, string> = {
   deprecated: 'Deprecated',
 };
 
+const COMPONENTS = componentStatus.components as Record<string, ComponentEntry>;
+
 /**
  * Renders the per-component lifecycle label that mirrors the central
  * Resources/Component status table. Apply once at the top of each
  * component's MDX page so consumers see stability state without
  * navigating elsewhere.
  *
- * Source of truth: `libs/core/src/stories/resources/component-status.docs.mdx`.
- * Keep this badge in sync with that table when a component is promoted
- * or deprecated.
+ * Source of truth: `libs/core/src/stories/resources/component-status.json`.
+ * Pass the component tag (`component="pds-button"`) so the badge stays
+ * in sync automatically.
  */
-export const StatusBadge: React.FC<StatusBadgeProps> = ({ status, note }) => {
-  const label = STATUS_LABELS[status];
+export const StatusBadge: React.FC<StatusBadgeProps> = ({ component, status, note }) => {
+  const entry = component !== undefined ? COMPONENTS[component] : undefined;
+  const resolvedStatus: ComponentStatus = entry?.status ?? status ?? 'stable';
+  const resolvedNote = note ?? entry?.note;
+  const label = STATUS_LABELS[resolvedStatus];
+
   return (
-    <div className="pine-status-badge" data-status={status} role="note" aria-label={`Component status: ${label}`}>
+    <div
+      className="pine-status-badge"
+      data-status={resolvedStatus}
+      role="note"
+      aria-label={`Component status: ${label}`}
+    >
       <span className="pine-status-badge__dot" aria-hidden="true" />
       <span className="pine-status-badge__label">{label}</span>
-      {note !== undefined && note !== '' ? <span className="pine-status-badge__note">— {note}</span> : null}
+      {resolvedNote !== undefined && resolvedNote !== '' ? (
+        <span className="pine-status-badge__note">— {resolvedNote}</span>
+      ) : null}
     </div>
   );
 };

--- a/libs/core/src/stories/_helpers/StatusBadge.tsx
+++ b/libs/core/src/stories/_helpers/StatusBadge.tsx
@@ -47,6 +47,10 @@ function isComponentStatus(value: unknown): value is ComponentStatus {
   return typeof value === 'string' && (VALID_STATUSES as readonly string[]).includes(value);
 }
 
+function isComponentEntry(value: unknown): value is ComponentEntry {
+  return value != null && typeof value === 'object';
+}
+
 function warnDev(message: string): void {
   if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
@@ -67,7 +71,7 @@ function resolveStatus(
     return status;
   }
 
-  if (entry !== undefined) {
+  if (isComponentEntry(entry)) {
     if (!isComponentStatus(entry.status)) {
       warnDev(
         `Invalid status "${String(entry.status)}" for "${component ?? 'component'}" in component-status.json.`,
@@ -103,9 +107,21 @@ function buildAriaLabel(label: string, note: string | undefined): string {
  * in sync automatically.
  */
 export const StatusBadge: React.FC<StatusBadgeProps> = ({ component, status, note }) => {
-  const entry = component !== undefined ? COMPONENTS[component] : undefined;
+  const rawEntry = component !== undefined ? COMPONENTS[component] : undefined;
+  let entry: ComponentEntry | undefined;
+
+  if (rawEntry === undefined) {
+    entry = undefined;
+  } else if (isComponentEntry(rawEntry)) {
+    entry = rawEntry;
+  } else {
+    warnDev(`Invalid entry for "${component}" in component-status.json.`);
+    entry = undefined;
+  }
+
   const resolvedStatus = resolveStatus(component, status, entry);
-  const resolvedNote = note ?? entry?.note;
+  const resolvedNote =
+    note ?? (status === undefined && entry !== undefined ? entry.note : undefined);
   const label = STATUS_LABELS[resolvedStatus];
   const ariaLabel = buildAriaLabel(label, resolvedNote);
 

--- a/libs/core/src/stories/_helpers/index.ts
+++ b/libs/core/src/stories/_helpers/index.ts
@@ -32,4 +32,6 @@ export const customArgsWithIconControl = ({property}: Omit<IconControlArgs, 'com
 
 export { ChangelogLoader } from './ChangelogLoader';
 export { ChangelogRenderer } from './ChangelogRenderer';
+export { StatusBadge } from './StatusBadge';
+export type { ComponentStatus, StatusBadgeProps } from './StatusBadge';
 

--- a/libs/core/src/stories/resources/component-status.docs.mdx
+++ b/libs/core/src/stories/resources/component-status.docs.mdx
@@ -1,0 +1,60 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Resources/Component status" parameters={{ previewTabs: { canvas: { hidden: true } } }} />
+
+# Component status
+
+Lifecycle labels describe **API and visual stability** for product teams—not Storybook polish. They are updated when a component’s contract or usage is intentionally changing.
+
+> **Source of truth:** `libs/core/src/stories/resources/component-status.json` drives both this table and the `StatusBadge` rendered on each component MDX page. When you promote or deprecate a component, edit the JSON manifest **and** the table below in the same PR.
+
+## Definitions
+
+| Label | Meaning |
+| --- | --- |
+| **Stable** | Safe for broad production use; breaking changes follow semver and migration notes. |
+| **Beta** | API or visuals may still shift; prefer new work here only when you accept occasional churn. |
+| **Deprecated** | Do not use in new UI; plan migration; removal is scheduled with notice in the changelog. |
+
+## Pine web components
+
+All components below are **Stable** unless noted. Subcomponents (for example `pds-table-row`) follow the parent unless called out separately.
+
+| Component | Status | Notes |
+| --- | --- | --- |
+| `pds-accordion` | Stable | |
+| `pds-alert` | Stable | |
+| `pds-avatar` | Stable | |
+| `pds-box` | Stable | |
+| `pds-button` | Stable | |
+| `pds-checkbox` | Stable | |
+| `pds-chip` | Stable | |
+| `pds-combobox` | Stable | |
+| `pds-container` | Stable | |
+| `pds-copytext` | Stable | |
+| `pds-divider` | Stable | |
+| `pds-dropdown-menu` | Stable | |
+| `pds-filters` / `pds-filter` | Stable | |
+| `pds-icon` | Stable | Icons ship from `@pine-ds/icons`. |
+| `pds-image` | Stable | |
+| `pds-input` | Stable | |
+| `pds-link` | Stable | |
+| `pds-loader` | Stable | |
+| `pds-modal` | Stable | |
+| `pds-multiselect` | Stable | |
+| `pds-popover` | Stable | |
+| `pds-progress` | Stable | |
+| `pds-property` | Stable | |
+| `pds-radio` / `pds-radio-group` | Stable | |
+| `pds-row` | Stable | |
+| `pds-select` | Stable | |
+| `pds-sortable` | Stable | |
+| `pds-switch` | Stable | |
+| `pds-table` | Stable | |
+| `pds-tabs` | Stable | |
+| `pds-text` | Stable | |
+| `pds-textarea` | Stable | |
+| `pds-toast` | Stable | |
+| `pds-tooltip` | Stable | |
+
+When a component moves to **Beta** or **Deprecated**, update this table in the same pull request as the changelog entry and any Storybook migration callouts.

--- a/libs/core/src/stories/resources/component-status.docs.mdx
+++ b/libs/core/src/stories/resources/component-status.docs.mdx
@@ -10,51 +10,213 @@ Lifecycle labels describe **API and visual stability** for product teams—not S
 
 ## Definitions
 
-| Label | Meaning |
-| --- | --- |
-| **Stable** | Safe for broad production use; breaking changes follow semver and migration notes. |
-| **Beta** | API or visuals may still shift; prefer new work here only when you accept occasional churn. |
-| **Deprecated** | Do not use in new UI; plan migration; removal is scheduled with notice in the changelog. |
+<pds-box border border-radius="sm" fit>
+  <pds-table component-id="status-definitions-table" responsive>
+    <pds-table-head>
+      <pds-table-head-cell>Label</pds-table-head-cell>
+      <pds-table-head-cell>Meaning</pds-table-head-cell>
+    </pds-table-head>
+    <pds-table-body>
+      <pds-table-row>
+        <pds-table-cell><strong>Stable</strong></pds-table-cell>
+        <pds-table-cell>Safe for broad production use; breaking changes follow semver and migration notes.</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><strong>Beta</strong></pds-table-cell>
+        <pds-table-cell>API or visuals may still shift; prefer new work here only when you accept occasional churn.</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><strong>Deprecated</strong></pds-table-cell>
+        <pds-table-cell>Do not use in new UI; plan migration; removal is scheduled with notice in the changelog.</pds-table-cell>
+      </pds-table-row>
+    </pds-table-body>
+  </pds-table>
+</pds-box>
 
 ## Pine web components
 
 All components below are **Stable** unless noted. Subcomponents (for example `pds-table-row`) follow the parent unless called out separately.
 
-| Component | Status | Notes |
-| --- | --- | --- |
-| `pds-accordion` | Stable | |
-| `pds-alert` | Stable | |
-| `pds-avatar` | Stable | |
-| `pds-box` | Stable | |
-| `pds-button` | Stable | |
-| `pds-checkbox` | Stable | |
-| `pds-chip` | Stable | |
-| `pds-combobox` | Stable | |
-| `pds-container` | Stable | |
-| `pds-copytext` | Stable | |
-| `pds-divider` | Stable | |
-| `pds-dropdown-menu` | Stable | |
-| `pds-filters` / `pds-filter` | Stable | |
-| `pds-icon` | Stable | Icons ship from `@pine-ds/icons`. |
-| `pds-image` | Stable | |
-| `pds-input` | Stable | |
-| `pds-link` | Stable | |
-| `pds-loader` | Stable | |
-| `pds-modal` | Stable | |
-| `pds-multiselect` | Stable | |
-| `pds-popover` | Stable | |
-| `pds-progress` | Stable | |
-| `pds-property` | Stable | |
-| `pds-radio` / `pds-radio-group` | Stable | |
-| `pds-row` | Stable | |
-| `pds-select` | Stable | |
-| `pds-sortable` | Stable | |
-| `pds-switch` | Stable | |
-| `pds-table` | Stable | |
-| `pds-tabs` | Stable | |
-| `pds-text` | Stable | |
-| `pds-textarea` | Stable | |
-| `pds-toast` | Stable | |
-| `pds-tooltip` | Stable | |
+<pds-box border border-radius="sm" fit>
+  <pds-table component-id="component-status-table" responsive>
+    <pds-table-head>
+      <pds-table-head-cell>Component</pds-table-head-cell>
+      <pds-table-head-cell>Status</pds-table-head-cell>
+      <pds-table-head-cell>Notes</pds-table-head-cell>
+    </pds-table-head>
+    <pds-table-body>
+      <pds-table-row>
+        <pds-table-cell><code>pds-accordion</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-alert</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-avatar</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-box</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-button</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-checkbox</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-chip</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-combobox</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-container</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-copytext</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-divider</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-dropdown-menu</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-filters</code> / <code>pds-filter</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-icon</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell>Icons ship from <code>@pine-ds/icons</code>.</pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-image</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-input</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-link</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-loader</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-modal</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-multiselect</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-popover</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-progress</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-property</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-radio</code> / <code>pds-radio-group</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-row</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-select</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-sortable</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-switch</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-table</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-tabs</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-text</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-textarea</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-toast</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+      <pds-table-row>
+        <pds-table-cell><code>pds-tooltip</code></pds-table-cell>
+        <pds-table-cell>Stable</pds-table-cell>
+        <pds-table-cell></pds-table-cell>
+      </pds-table-row>
+    </pds-table-body>
+  </pds-table>
+</pds-box>
 
 When a component moves to **Beta** or **Deprecated**, update this table in the same pull request as the changelog entry and any Storybook migration callouts.

--- a/libs/core/src/stories/resources/component-status.json
+++ b/libs/core/src/stories/resources/component-status.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "./component-status.schema.json",
+  "description": "Lifecycle status for every Pine component. Source of truth for StatusBadge and the central Component status table. Update both when a component is promoted to Beta or Deprecated.",
+  "statuses": {
+    "stable": {
+      "label": "Stable",
+      "summary": "Safe for broad production use; breaking changes follow semver and migration notes."
+    },
+    "beta": {
+      "label": "Beta",
+      "summary": "API or visuals may still shift; prefer new work here only when you accept occasional churn."
+    },
+    "deprecated": {
+      "label": "Deprecated",
+      "summary": "Do not use in new UI; plan migration; removal is scheduled with notice in the changelog."
+    }
+  },
+  "components": {
+    "pds-accordion": { "status": "stable" },
+    "pds-alert": { "status": "stable" },
+    "pds-avatar": { "status": "stable" },
+    "pds-box": { "status": "stable" },
+    "pds-button": { "status": "stable" },
+    "pds-checkbox": { "status": "stable" },
+    "pds-chip": { "status": "stable" },
+    "pds-combobox": { "status": "stable" },
+    "pds-container": { "status": "stable" },
+    "pds-copytext": { "status": "stable" },
+    "pds-divider": { "status": "stable" },
+    "pds-dropdown-menu": { "status": "stable" },
+    "pds-filters": { "status": "stable" },
+    "pds-filter": { "status": "stable", "note": "Subcomponent of pds-filters." },
+    "pds-icon": { "status": "stable", "note": "Icons ship from `@pine-ds/icons`." },
+    "pds-image": { "status": "stable" },
+    "pds-input": { "status": "stable" },
+    "pds-link": { "status": "stable" },
+    "pds-loader": { "status": "stable" },
+    "pds-modal": { "status": "stable" },
+    "pds-multiselect": { "status": "stable" },
+    "pds-popover": { "status": "stable" },
+    "pds-progress": { "status": "stable" },
+    "pds-property": { "status": "stable" },
+    "pds-radio": { "status": "stable" },
+    "pds-radio-group": { "status": "stable" },
+    "pds-row": { "status": "stable" },
+    "pds-select": { "status": "stable" },
+    "pds-sortable": { "status": "stable" },
+    "pds-switch": { "status": "stable" },
+    "pds-table": { "status": "stable" },
+    "pds-tabs": { "status": "stable" },
+    "pds-text": { "status": "stable" },
+    "pds-textarea": { "status": "stable" },
+    "pds-toast": { "status": "stable" },
+    "pds-tooltip": { "status": "stable" }
+  }
+}


### PR DESCRIPTION
# Description

Renders a Stable / Beta / Deprecated badge at the top of each component MDX page so consumers see lifecycle state without navigating to the central Resources/Component status table.

**What's new**

- `libs/core/src/stories/_helpers/StatusBadge.tsx` (+ companion CSS) — typed React helper rendered as `<StatusBadge status="stable" />`. Uses Pine semantic tokens (`--pine-color-text-success` / `-warning` / `-danger`) for color so the badge respects current and future theming.
- Applied to **pds-button**, **pds-modal**, **pds-table** as a proof-of-pattern. All three are listed as Stable in the central table.

**What's not in this PR**

- Remaining ~32 components (intentional — keeping the first pass tight; a follow-up PR can bulk-apply).
- Reading status from a structured data file. Today the badge value is hard-coded per page, and the central table remains the source of truth. A future enhancement could extract a JSON manifest both surfaces read from.

**Dependency note**

This PR is **based on `docs/foundations`** ([#736](https://github.com/Kajabi/pine/pull/736)) because the badge mirrors the lifecycle labels introduced there. Merge that first; rebase on `main` once it lands.

Closes a Level-3 "Component status page" surfacing gap on the maturity scorecard.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Confirmed the helper lint-passes (ESLint + pine-colors Stylelint plugin).
- Verified import path from each component MDX resolves under the existing `_helpers` re-export pattern.
- Storybook builds and renders the badge above the component name on each affected page.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests (badge has `role="note"` + descriptive `aria-label`)
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.25.1 (current main)
- OS: macOS 25.3.0
- Browsers: Storybook preview
- Screen readers: n/a
- Misc: docs-only addition

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Storybook-only helpers; no runtime component API or app behavior changes.
> 
> **Overview**
> Introduces a **shared lifecycle status system** for Storybook: a `component-status.json` manifest, a **Resources/Component status** MDX page, and a reusable **`StatusBadge`** helper that reads status (and optional notes) from the manifest when you pass `component="pds-…"`.
> 
> **`StatusBadge`** (React + CSS) renders Stable / Beta / Deprecated (and Unknown on bad/missing data) using Pine semantic color tokens, `role="note"`, and an `aria-label` that can include manifest notes. It is re-exported from `stories/_helpers` and wired at the top of **`pds-button`**, **`pds-modal`**, and **`pds-table`** docs as the initial rollout pattern.
> 
> The central status doc duplicates the component list in a manual table; the JSON is documented as the source of truth for badges, with an expectation to keep the table in sync when statuses change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7daf9a8d8408925754215e91b451b250165952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->