### PR TITLE
feat(storybook): add LTR/RTL preview toggle and audit pointer

### DIFF
--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -138,10 +138,35 @@ const withTheme = (StoryFn, context) => {
   return StoryFn();
 };
 
+// Direction decorator that applies `dir` attribute for RTL/LTR previews.
+// Pair this with the audit checklist at
+// Guides/RTL and localization when verifying component behavior.
+const withDirection = (StoryFn, context) => {
+  const direction = context.globals.direction || 'ltr';
+
+  document.documentElement.setAttribute('dir', direction);
+  document.body.setAttribute('dir', direction);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('dir', direction);
+    document.body.setAttribute('dir', direction);
+
+    try {
+      window.parent.document.documentElement.setAttribute('dir', direction);
+      window.parent.document.body.setAttribute('dir', direction);
+    } catch (e) {
+      // Cross-origin access may fail, that's ok
+    }
+  }, [direction]);
+
+  return StoryFn();
+};
+
 const preview = {
   decorators: [
     withCustomEventActions,
     withTheme,
+    withDirection,
   ],
 
   globalTypes: {
@@ -157,10 +182,23 @@ const preview = {
         dynamicTitle: true,
       },
     },
+    direction: {
+      description: 'Document direction (LTR or RTL)',
+      toolbar: {
+        title: 'Direction',
+        icon: 'transfer',
+        items: [
+          { value: 'ltr', title: 'LTR', right: 'Left-to-right' },
+          { value: 'rtl', title: 'RTL', right: 'Right-to-left' },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
 
   initialGlobals: {
     theme: 'light',
+    direction: 'ltr',
   },
 
   parameters: {

--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -141,7 +141,7 @@ const withTheme = (StoryFn, context) => {
 // Direction decorator that applies `dir` on the preview iframe only.
 // Unlike data-theme, `dir` is interpreted by the browser and must not be set on
 // window.parent (that would flip Storybook manager/docs chrome).
-// Pair with the audit checklist at Guides/RTL and localization.
+// See Guides/RTL and localization for usage.
 const withDirection = (StoryFn, context) => {
   const direction = context.globals.direction || 'ltr';
 

--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -180,7 +180,7 @@ const preview = {
       description: 'Document direction (LTR or RTL)',
       toolbar: {
         title: 'Direction',
-        icon: 'direction',
+        icon: 'transfer',
         items: [
           { value: 'ltr', title: 'LTR', right: 'Left-to-right' },
           { value: 'rtl', title: 'RTL', right: 'Right-to-left' },

--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -186,7 +186,7 @@ const preview = {
       description: 'Document direction (LTR or RTL)',
       toolbar: {
         title: 'Direction',
-        icon: 'transfer',
+        icon: 'direction',
         items: [
           { value: 'ltr', title: 'LTR', right: 'Left-to-right' },
           { value: 'rtl', title: 'RTL', right: 'Right-to-left' },

--- a/libs/core/.storybook/preview.js
+++ b/libs/core/.storybook/preview.js
@@ -138,9 +138,10 @@ const withTheme = (StoryFn, context) => {
   return StoryFn();
 };
 
-// Direction decorator that applies `dir` attribute for RTL/LTR previews.
-// Pair this with the audit checklist at
-// Guides/RTL and localization when verifying component behavior.
+// Direction decorator that applies `dir` on the preview iframe only.
+// Unlike data-theme, `dir` is interpreted by the browser and must not be set on
+// window.parent (that would flip Storybook manager/docs chrome).
+// Pair with the audit checklist at Guides/RTL and localization.
 const withDirection = (StoryFn, context) => {
   const direction = context.globals.direction || 'ltr';
 
@@ -150,13 +151,6 @@ const withDirection = (StoryFn, context) => {
   useEffect(() => {
     document.documentElement.setAttribute('dir', direction);
     document.body.setAttribute('dir', direction);
-
-    try {
-      window.parent.document.documentElement.setAttribute('dir', direction);
-      window.parent.document.body.setAttribute('dir', direction);
-    } catch (e) {
-      // Cross-origin access may fail, that's ok
-    }
   }, [direction]);
 
   return StoryFn();

--- a/libs/core/src/stories/guides/rtl-and-localization.docs.mdx
+++ b/libs/core/src/stories/guides/rtl-and-localization.docs.mdx
@@ -12,6 +12,10 @@ Pine targets **English-first** Kajabi product surfaces today. Components are bui
 2. **Prefer tokens and logical properties** in consuming apps for spacing and alignment that should mirror under RTL. Report gaps in Slack (`#ds-support`).
 3. **Strings live in the product**, not inside Pine primitives—pass translated `label`, `aria-label`, and slot content from your app’s i18n layer.
 
-## Storybook tooling
+## Verifying in Storybook
 
-**Pending:** The **Direction** toolbar (LTR / RTL) for spot-checking components in Storybook ships in [#739](https://github.com/Kajabi/pine/pull/739). Audit steps and usage notes will live in this guide once that PR merges.
+Storybook includes a **Direction** toolbar control (LTR / RTL). Switching it applies `dir` on the preview iframe’s `<html>` and `<body>`, matching the consumer-app contract for RTL surfaces.
+
+Use the toggle to spot-check components: mirroring, overlay placement, iconography, truncation, keyboard, and screen reader behavior where applicable.
+
+When you change component layout or positioning, add or update Stencil tests and a short RTL Storybook example where it helps catch regressions in CI.


### PR DESCRIPTION
# Description

Adds a **Direction** toolbar (LTR / RTL) to Storybook so contributors can spot-check components against the audit checklist introduced in [docs/foundations](https://github.com/Kajabi/pine/pull/736).

**What's new**

- `libs/core/.storybook/preview.js` — new `withDirection` decorator + `direction` globalType (toolbar icon, dynamic title, default `ltr`). Applies `dir` to `<html>` and `<body>` in both the story iframe and the docs frame, mirroring the consumer-app contract.
- `libs/core/src/stories/guides/rtl-and-localization.docs.mdx` — new **How to audit** section that points teams at the toolbar and clarifies the verification expectations (visual + keyboard + screen reader where applicable).

**What this PR does not do**

The audit checklist stays intentionally unchecked. Rows should be marked off in the PR that proves behavior for each component, so the doc remains a record of what's actually been verified.

**Dependency note**

Based on **`docs/foundations`** ([#736](https://github.com/Kajabi/pine/pull/736)) because the guide it extends is introduced there. Merge that first, then rebase this on `main`.

Closes a Level-4 "Localization" surfacing gap on the maturity scorecard.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Confirmed Storybook config syntax matches the existing `withTheme` pattern.
- Verified the new toolbar surfaces alongside the Theme toggle.
- Reviewed the `dir` propagation pattern against the existing theme-decorator double-set (documentElement + body + parent docs frame).

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.25.1 (current main)
- OS: macOS 25.3.0
- Browsers: Storybook preview
- Screen readers: n/a (decorator only)
- Misc: Storybook 10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

## Follow-ups

- Audit and check off the 30 components in `rtl-and-localization.docs.mdx`.
- Once Chromatic is wired (PR #737), consider an `rtl` Storybook tag or per-story override so visual regression baselines include RTL renders.

cc @Kajabi/dss-devs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Storybook preview and documentation only; no runtime component or auth/data changes.
> 
> **Overview**
> Adds a **Direction** Storybook toolbar (LTR / RTL) so contributors can preview components under `dir="rtl"` without touching product apps.
> 
> A new `withDirection` decorator sets `dir` on the preview iframe’s `<html>` and `<body>` (default `ltr`), following the same reactive pattern as `withTheme` but **without** updating `window.parent`, so Storybook’s own UI stays LTR.
> 
> The **RTL and localization** guide replaces the “pending PR #739” note with **Verifying in Storybook**: how to use the toggle, what to spot-check (mirroring, overlays, a11y), and when to add Stencil/Storybook RTL coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3e48b3bc11b5dd9c878e93b1edd38d7b93c443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->