### PR TITLE
fix(pds-alert): center-align icon and content in small variant

### DIFF
--- a/libs/core/src/components/pds-alert/pds-alert.scss
+++ b/libs/core/src/components/pds-alert/pds-alert.scss
@@ -83,7 +83,7 @@
 }
 
 .pds-alert__icon--small {
-  margin-block-start: calc(var(--pine-dimension-2xs) / 2); // half the default icon margin
+  margin-block-start: 0;
 }
 
 .pds-alert__content-wrapper {

--- a/libs/core/src/components/pds-alert/pds-alert.tsx
+++ b/libs/core/src/components/pds-alert/pds-alert.tsx
@@ -122,7 +122,7 @@ export class PdsAlert {
           border
           display="block"
         >
-          <pds-box gap="sm" display="flex">
+          <pds-box gap="sm" display="flex" align-items={this.small ? "center" : undefined}>
             {!this.hideIcon && (
               <pds-icon
                 class={`pds-alert__icon ${this.small ? 'pds-alert__icon--small' : ''}`}

--- a/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
+++ b/libs/core/src/components/pds-alert/test/pds-alert.spec.tsx
@@ -88,7 +88,7 @@ describe('pds-alert', () => {
       <pds-alert class="pds-alert" heading="This heading should not show" small="true" variant="default">
         <mock:shadow-root>
           <pds-box class="pds-alert__container pds-alert__container--default" background-color="var(--pds-alert-background)" border="" border-color="var(--pds-alert-border-color)" border-radius="md" display="block">
-            <pds-box display="flex" gap="sm">
+            <pds-box align-items="center" display="flex" gap="sm">
               <pds-icon class="pds-alert__icon pds-alert__icon--small" color="var(--pds-alert-color-icon)" icon="info-circle-filled" size="var(--pds-alert-icon-size)"></pds-icon>
               <pds-box class="pds-alert__content-wrapper" direction="column" flex="grow" gap="xs">
                 <pds-box align-items="center" display="flex" gap="md">


### PR DESCRIPTION
# Description

In the small variant of `pds-alert`, the icon and inline content/actions sit on a single flex row but were top-aligned, which read as misaligned when the content was a single line of text. This applies `align-items="center"` to the outer flex `<pds-box>` when `small` is true and removes the compensating `margin-block-start` on `.pds-alert__icon--small` that was nudging the icon down to fake center alignment.

Default (non-small) variant rendering is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] tested manually

Updated the small-variant spec snapshot to include the new `align-items="center"` on the outer wrapper. Full `@pine-ds/core` test suite (2851 tests) passes locally.

**Test Configuration**:

- Pine versions: main
- OS: macOS
- Browsers: Chrome (Storybook)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling/layout tweak limited to the `small` variant of `pds-alert`, with a snapshot test update to lock in the new DOM attributes.
> 
> **Overview**
> Fixes visual misalignment in `pds-alert` *small* variant by vertically centering the icon and inline content/actions.
> 
> This applies `align-items="center"` to the outer flex wrapper only when `small` is true, and removes the previous `.pds-alert__icon--small` top-margin offset used to fake centering. The small-variant spec snapshot is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98adb75e224df89273e6916836fce9f149ad9973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->