### PR TITLE
fix(pds-button): block clicks when disabled attribute is reflected

### DIFF
--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -39,7 +39,6 @@
   pointer-events: none;
 }
 
-:host([disabled]),
 :host([aria-disabled="true"]) {
   pointer-events: none;
 }

--- a/libs/core/src/components/pds-button/pds-button.scss
+++ b/libs/core/src/components/pds-button/pds-button.scss
@@ -39,7 +39,8 @@
   pointer-events: none;
 }
 
-:host([disabled="true"]) {
+:host([disabled]),
+:host([aria-disabled="true"]) {
   pointer-events: none;
 }
 

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -78,6 +78,19 @@ describe('pds-button', () => {
     expect(value).toBe(true);
   });
 
+  it('does not emit pdsClick when disabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-button disabled>Disabled</pds-button>');
+
+    const component = await page.find('pds-button');
+    const clickEvent = await component.spyOnEvent('pdsClick');
+
+    await component.click();
+    await page.waitForChanges();
+
+    expect(clickEvent).toHaveReceivedEventTimes(0);
+  });
+
   it('renders caret-down icon when variant is disclosure', async () => {
     const page = await newE2EPage();
 

--- a/libs/core/src/components/pds-button/test/pds-button.e2e.ts
+++ b/libs/core/src/components/pds-button/test/pds-button.e2e.ts
@@ -91,6 +91,24 @@ describe('pds-button', () => {
     expect(clickEvent).toHaveReceivedEventTimes(0);
   });
 
+  it('does not emit pdsClick when disabled link button', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<pds-button href="https://example.com" disabled>Disabled link</pds-button>',
+    );
+
+    const component = await page.find('pds-button');
+    const anchor = await page.find('pds-button >>> a');
+    const clickEvent = await component.spyOnEvent('pdsClick');
+
+    expect(await anchor.getAttribute('href')).toBeNull();
+
+    await component.click();
+    await page.waitForChanges();
+
+    expect(clickEvent).toHaveReceivedEventTimes(0);
+  });
+
   it('renders caret-down icon when variant is disclosure', async () => {
     const page = await newE2EPage();
 

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -378,6 +378,22 @@ describe('pds-button', () => {
     expect(clickSpy).not.toHaveBeenCalled();
   });
 
+  it('prevents click when disabled', async () => {
+    const page = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button disabled></pds-button>`,
+    });
+
+    const button = page.root;
+    const clickSpy = jest.fn();
+    button?.addEventListener('pdsClick', clickSpy);
+
+    button?.click();
+    await page.waitForChanges();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
   it('renders full width button', async () => {
     const {root} = await newSpecPage({
       components: [PdsButton],

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -394,6 +394,23 @@ describe('pds-button', () => {
     expect(clickSpy).not.toHaveBeenCalled();
   });
 
+  it('allows click when disabled="false"', async () => {
+    const page = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button disabled="false"></pds-button>`,
+    });
+
+    expect(page.root?.getAttribute('aria-disabled')).toBe(null);
+
+    const clickSpy = jest.fn();
+    page.root?.addEventListener('pdsClick', clickSpy);
+
+    page.root?.click();
+    await page.waitForChanges();
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
   it('renders full width button', async () => {
     const {root} = await newSpecPage({
       components: [PdsButton],

--- a/libs/core/src/components/pds-button/test/pds-button.spec.tsx
+++ b/libs/core/src/components/pds-button/test/pds-button.spec.tsx
@@ -411,6 +411,24 @@ describe('pds-button', () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
+  it('prevents click when disabled link button', async () => {
+    const page = await newSpecPage({
+      components: [PdsButton],
+      html: `<pds-button href="https://example.com" disabled></pds-button>`,
+    });
+
+    const anchor = page.root?.shadowRoot?.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBeNull();
+
+    const clickSpy = jest.fn();
+    page.root?.addEventListener('pdsClick', clickSpy);
+
+    page.root?.click();
+    await page.waitForChanges();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
   it('renders full width button', async () => {
     const {root} = await newSpecPage({
       components: [PdsButton],

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -4,7 +4,7 @@
   display: block;
 }
 
-:host([disabled="true"]) {
+:host([aria-disabled="true"]) {
   .pds-combobox__input-icon {
     color: var(--pine-color-text-disabled);
     pointer-events: none;

--- a/libs/core/src/components/pds-combobox/pds-combobox.tsx
+++ b/libs/core/src/components/pds-combobox/pds-combobox.tsx
@@ -1870,7 +1870,7 @@ export class PdsCombobox implements BasePdsProps {
       .filter(Boolean)
       .join(' ');
     return (
-      <Host>
+      <Host aria-disabled={this.disabled ? 'true' : null}>
         <div class="pds-combobox" tabIndex={-1} onFocusout={this.onComboboxFocusOut} part="combobox">
           {this.label && !this.hideLabel && (
             <label htmlFor={this.componentId} class="pds-combobox__label">

--- a/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
+++ b/libs/core/src/components/pds-combobox/test/pds-combobox.spec.tsx
@@ -162,6 +162,7 @@ describe('pds-combobox', () => {
     const input = root?.shadowRoot?.querySelector('input');
     expect(input?.disabled).toBe(true);
     expect(input?.getAttribute('aria-disabled')).toBe('true');
+    expect(root?.getAttribute('aria-disabled')).toBe('true');
   });
 
   it('renders with button trigger', async () => {

--- a/libs/core/src/components/pds-input/pds-input.scss
+++ b/libs/core/src/components/pds-input/pds-input.scss
@@ -134,7 +134,7 @@
   }
 }
 
-:host([disabled="true"]) {
+:host([aria-disabled="true"]) {
   &::part(prepend),
   &::part(append) {
     background-color: var(--pds-input-disabled-background);


### PR DESCRIPTION
## Summary

- Updates `:host` disabled styles to match Stencil's reflected boolean attribute (`disabled`) and `aria-disabled="true"`, not only `disabled="true"`.
- Restores `pointer-events: none` on the host so disabled buttons (including link-style `href` buttons) cannot receive clicks.
- Adds spec and e2e coverage for disabled click prevention with the reflected `disabled` attribute.

## Test plan

- [x] unit tests (`pds-button.spec.tsx`)
- [x] e2e tests (`pds-button.e2e.ts`)
- [ ] accessibility tests
- [ ] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: local branch
- OS: macOS
- Browsers:
- Screen readers:
- Misc:

Fixes disabled `pds-button` remaining clickable when the DOM shows `<pds-button disabled>` instead of `disabled="true"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped design-system styling and interaction fixes for disabled state, with added tests and no auth or data-path changes.
> 
> **Overview**
> Fixes disabled Pine components staying interactive when the DOM uses a **reflected boolean** `disabled` (e.g. `<pds-button disabled>`) instead of `disabled="true"`.
> 
> **Host disabled styling** now keys off `:host([aria-disabled="true"])` instead of `:host([disabled="true"])` on `pds-button`, `pds-combobox`, and `pds-input`, restoring **`pointer-events: none`** on the host so disabled controls (including link-style `href` buttons) do not receive clicks. **`pds-combobox`** also sets `aria-disabled` on its `Host` when `disabled` is true, with a spec assertion on the host attribute.
> 
> **Tests** add unit and e2e coverage that disabled `pds-button` does not emit `pdsClick` (plain button, `disabled="false"` still clickable, and disabled link with `href` removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660d54b604c3c3f97e5c82457b7bba36428cb586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->