### PR TITLE
docs(storybook): add StatusBadge to all component docs pages

### DIFF
--- a/libs/core/src/components/pds-accordion/docs/pds-accordion.mdx
+++ b/libs/core/src/components/pds-accordion/docs/pds-accordion.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-accordion.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-accordion" />
 
 # Accordion
 

--- a/libs/core/src/components/pds-alert/docs/pds-alert.mdx
+++ b/libs/core/src/components/pds-alert/docs/pds-alert.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-alert.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-alert" />
 
 # Alert
 

--- a/libs/core/src/components/pds-avatar/docs/pds-avatar.mdx
+++ b/libs/core/src/components/pds-avatar/docs/pds-avatar.mdx
@@ -5,8 +5,11 @@ import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
 
 import sampleImg from '../assets/demi_wilkinson.jpg';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-avatar" />
 
 # Avatar
 

--- a/libs/core/src/components/pds-box/docs/pds-box.mdx
+++ b/libs/core/src/components/pds-box/docs/pds-box.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-box.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-box" />
 
 # Box
 

--- a/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
+++ b/libs/core/src/components/pds-checkbox/docs/pds-checkbox.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-checkbox.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-checkbox" />
 
 # Checkbox
 

--- a/libs/core/src/components/pds-chip/docs/pds-chip.mdx
+++ b/libs/core/src/components/pds-chip/docs/pds-chip.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-chip.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-chip" />
 
 # Chip
 

--- a/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
+++ b/libs/core/src/components/pds-combobox/docs/pds-combobox.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-combobox.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-combobox" />
 
 # Combobox
 

--- a/libs/core/src/components/pds-container/docs/pds-container.mdx
+++ b/libs/core/src/components/pds-container/docs/pds-container.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-container.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-container" />
 
 # Container
 

--- a/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
+++ b/libs/core/src/components/pds-copytext/docs/pds-copytext.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-copytext.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-copytext" />
 
 # Copy Text
 

--- a/libs/core/src/components/pds-divider/docs/pds-divider.mdx
+++ b/libs/core/src/components/pds-divider/docs/pds-divider.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-divider.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-divider" />
 
 # Divider
 

--- a/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
+++ b/libs/core/src/components/pds-dropdown-menu/docs/pds-dropdown-menu.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-dropdown-menu.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-dropdown-menu" />
 
 # Dropdown Menu
 

--- a/libs/core/src/components/pds-filters/docs/pds-filters.mdx
+++ b/libs/core/src/components/pds-filters/docs/pds-filters.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-filters.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-filters" />
 
 # Filters
 

--- a/libs/core/src/components/pds-icon/docs/pds-icon.mdx
+++ b/libs/core/src/components/pds-icon/docs/pds-icon.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-icon.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components as pdsDocsJson } from '@pine-ds/icons/dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-icon" />
 
 # Icon
 Icons render scalable glyphs from Pine's icon set, representing actions, statuses, or features in the interface.

--- a/libs/core/src/components/pds-image/docs/pds-image.mdx
+++ b/libs/core/src/components/pds-image/docs/pds-image.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-image.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-image" />
 
 # Image
 

--- a/libs/core/src/components/pds-input/docs/pds-input.mdx
+++ b/libs/core/src/components/pds-input/docs/pds-input.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-input.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-input" />
 
 # Input
 

--- a/libs/core/src/components/pds-link/docs/pds-link.mdx
+++ b/libs/core/src/components/pds-link/docs/pds-link.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-link.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-link" />
 
 # Link
 

--- a/libs/core/src/components/pds-loader/docs/pds-loader.mdx
+++ b/libs/core/src/components/pds-loader/docs/pds-loader.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-loader.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-loader" />
 
 # Loader
 

--- a/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
+++ b/libs/core/src/components/pds-multiselect/docs/pds-multiselect.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-multiselect.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-multiselect" />
 
 # Multiselect
 

--- a/libs/core/src/components/pds-popover/docs/pds-popover.mdx
+++ b/libs/core/src/components/pds-popover/docs/pds-popover.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-popover.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-popover" />
 
 # Popover
 Popovers display contextual information when users click or initiates a keyboard event on an element. They typically contain more information than tooltips and can include interactive elements.

--- a/libs/core/src/components/pds-progress/docs/pds-progress.mdx
+++ b/libs/core/src/components/pds-progress/docs/pds-progress.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-progress.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-progress" />
 
 # Progress
 

--- a/libs/core/src/components/pds-property/docs/pds-property.mdx
+++ b/libs/core/src/components/pds-property/docs/pds-property.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-property.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-property" />
 
 # Property
 

--- a/libs/core/src/components/pds-radio-group/docs/pds-radio-group.mdx
+++ b/libs/core/src/components/pds-radio-group/docs/pds-radio-group.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-radio-group.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-radio-group" />
 
 # Radio Group
 

--- a/libs/core/src/components/pds-radio/docs/pds-radio.mdx
+++ b/libs/core/src/components/pds-radio/docs/pds-radio.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-radio.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-radio" />
 
 # Radio
 

--- a/libs/core/src/components/pds-row/docs/pds-row.mdx
+++ b/libs/core/src/components/pds-row/docs/pds-row.mdx
@@ -3,9 +3,11 @@ import * as stories from '../stories/pds-row.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
-
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-row" />
 
 # Row
 

--- a/libs/core/src/components/pds-select/docs/pds-select.mdx
+++ b/libs/core/src/components/pds-select/docs/pds-select.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-select.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-select" />
 
 # Select
 

--- a/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
+++ b/libs/core/src/components/pds-sortable/docs/pds-sortable.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-sortable.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components'
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-sortable" />
 
 # Sortable
 

--- a/libs/core/src/components/pds-switch/docs/pds-switch.mdx
+++ b/libs/core/src/components/pds-switch/docs/pds-switch.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-switch.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-switch" />
 
 # Switch
 

--- a/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
+++ b/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-tabs.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-tabs" />
 
 # Tabs
 

--- a/libs/core/src/components/pds-text/docs/pds-text.mdx
+++ b/libs/core/src/components/pds-text/docs/pds-text.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-text.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-text" />
 
 # Text
 

--- a/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
+++ b/libs/core/src/components/pds-textarea/docs/pds-textarea.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-textarea.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-textarea" />
 
 # Textarea
 

--- a/libs/core/src/components/pds-toast/docs/pds-toast.mdx
+++ b/libs/core/src/components/pds-toast/docs/pds-toast.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-toast.stories.js';
 
 import {DocArgsTable, DocCanvas} from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-toast" />
 
 # Toast
 

--- a/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
+++ b/libs/core/src/components/pds-tooltip/docs/pds-tooltip.mdx
@@ -3,8 +3,11 @@ import * as stories from '../stories/pds-tooltip.stories.js';
 
 import { DocArgsTable, DocCanvas } from '@pine-ds/doc-components';
 import { components } from '../../../../dist/docs.json';
+import { StatusBadge } from '../../../stories/_helpers';
 
 <Meta of={stories} />
+
+<StatusBadge component="pds-tooltip" />
 
 # Tooltip
 


### PR DESCRIPTION
## Summary

Follow-up to #738 that rolls out lifecycle status badges to the remaining 32 component MDX pages. Every component docs page now renders `<StatusBadge component="pds-*" />`, reading Stable from `component-status.json`.

- Adds `StatusBadge` import and badge markup to all component docs not covered in the initial proof-of-pattern PR (button, modal, table were already done)
- No runtime component API changes — docs-only rollout

**Stack:** targets `docs/add-status-badges` (#738). Merge #738 first, then this.

Fixes #(no-issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: current `docs/add-status-badges` branch
- OS: macOS
- Browsers: n/a (docs-only)
- Screen readers: n/a
- Misc: `npx nx run @pine-ds/core:lint` passes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX edits; no runtime, API, or security impact.
> 
> **Overview**
> Rolls out **lifecycle status badges** to the remaining Pine component Storybook MDX pages (32 components not covered in the initial pattern PR).
> 
> Each page now imports `StatusBadge` from `stories/_helpers` and renders `<StatusBadge component="pds-*" />` immediately after `<Meta />`, so docs show **Stable / Beta / Deprecated** from `component-status.json` without opening the central status table. **Docs-only** — no component runtime or API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5265cddefcb083df3182640c5436c14398cd24f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->