### PR TITLE
fix(pds-input): remove label wrapper margin when label is hidden

### DIFF
--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -539,9 +539,14 @@ export class PdsInput {
       >
         <div class="pds-input">
           {label && (
-            <div class="pds-input__label-wrapper">
+            <div
+              class={{
+                'pds-input__label-wrapper': true,
+                'visually-hidden': this.hideLabel,
+              }}
+            >
               <label htmlFor={componentId} class="pds-input__label">
-                <span class={this.hideLabel ? 'visually-hidden' : ''}>
+                <span>
                   {label}
                   {this.required && <span class="pds-input__required-indicator"> *</span>}
                 </span>

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -934,7 +934,7 @@ describe('pds-input', () => {
       const labelSpan = root?.shadowRoot?.querySelector('.pds-input__label span');
 
       expect(labelWrapper).not.toBeNull();
-      expect(labelSpan?.classList.contains('visually-hidden')).toBe(true);
+      expect(labelWrapper?.classList.contains('visually-hidden')).toBe(true);
       expect(labelSpan?.textContent?.trim()).toBe('Name');
     });
 
@@ -976,7 +976,7 @@ describe('pds-input', () => {
       const labelSpan = root?.shadowRoot?.querySelector('.pds-input__label span');
 
       expect(labelWrapper).not.toBeNull();
-      expect(labelSpan?.classList.contains('visually-hidden')).toBe(false);
+      expect(labelWrapper?.classList.contains('visually-hidden')).toBe(false);
       expect(labelSpan?.textContent?.trim()).toBe('Name');
     });
 


### PR DESCRIPTION
# Description

When `pds-input` is given both a `label` and `hideLabel`, the label text is visually hidden but the label wrapper still applied `margin-block-end: var(--pine-dimension-2xs)` (4px), leaving a visible gap above the input.

**Root cause:** `visually-hidden` was applied to the inner `<span>` (the text), but the margin lives on the `.pds-input__label-wrapper` div. Hiding the span collapsed its height, but the wrapper's margin survived.

**Fix:** Apply `visually-hidden` to the wrapper itself — the element that owns the margin. Since `visually-hidden` sets `position: absolute`, the wrapper and its margin leave the layout flow entirely (no SCSS change needed). The label text stays in the DOM and remains screen-reader accessible. This mirrors how `pds-multiselect` already hides its margin-bearing label.

I also checked the rest of the input family — `pds-input` was the only affected component:
- `pds-select` / `pds-combobox` already omit the wrapper and fall back to `aria-label`
- `pds-multiselect` already applies `visually-hidden` to its margin-bearing label
- `pds-textarea` has no wrapper margin (and no flex `gap`) to leak
- `pds-radio` / `pds-checkbox` / `pds-switch` render the label inline beside the control

Addresses Linear **DSS-203**.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Updated the existing `hideLabel` spec assertions to check the wrapper (the test was already named for the wrapper but asserted the span). Verified visually in Storybook with `<pds-input label="Name" hide-label>` — the field now sits flush, and toggling `hide-label` off restores normal label spacing.

- [x] unit tests
- [ ] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: `@pine-ds/core` (this branch)
- OS: macOS
- Browsers: Chrome
- Screen readers:
- Misc: `@pine-ds/core:test` 2865/2865 pass; `@pine-ds/core:lint` 0 errors

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DOM/class change in one component with updated unit tests; no API or security impact.
> 
> **Overview**
> Fixes a layout gap when **`pds-input`** uses **`hideLabel`** with a **`label`**: **`visually-hidden`** now applies to **`.pds-input__label-wrapper`** (the element with **`margin-block-end`**) instead of the inner label **`<span>`**, so the wrapper is taken out of flow and the field sits flush while the label stays in the DOM for assistive tech.
> 
> Unit tests in the **`hideLabel`** describe block now assert **`visually-hidden`** on the wrapper, matching the intended DOM behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b14d2db7b052a3bd67c9e9663a2d3507a6b567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->