### PR TITLE
chore: add figma code connect coverage guard to lint pipeline

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -61,6 +61,7 @@
     "generate": "stencil generate",
     "lint": "run-p lint.*",
     "lint.eslint": "eslint src",
+    "lint.figma": "node scripts/check-figma-coverage.mjs",
     "lint.status": "node scripts/check-component-status.mjs",
     "lint.styles": "stylelint \"./src/**/*.*css\"",
     "prettier": "prettier \"./src/**/*.{html,ts,tsx,js,jsx}\"",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -127,7 +127,15 @@
     "webpack": "^5.74.0"
   },
   "nx": {
+    "implicitDependencies": ["@pine-ds/figma"],
     "targets": {
+      "lint": {
+        "inputs": [
+          "default",
+          "{workspaceRoot}/libs/figma/code-connect-waivers.json",
+          "{workspaceRoot}/libs/figma/components/**/*.figma.ts"
+        ]
+      },
       "start.stencil": {
         "dependsOn": [
           {

--- a/libs/core/scripts/check-component-status.mjs
+++ b/libs/core/scripts/check-component-status.mjs
@@ -16,41 +16,10 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { CORE_ROOT, topLevelComponents, allComponentDirs } from './lib/components.mjs';
 
-const CORE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const COMPONENTS_DIR = path.join(CORE_ROOT, 'src', 'components');
 const MANIFEST_PATH = path.join(CORE_ROOT, 'src', 'stories', 'resources', 'component-status.json');
 const MANIFEST_REL = path.relative(CORE_ROOT, MANIFEST_PATH);
-
-/** Directory names under `src/components` matching `pds-*`. */
-function pdsDirs(dir) {
-  return fs
-    .readdirSync(dir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith('pds-'))
-    .map((entry) => entry.name);
-}
-
-/** Top-level components — these each require a status entry. */
-function topLevelComponents() {
-  return pdsDirs(COMPONENTS_DIR).sort();
-}
-
-/**
- * Every `pds-*` directory, including nested subcomponents. Used to validate
- * manifest entries so a deliberate subcomponent entry (e.g. `pds-filter`) is
- * accepted while a typo or removed component is not.
- */
-function allComponentDirs() {
-  const names = new Set();
-  for (const top of topLevelComponents()) {
-    names.add(top);
-    for (const nested of pdsDirs(path.join(COMPONENTS_DIR, top))) {
-      names.add(nested);
-    }
-  }
-  return names;
-}
 
 function readManifestKeys() {
   let raw;

--- a/libs/core/scripts/check-figma-coverage.mjs
+++ b/libs/core/scripts/check-figma-coverage.mjs
@@ -1,0 +1,106 @@
+/**
+ * Figma Code Connect coverage check.
+ *
+ * Guards that every top-level `pds-*` component is either:
+ *   - mapped: has a `libs/figma/components/<name>.figma.ts`, or
+ *   - explicitly waived: listed in `libs/figma/code-connect-waivers.json`.
+ *
+ * This stops a new component from silently shipping with no Code Connect
+ * mapping and no deliberate decision. It also flags stale waivers (a waived
+ * component that has since been mapped, or that no longer exists) so the
+ * waiver list cannot rot.
+ *
+ * Runs as `lint.figma` via `run-p lint.*`, gated through the existing
+ * `nx affected --target=lint` CI job — no workflow changes needed.
+ *
+ * Exits 0 when coverage is accounted for, 1 (with an actionable report) otherwise.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { CORE_ROOT, topLevelComponents } from './lib/components.mjs';
+
+const FIGMA_ROOT = path.resolve(CORE_ROOT, '..', 'figma');
+const FIGMA_COMPONENTS_DIR = path.join(FIGMA_ROOT, 'components');
+const WAIVERS_PATH = path.join(FIGMA_ROOT, 'code-connect-waivers.json');
+const WAIVERS_REL = path.relative(path.resolve(CORE_ROOT, '..', '..'), WAIVERS_PATH);
+
+/** Component names with a `<name>.figma.ts` under libs/figma/components. */
+function mappedComponents() {
+  if (!fs.existsSync(FIGMA_COMPONENTS_DIR)) return new Set();
+  const names = fs
+    .readdirSync(FIGMA_COMPONENTS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.figma.ts'))
+    .map((entry) => entry.name.replace(/\.figma\.ts$/, ''));
+  return new Set(names);
+}
+
+function readWaivers() {
+  let raw;
+  try {
+    raw = fs.readFileSync(WAIVERS_PATH, 'utf8');
+  } catch {
+    throw new Error(`Could not read waivers at ${WAIVERS_REL}`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Waivers file ${WAIVERS_REL} is not valid JSON: ${err.message}`);
+  }
+  if (!parsed.waived || typeof parsed.waived !== 'object') {
+    throw new Error(`Waivers file ${WAIVERS_REL} is missing a "waived" object`);
+  }
+  return new Set(Object.keys(parsed.waived));
+}
+
+function main() {
+  let waived;
+  try {
+    waived = readWaivers();
+  } catch (err) {
+    console.error(`✖ figma-coverage check failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  const components = topLevelComponents();
+  const mapped = mappedComponents();
+  const componentSet = new Set(components);
+
+  // A component with neither a mapping nor a waiver is an unaccounted gap.
+  const uncovered = components.filter((name) => !mapped.has(name) && !waived.has(name));
+  // A waiver for a component that is now mapped should be removed.
+  const redundant = [...waived].filter((name) => mapped.has(name)).sort();
+  // A waiver for a component that no longer exists is stale.
+  const orphaned = [...waived].filter((name) => !componentSet.has(name)).sort();
+
+  if (uncovered.length === 0 && redundant.length === 0 && orphaned.length === 0) {
+    console.log(
+      `✔ figma code connect coverage accounted for ` +
+        `(${mapped.size} mapped, ${waived.size} waived, ${components.length} components).`,
+    );
+    return;
+  }
+
+  console.error(`✖ figma code connect coverage is unaccounted for.\n`);
+  if (uncovered.length > 0) {
+    console.error(`Components with no .figma.ts and no waiver:`);
+    uncovered.forEach((name) => console.error(`  - ${name}`));
+    console.error(
+      `  → add libs/figma/components/<name>.figma.ts, ` +
+        `or add an entry to ${WAIVERS_REL} with a reason.\n`,
+    );
+  }
+  if (redundant.length > 0) {
+    console.error(`Waivers for components that are already mapped (remove the waiver):`);
+    redundant.forEach((name) => console.error(`  - ${name}`));
+    console.error('');
+  }
+  if (orphaned.length > 0) {
+    console.error(`Waivers for components that no longer exist (remove or rename):`);
+    orphaned.forEach((name) => console.error(`  - ${name}`));
+    console.error('');
+  }
+  process.exit(1);
+}
+
+main();

--- a/libs/core/scripts/check-figma-coverage.mjs
+++ b/libs/core/scripts/check-figma-coverage.mjs
@@ -11,7 +11,10 @@
  * waiver list cannot rot.
  *
  * Runs as `lint.figma` via `run-p lint.*`, gated through the existing
- * `nx affected --target=lint` CI job — no workflow changes needed.
+ * `nx affected --target=lint` CI job. `@pine-ds/core` declares an implicit
+ * dependency on `@pine-ds/figma` so figma-only PRs still schedule core lint,
+ * and the core `lint` target inputs include waiver/mapping paths so Nx cache
+ * invalidates when those files change.
  *
  * Exits 0 when coverage is accounted for, 1 (with an actionable report) otherwise.
  */

--- a/libs/core/scripts/check-figma-coverage.mjs
+++ b/libs/core/scripts/check-figma-coverage.mjs
@@ -47,7 +47,7 @@ function readWaivers() {
   } catch (err) {
     throw new Error(`Waivers file ${WAIVERS_REL} is not valid JSON: ${err.message}`);
   }
-  if (!parsed.waived || typeof parsed.waived !== 'object') {
+  if (!parsed.waived || typeof parsed.waived !== 'object' || Array.isArray(parsed.waived)) {
     throw new Error(`Waivers file ${WAIVERS_REL} is missing a "waived" object`);
   }
   return new Set(Object.keys(parsed.waived));

--- a/libs/core/scripts/lib/components.mjs
+++ b/libs/core/scripts/lib/components.mjs
@@ -1,0 +1,43 @@
+/**
+ * Shared component-enumeration helpers for the maturity lint checks
+ * (`check-component-status.mjs`, `check-figma-coverage.mjs`).
+ *
+ * Single source for "what are the components" so the guards cannot diverge on
+ * their globbing logic.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repo `libs/core` root (this file lives at `libs/core/scripts/lib/`). */
+export const CORE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+export const COMPONENTS_DIR = path.join(CORE_ROOT, 'src', 'components');
+
+/** Directory names directly under `dir` matching `pds-*`. */
+function pdsDirs(dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith('pds-'))
+    .map((entry) => entry.name);
+}
+
+/** Top-level components — the public surface that needs status + Figma coverage. */
+export function topLevelComponents() {
+  return pdsDirs(COMPONENTS_DIR).sort();
+}
+
+/**
+ * Every `pds-*` directory, including nested subcomponents (e.g. `pds-filter`,
+ * `pds-table-cell`). Used to accept deliberate subcomponent references while
+ * rejecting typos or removed components.
+ */
+export function allComponentDirs() {
+  const names = new Set();
+  for (const top of topLevelComponents()) {
+    names.add(top);
+    for (const nested of pdsDirs(path.join(COMPONENTS_DIR, top))) {
+      names.add(nested);
+    }
+  }
+  return names;
+}

--- a/libs/core/scripts/lib/components.mjs
+++ b/libs/core/scripts/lib/components.mjs
@@ -33,9 +33,16 @@ export function topLevelComponents() {
  */
 export function allComponentDirs() {
   const names = new Set();
+  // Top-level pds-* components.
   for (const top of topLevelComponents()) {
     names.add(top);
-    for (const nested of pdsDirs(path.join(COMPONENTS_DIR, top))) {
+  }
+  // Nested pds-* subcomponents under ANY top-level directory — including
+  // non-pds-* parents like `_internal/` (e.g. `_internal/pds-label`) — so a
+  // deliberate subcomponent reference is not falsely rejected.
+  for (const entry of fs.readdirSync(COMPONENTS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    for (const nested of pdsDirs(path.join(COMPONENTS_DIR, entry.name))) {
       names.add(nested);
     }
   }

--- a/libs/figma/code-connect-waivers.json
+++ b/libs/figma/code-connect-waivers.json
@@ -1,0 +1,20 @@
+{
+  "$comment": "Machine-readable source of truth for INTENTIONALLY unmapped Pine components. A top-level pds-* component passes the Figma Code Connect coverage guard (libs/core/scripts/check-figma-coverage.mjs) when it has a matching libs/figma/components/<name>.figma.ts OR an entry here. Remove a component's entry once it is mapped. Keep CODE_CONNECT_COVERAGE.md in sync (a future change can render that doc from this file).",
+  "waived": {
+    "pds-accordion": "No Figma Code Connect mapping yet; add components/pds-accordion.figma.ts when the Figma node is ready.",
+    "pds-box": "Layout primitive; may map to layout frames rather than a single component node.",
+    "pds-combobox": "No Figma Code Connect mapping yet; add components/pds-combobox.figma.ts when the Figma node is ready.",
+    "pds-container": "No Figma Code Connect mapping yet; add components/pds-container.figma.ts when the Figma node is ready.",
+    "pds-copytext": "No Figma Code Connect mapping yet; add components/pds-copytext.figma.ts when the Figma node is ready.",
+    "pds-dropdown-menu": "No Figma Code Connect mapping yet; add components/pds-dropdown-menu.figma.ts when the Figma node is ready.",
+    "pds-icon": "Icon set lives in @pine-ds/icons; map if Figma documents a dedicated icon wrapper.",
+    "pds-image": "No Figma Code Connect mapping yet; add components/pds-image.figma.ts when the Figma node is ready.",
+    "pds-multiselect": "No Figma Code Connect mapping yet; add components/pds-multiselect.figma.ts when the Figma node is ready.",
+    "pds-popover": "No Figma Code Connect mapping yet; add components/pds-popover.figma.ts when the Figma node is ready.",
+    "pds-row": "Often used with pds-box; may share layout documentation.",
+    "pds-sortable": "Figma substitutions exist for sortable list patterns; wire components/pds-sortable.figma.ts when aligned.",
+    "pds-table": "Composite; consider per-subcomponent mappings (row, cell, head) if needed.",
+    "pds-text": "No Figma Code Connect mapping yet; add components/pds-text.figma.ts when the Figma node is ready.",
+    "pds-tooltip": "No Figma Code Connect mapping yet; add components/pds-tooltip.figma.ts when the Figma node is ready."
+  }
+}

--- a/libs/figma/package.json
+++ b/libs/figma/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@pine-ds/figma",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Figma Code Connect sources for Pine (not published)"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -890,6 +890,10 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "libs/figma": {
+      "name": "@pine-ds/figma",
+      "version": "0.0.0"
+    },
     "libs/react": {
       "name": "@pine-ds/react",
       "version": "3.26.1",
@@ -6832,6 +6836,10 @@
     },
     "node_modules/@pine-ds/doc-components": {
       "resolved": "libs/doc-components",
+      "link": true
+    },
+    "node_modules/@pine-ds/figma": {
+      "resolved": "libs/figma",
       "link": true
     },
     "node_modules/@pine-ds/icons": {


### PR DESCRIPTION
# Description

Adds a CI-gated check that every top-level `pds-*` component is either **mapped** (has `libs/figma/components/<name>.figma.ts`) or **explicitly waived** in a new machine-readable `libs/figma/code-connect-waivers.json`. Prevents a new component from silently shipping with no Code Connect mapping and no deliberate decision, and flags **redundant** waivers (component since mapped) and **orphaned** waivers (component removed) so the waiver list cannot rot.

Seeded the waiver file with the **15** top-level components that currently have no `.figma.ts` (notes carried over from `CODE_CONNECT_COVERAGE.md`). No `.figma.ts` files were authored here — real mappings need Figma node URLs from design and are a paired follow-up; waiving keeps the gap honest and tracked.

Extracts a shared component-enumeration helper (`libs/core/scripts/lib/components.mjs`) used by both this guard and the component-status guard so their globbing logic can't diverge.

**Stacked on #750** (component-status guard) for the shared helper. Review/merge #750 first; this will auto-retarget to `main`.

**Why no workflow changes:** gated via `lint.figma` in `run-p lint.*`, which the existing `nx affected --target=lint` job already runs.

**Note for #736 author:** once `CODE_CONNECT_COVERAGE.md` lands on `main`, that doc and this JSON both list the 15 gaps. The clean end-state is rendering the doc from this JSON (single source of truth) — flagged as a follow-up in the JSON's `$comment`.

New dependencies: none.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Passes on current state (21 mapped, 15 waived, 35 components).
- Verified it fails for an uncovered component (dropped `pds-tooltip` waiver), a redundant waiver (`pds-button`, already mapped), and an orphaned waiver (`pds-ghost`), then confirmed clean after restore.
- Confirmed the component-status guard still passes after the shared-helper refactor.
- `run-p lint.*` enumerates `lint.eslint, lint.figma, lint.status, lint.styles`.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: self-validating checks run against real + simulated drift

**Test Configuration**:

- Pine versions: 3.26.1 (current main)
- OS: macOS 25.3.0
- Browsers: n/a
- Screen readers: n/a
- Misc: tooling-only change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to lint/CI inputs; no runtime component or auth behavior is modified.
> 
> **Overview**
> Adds a **Figma Code Connect coverage guard** to the existing `@pine-ds/core` lint pipeline so every top-level `pds-*` component must either have `libs/figma/components/<name>.figma.ts` or an explicit entry in new **`libs/figma/code-connect-waivers.json`**. The check also fails on **redundant** waivers (component already mapped) and **orphaned** waivers (component removed).
> 
> Wires it as **`lint.figma`** under `run-p lint.*` (no CI workflow changes). Nx gets an **`implicitDependencies`** link from core to **`@pine-ds/figma`** and extra **lint inputs** for waivers and `.figma.ts` files so figma-only changes still run core lint and cache invalidates correctly.
> 
> **Refactors** component discovery into shared **`libs/core/scripts/lib/components.mjs`**, used by both the new guard and **`check-component-status.mjs`**. Seeds the waiver file with the 15 currently unmapped components and registers the private **`@pine-ds/figma`** workspace package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba14f2de4bde906ed9c4fb85332881e0f3d53e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->