### PR TITLE
test: add axe accessibility coverage to form and interactive components

### DIFF
--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.e2e.ts
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-checkbox', () => {
   it('toggles checked and unchecked', async () => {
@@ -22,7 +23,7 @@ describe('pds-checkbox', () => {
     const component = await page.find('pds-checkbox');
     expect(component).toHaveClass('hydrated');
 
-    let checkbox = await page.find('pds-checkbox >>> input');
+    const checkbox = await page.find('pds-checkbox >>> input');
     component.setProperty('disabled', false);
     await page.waitForChanges();
     expect(await checkbox.getProperty('disabled')).toBe(false);
@@ -52,5 +53,14 @@ describe('pds-checkbox', () => {
 
     await checkbox.press('Space');
     expect(eventSpy).not.toHaveReceivedEvent();
+  });
+});
+
+describe('pds-checkbox accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-checkbox component-id="terms" label="Accept the terms"></pds-checkbox>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-chip/test/pds-chip.e2e.ts
+++ b/libs/core/src/components/pds-chip/test/pds-chip.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-chip', () => {
   it('renders', async () => {
@@ -80,5 +81,14 @@ describe('pds-chip', () => {
     await closeLink.click();
 
     expect(eventSpy).toHaveReceivedEvent();
+  });
+});
+
+describe('pds-chip accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-chip>Active</pds-chip>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-link/test/pds-link.e2e.ts
+++ b/libs/core/src/components/pds-link/test/pds-link.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-link', () => {
   it('renders', async () => {
@@ -33,5 +34,14 @@ describe('pds-link', () => {
 
     const element = await page.find('pds-link');
     expect(element.textContent).toEqual(`This is slot content`);
+  });
+});
+
+describe('pds-link accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-link href="#section">Read more</pds-link>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-radio-group/test/pds-radio-group.e2e.ts
+++ b/libs/core/src/components/pds-radio-group/test/pds-radio-group.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-radio-group', () => {
   it('renders', async () => {
@@ -340,3 +341,16 @@ describe('pds-radio-group', () => {
   });
 });
 
+describe('pds-radio-group accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-radio-group name="plan">
+        <pds-radio component-id="plan-basic" label="Basic" value="basic"></pds-radio>
+        <pds-radio component-id="plan-pro" label="Pro" value="pro"></pds-radio>
+      </pds-radio-group>
+    `);
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
+  });
+});

--- a/libs/core/src/components/pds-radio/test/pds-radio.e2e.ts
+++ b/libs/core/src/components/pds-radio/test/pds-radio.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-radio', () => {
   it('renders', async () => {
@@ -114,5 +115,14 @@ describe('pds-radio', () => {
     expect(component).toHaveClass('has-border');
     expect(component).toHaveClass('is-invalid');
     expect(component).toHaveClass('is-disabled');
+  });
+});
+
+describe('pds-radio accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-radio component-id="opt-1" label="Option one"></pds-radio>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
+++ b/libs/core/src/components/pds-switch/test/pds-switch.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-switch', () => {
   it('renders a checked input when toggled', async () => {
@@ -52,7 +53,7 @@ describe('pds-switch', () => {
     await page.waitForChanges();
 
     value = el.getAttribute('aria-invalid');
-    expect(value).toBe("true");
+    expect(value).toBe('true');
   });
 
   it('renders an invalid input with error message when toggled', async () => {
@@ -67,14 +68,16 @@ describe('pds-switch', () => {
     const ariaDesc = el.getAttribute('aria-describedby');
     const ariaInvalid = el.getAttribute('aria-invalid');
 
-    expect(ariaInvalid).toBe("true");
-    expect(ariaDesc).toBe("switch-with-error__error-message");
+    expect(ariaInvalid).toBe('true');
+    expect(ariaDesc).toBe('switch-with-error__error-message');
     expect(errText.textContent).toEqual(`Please correct this item`);
   });
 
   it('renders a helper and error message and assigns the aria-description to the input', async () => {
     const page = await newE2EPage();
-    await page.setContent('<pds-switch component-id="switch-with-description" invalid="true" helper-message="This is a helper message" error-message="This is an error message"></pds-switch>');
+    await page.setContent(
+      '<pds-switch component-id="switch-with-description" invalid="true" helper-message="This is a helper message" error-message="This is an error message"></pds-switch>',
+    );
 
     const component = await page.find('pds-switch');
     const el = await page.find('pds-switch >>> input');
@@ -86,9 +89,18 @@ describe('pds-switch', () => {
     const ariaDesc = el.getAttribute('aria-describedby');
     const ariaInvalid = el.getAttribute('aria-invalid');
 
-    expect(ariaInvalid).toBe("true");
+    expect(ariaInvalid).toBe('true');
     expect(ariaDesc).toBe('switch-with-description__error-message');
     expect(helperMessage.textContent).toEqual(`This is a helper message`);
     expect(errorMessage.textContent).toEqual(`This is an error message`);
+  });
+});
+
+describe('pds-switch accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-switch component-id="notify" label="Enable notifications"></pds-switch>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.e2e.ts
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.e2e.ts
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { formatViolations, runAxe } from '../../../utils/test/axe';
 
 describe('pds-textarea', () => {
   it('renders', async () => {
@@ -258,5 +259,14 @@ describe('pds-textarea', () => {
 
     // Should not have highlight attribute
     expect(component).not.toHaveAttribute('highlight');
+  });
+});
+
+describe('pds-textarea accessibility', () => {
+  it('has no axe violations', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-textarea component-id="bio" label="Bio"></pds-textarea>');
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
   });
 });


### PR DESCRIPTION
# Description

First batch of the accessibility coverage rollout (implementation-plan item #4). Extends the existing `runAxe` / `formatViolations` e2e helper (`libs/core/src/utils/test/axe.ts`) — already used by `pds-button`, `pds-input`, `pds-modal` — to a batch of form and interactive components, each asserting a zero-violation WCAG 2.0/2.1 A+AA baseline.

**Components covered:** `pds-checkbox`, `pds-radio`, `pds-radio-group`, `pds-switch`, `pds-textarea`, `pds-link`, `pds-chip`.

No new infrastructure or workflow changes — these run in the existing `nx affected --target=test` (`stencil test --e2e`) job. Remaining components land in follow-up batch PRs.

**Drive-by:** fixed a pre-existing `prefer-const` lint error in `pds-checkbox.e2e.ts` that lint-staged flagged once the file was touched.

New dependencies: none.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran `stencil test --e2e` for all seven components — all axe assertions pass.
- `pds-textarea` initially failed axe's `label` rule because the test markup omitted the required `component-id` (which wires `<label for>` ↔ `<textarea id>`); corrected the markup. Demonstrates the gate catches missing label associations.

- [ ] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.26.1 (current main)
- OS: macOS 25.3.0
- Browsers: Puppeteer (Stencil e2e)
- Screen readers: n/a (automated axe-core)
- Misc: WCAG 2.0/2.1 A+AA tags

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or CI workflow changes; failures would surface existing a11y issues rather than introducing runtime risk.
> 
> **Overview**
> Adds **axe-core e2e coverage** (WCAG 2.0/2.1 A+AA via existing `runAxe` / `formatViolations`) for **`pds-checkbox`**, **`pds-radio`**, **`pds-radio-group`**, **`pds-switch`**, **`pds-textarea`**, **`pds-link`**, and **`pds-chip`**. Each file gets a `* accessibility` block that renders representative markup and asserts zero violations.
> 
> **Drive-by test tweaks:** `prefer-const` in `pds-checkbox.e2e.ts`; quote/style consistency and a wrapped `setContent` line in `pds-switch.e2e.ts`. No component implementation or new test utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd81a65509d37a7fe96f357f02481c4abf581aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->