### PR TITLE
chore(lint): add pine-motion stylelint rule banning hardcoded transition timing

### DIFF
--- a/libs/.stylelintrc.json
+++ b/libs/.stylelintrc.json
@@ -6,11 +6,13 @@
   ],
   "plugins": [
     "./core/lint-plugins/stylelint-plugin-pine-colors.cjs",
-    "./core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs"
+    "./core/lint-plugins/stylelint-plugin-pine-semantic-tokens.cjs",
+    "./core/lint-plugins/stylelint-plugin-pine-motion.cjs"
   ],
   "rules": {
     "pine-design-system/no-hardcoded-colors": true,
     "pine-design-system/prefer-semantic-tokens": true,
+    "pine-design-system/no-hardcoded-motion": true,
     "at-rule-no-unknown": null,
     "color-hex-length": "long",
     "length-zero-no-unit": [

--- a/libs/core/lint-plugins/stylelint-plugin-pine-motion.cjs
+++ b/libs/core/lint-plugins/stylelint-plugin-pine-motion.cjs
@@ -1,0 +1,111 @@
+/**
+ * Stylelint plugin to enforce Pine motion duration tokens.
+ *
+ * Flags hard-coded time values in `transition` / `transition-duration`
+ * declarations and points to the `--pine-motion-duration-*` tokens, so
+ * component transitions stay consistent and inherit the `prefers-reduced-motion`
+ * override.
+ *
+ * Scope (deliberate):
+ *   - Only `transition` / `transition-duration`. Keyframe `animation` durations
+ *     (spinners, progress bars, etc.) are bespoke ongoing motion, not interaction
+ *     transitions, and are intentionally out of scope.
+ *   - `0` / `0s` / `0ms` are always allowed.
+ *   - Values that exactly match a token (120ms/200ms/300ms and their `s` forms)
+ *     get an autofix to the token var. Off-grid values (e.g. 0.15s) have no exact
+ *     token; they must use the nearest token or carry a justified
+ *     `stylelint-disable-next-line` with a comment.
+ */
+const stylelint = require('stylelint');
+
+const ruleName = 'pine-design-system/no-hardcoded-motion';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (message) => message,
+});
+
+// Properties whose hard-coded timing should use a motion token.
+const TIMING_PROPS = new Set(['transition', 'transition-duration']);
+
+// Exact literal → `--pine-motion-duration-*` token name (both ms and s spellings).
+const DURATION_TOKENS = {
+  '120ms': 'fast',
+  '0.12s': 'fast',
+  '.12s': 'fast',
+  '200ms': 'base',
+  '0.2s': 'base',
+  '.2s': 'base',
+  '300ms': 'slow',
+  '0.3s': 'slow',
+  '.3s': 'slow',
+};
+
+// Matches a CSS time value (e.g. `200ms`, `0.2s`, `.15s`).
+const TIME_REGEX = /(\d*\.?\d+)(ms|s)\b/g;
+
+function isZeroTime(raw) {
+  return /^0*\.?0+(ms|s)$/.test(raw);
+}
+
+module.exports = stylelint.createPlugin(ruleName, (primaryOption, _secondaryOptions, context) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primaryOption,
+      possible: [true, false],
+    });
+
+    if (!validOptions || primaryOption === false) {
+      return;
+    }
+
+    root.walkDecls((decl) => {
+      if (!TIMING_PROPS.has(decl.prop.toLowerCase())) {
+        return;
+      }
+
+      const value = decl.value;
+      const replacements = [];
+      let match;
+
+      TIME_REGEX.lastIndex = 0;
+      while ((match = TIME_REGEX.exec(value)) !== null) {
+        const raw = match[0];
+        if (isZeroTime(raw)) {
+          continue;
+        }
+
+        const token = DURATION_TOKENS[raw];
+        const tokenVar = token ? `var(--pine-motion-duration-${token})` : null;
+
+        const message = tokenVar
+          ? `Hard-coded transition duration "${raw}" should use the motion token ${tokenVar}.`
+          : `Hard-coded transition duration "${raw}" has no exact Pine motion token ` +
+            `(fast 120ms / base 200ms / slow 300ms). Use the nearest token, or add a ` +
+            `justified \`stylelint-disable-next-line ${ruleName}\` when an off-grid value is intentional.`;
+
+        if (tokenVar && context && context.fix) {
+          replacements.push({ original: raw, replacement: tokenVar });
+          continue;
+        }
+
+        stylelint.utils.report({
+          ruleName,
+          result,
+          node: decl,
+          message: messages.rejected(message),
+          word: raw,
+        });
+      }
+
+      if (context && context.fix && replacements.length > 0) {
+        let newValue = value;
+        for (const { original, replacement } of replacements) {
+          newValue = newValue.replace(original, replacement);
+        }
+        decl.value = newValue;
+      }
+    });
+  };
+});
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/libs/core/lint-plugins/stylelint-plugin-pine-motion.cjs
+++ b/libs/core/lint-plugins/stylelint-plugin-pine-motion.cjs
@@ -39,8 +39,10 @@ const DURATION_TOKENS = {
   '.3s': 'slow',
 };
 
-// Matches a CSS time value (e.g. `200ms`, `0.2s`, `.15s`).
-const TIME_REGEX = /(\d*\.?\d+)(ms|s)\b/g;
+// Matches a CSS time value (e.g. `200ms`, `0.2s`, `.15s`). The leading
+// negative lookbehind prevents matching time-like substrings inside
+// identifiers / custom-property names (e.g. `var(--app-delay-200ms)`).
+const TIME_REGEX = /(?<![\w-])(\d*\.?\d+)(ms|s)\b/g;
 
 function isZeroTime(raw) {
   return /^0*\.?0+(ms|s)$/.test(raw);
@@ -83,7 +85,10 @@ module.exports = stylelint.createPlugin(ruleName, (primaryOption, _secondaryOpti
             `justified \`stylelint-disable-next-line ${ruleName}\` when an off-grid value is intentional.`;
 
         if (tokenVar && context && context.fix) {
-          replacements.push({ original: raw, replacement: tokenVar });
+          // Record position + length so the fix is applied by index (not by a
+          // first-match string replace, which could rewrite the wrong
+          // occurrence in a multi-segment shorthand).
+          replacements.push({ index: match.index, length: raw.length, replacement: tokenVar });
           continue;
         }
 
@@ -97,9 +102,10 @@ module.exports = stylelint.createPlugin(ruleName, (primaryOption, _secondaryOpti
       }
 
       if (context && context.fix && replacements.length > 0) {
+        // Apply right-to-left so earlier indices stay valid as the string length changes.
         let newValue = value;
-        for (const { original, replacement } of replacements) {
-          newValue = newValue.replace(original, replacement);
+        for (const { index, length, replacement } of replacements.reverse()) {
+          newValue = newValue.slice(0, index) + replacement + newValue.slice(index + length);
         }
         decl.value = newValue;
       }

--- a/libs/core/src/components/pds-combobox/pds-combobox-dropdown-panel.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox-dropdown-panel.scss
@@ -24,6 +24,7 @@
     justify-content: space-between;
     padding: var(--pine-dimension-xs) var(--pine-dimension-sm);
     position: relative;
+    /* stylelint-disable-next-line pine-design-system/no-hardcoded-motion -- 0.15s off-grid micro-transition; no exact motion token */
     transition: background 0.15s;
 
     &[aria-selected="true"] {

--- a/libs/core/src/components/pds-combobox/pds-combobox.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox.scss
@@ -91,6 +91,7 @@
   min-height: var(--pine-dimension-450);
   outline: none;
   padding: 0 var(--pine-dimension-sm);
+  /* stylelint-disable-next-line pine-design-system/no-hardcoded-motion -- 0.15s off-grid micro-transition; no exact motion token */
   transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
   width: fit-content;
 
@@ -226,6 +227,7 @@
   outline: none;
   padding-block: var(--pine-dimension-025);
   padding-inline: var(--pine-dimension-150);
+  /* stylelint-disable-next-line pine-design-system/no-hardcoded-motion -- 0.15s off-grid micro-transition; no exact motion token */
   transition: all 0.15s ease;
   width: fit-content;
 

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -271,6 +271,7 @@
   cursor: pointer;
   display: flex;
   padding: var(--pine-dimension-2xs) var(--pine-dimension-xs);
+  /* stylelint-disable-next-line pine-design-system/no-hardcoded-motion -- 0.15s off-grid micro-transition; no exact motion token */
   transition: background 0.15s;
 
   // Prevent checkbox label from triggering double events

--- a/libs/core/src/components/pds-table/pds-table.scss
+++ b/libs/core/src/components/pds-table/pds-table.scss
@@ -75,6 +75,7 @@
   pointer-events: none;
   position: absolute;
   top: 0;
+  /* stylelint-disable-next-line pine-design-system/no-hardcoded-motion -- 0.1s off-grid micro-transition; no exact motion token */
   transition: opacity 0.1s ease;
   width: 4px;
   z-index: var(--pine-z-index);


### PR DESCRIPTION
# Description

Implementation-plan item #3 (part 2 of 2): a custom stylelint rule `pine-design-system/no-hardcoded-motion` that flags hard-coded time values in `transition` / `transition-duration` and points to the `--pine-motion-duration-*` tokens. Prevents new component transitions from drifting back to hard-coded timings after the migration in the parent PR.

**Behavior & scope:**
- Targets only `transition` / `transition-duration`. Keyframe `animation` durations (spinners, progress bars) are bespoke ongoing motion, intentionally out of scope.
- `0` / `0s` / `0ms` always allowed.
- Exact token matches (120ms/200ms/300ms and `s` forms) get a token suggestion **and autofix** (`--fix` rewrites `0.2s` → `var(--pine-motion-duration-base)`).
- Off-grid values (e.g. `0.15s`) report and must either use the nearest token or carry a justified `stylelint-disable-next-line … -- <reason>`.

The 5 existing off-grid micro-transitions (combobox ×3, multiselect, table — all 0.15s/0.1s) are annotated with documented disables, consistent with the behavior-preserving decision in the parent PR (these have no exact token; a follow-up can add 100/150ms tokens or retune them with design).

**Stacked on #755** (`style/adopt-motion-tokens`), which migrates the exact-match transitions; landing the rule after the sweep keeps both PRs green. Mirrors the existing `stylelint-plugin-pine-colors` / `-semantic-tokens` plugins; registered under the same `pine-design-system/` namespace; gated by the existing `lint.styles` → `nx affected --target=lint` job (no workflow changes).

New dependencies: none.

Fixes #(no-issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- `npx stylelint "src/**/*.scss"` is clean (exit 0) with the rule active.
- Verified the rule fires on a fresh `transition: opacity 0.2s ease` and that `--fix` rewrites it to `var(--pine-motion-duration-base)`.
- Verified off-grid `0.15s`/`0.1s` lines report without a disable and pass with the documented disable.

- [ ] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [x] other: rule run against the full SCSS surface + synthetic fixtures

**Test Configuration**:

- Pine versions: 3.26.x (docs/foundations lineage)
- OS: macOS 25.3.0
- Misc: stylelint ^14.13; tooling-only

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only change plus comment annotations; no runtime or auth/data behavior changes.
> 
> **Overview**
> Adds a **Stylelint guard** so new SCSS cannot use raw durations on **`transition`** / **`transition-duration`**, steering authors toward **`--pine-motion-duration-*`** (with **`--fix`** rewriting exact 120/200/300ms spellings to token vars). **`animation`** timings stay out of scope; zero durations are allowed; off-grid values must use a token or a justified disable.
> 
> **`libs/.stylelintrc.json`** registers **`stylelint-plugin-pine-motion.cjs`** and enables **`pine-design-system/no-hardcoded-motion`**.
> 
> Five existing **0.15s / 0.1s** micro-transitions in combobox, multiselect, and table styles get **`stylelint-disable-next-line`** comments so the tree stays green until those timings are retokenized or retuned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616926f5c85878f07ab15a1bbaa0fc8f721e48c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->