### PR TITLE
fix: hide decorative pds-icon from assistive tech + stop suppressing harness color-contrast

### DIFF
--- a/libs/core/src/components/pds-accordion/pds-accordion.tsx
+++ b/libs/core/src/components/pds-accordion/pds-accordion.tsx
@@ -63,7 +63,7 @@ export class PdsAccordion {
         <details {...this.getOpenAttribute()} ref={(el) => (this.detailsEl = el as HTMLDetailsElement)}>
           <summary part="accordion-button">
             <slot name="label">Details</slot>
-            <pds-icon icon={downSmall} part="accordion-icon" />
+            <pds-icon aria-hidden="true" icon={downSmall} part="accordion-icon" />
           </summary>
           <div part="accordion-body" class="pds-accordion__body">
             <slot />

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.e2e.ts
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.e2e.ts
@@ -88,13 +88,7 @@ describe('pds-accordion accessibility', () => {
       </pds-accordion>
     `);
     await page.waitForChanges();
-    // `role-img-alt` is disabled here: the accordion trigger's chevron
-    // (pds-icon) renders role="img" without an accessible name. Matches the
-    // documented suppression in the pds-input test — remove once pds-icon
-    // exposes an accessible label.
-    const violations = await runAxe(page, {
-      rules: { 'role-img-alt': { enabled: false } },
-    });
+    const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
+++ b/libs/core/src/components/pds-accordion/test/pds-accordion.spec.tsx
@@ -14,7 +14,7 @@ describe('pds-accordion', () => {
             <details>
               <summary part="accordion-button">
                 <slot name="label">Details</slot>
-                <pds-icon icon="${downSmall}"></pds-icon>
+                <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
               </summary>
               <div part="accordion-body" class="pds-accordion__body">
                 <slot />
@@ -36,7 +36,7 @@ describe('pds-accordion', () => {
             <details open>
               <summary part="accordion-button">
                 <slot name="label">Details</slot>
-                <pds-icon icon="${downSmall}"></pds-icon>
+                <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
               </summary>
               <div part="accordion-body" class="pds-accordion__body">
                 <slot />
@@ -59,7 +59,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -82,7 +82,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -106,7 +106,7 @@ describe('pds-accordion', () => {
           <details>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />
@@ -164,7 +164,7 @@ describe('pds-accordion', () => {
           <details open>
             <summary part="accordion-button">
               <slot name="label">Details</slot>
-              <pds-icon icon="${downSmall}"></pds-icon>
+              <pds-icon aria-hidden="true" icon="${downSmall}"></pds-icon>
             </summary>
             <div part="accordion-body" class="pds-accordion__body">
               <slot />

--- a/libs/core/src/components/pds-filters/test/pds-filters.e2e.ts
+++ b/libs/core/src/components/pds-filters/test/pds-filters.e2e.ts
@@ -226,12 +226,7 @@ describe('pds-filters accessibility', () => {
     await page.waitForChanges();
     const popover1 = await page.find('pds-filter[component-id="filter1"] >>> .pds-filter__popover');
     expect(await popover1.isVisible()).toBe(true);
-    // `color-contrast` is disabled here: axe flags `.pds-filter__button-text`
-    // in the bare e2e harness, which renders without the full theme/global
-    // styles, so contrast can't be measured reliably here.
-    const violations = await runAxe(page, {
-      rules: { 'color-contrast': { enabled: false } },
-    });
+    const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -599,7 +599,7 @@ export class PdsInput {
 
           {errorMessage && (
             <p class="pds-input__error-message" id={messageId(componentId, 'error')}>
-              <pds-icon icon={danger} size="small" />
+              <pds-icon aria-hidden="true" icon={danger} size="small" />
               {errorMessage}
             </p>
           )}

--- a/libs/core/src/components/pds-input/test/pds-input.e2e.ts
+++ b/libs/core/src/components/pds-input/test/pds-input.e2e.ts
@@ -237,12 +237,7 @@ describe('pds-input', () => {
       await page.setContent(
         '<pds-input label="Email" component-id="email" error-message="Enter a valid email address" invalid></pds-input>',
       );
-      // `role-img-alt` is disabled here pending a fix on the internal error
-      // icon (it renders without an accessible name). Tracked separately;
-      // remove this override once the icon exposes a label.
-      const violations = await runAxe(page, {
-        rules: { 'role-img-alt': { enabled: false } },
-      });
+      const violations = await runAxe(page);
       expect(formatViolations(violations)).toBe('');
     });
   });

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -309,6 +309,9 @@ describe('pds-input', () => {
 
     const errorMessage = root.shadowRoot.querySelector('.pds-input__error-message');
     expect(errorMessage).not.toBeNull();
+
+    const errorIcon = errorMessage?.querySelector('pds-icon');
+    expect(errorIcon?.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('renders a prefix', async () => {

--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -247,7 +247,7 @@ export class PdsSelect {
   private getErrorMessage() {
     return this.errorMessage && (
       <p class="pds-select__error-message" id={messageId(this.componentId, 'error')} aria-live="assertive">
-        <pds-icon icon={danger} size="small"></pds-icon>
+        <pds-icon aria-hidden="true" icon={danger} size="small"></pds-icon>
         {this.errorMessage}
       </p>
     );
@@ -391,7 +391,7 @@ export class PdsSelect {
             <slot onSlotchange={this.handleSlotChange}></slot>
           </div>
           {this.renderMessages()}
-          {!this.multiple && <pds-icon class="pds-select__select-icon" icon={enlarge} />}
+          {!this.multiple && <pds-icon aria-hidden="true" class="pds-select__select-icon" icon={enlarge} />}
         </div>
       </Host>
     );

--- a/libs/core/src/components/pds-select/test/pds-select.e2e.ts
+++ b/libs/core/src/components/pds-select/test/pds-select.e2e.ts
@@ -150,13 +150,7 @@ describe('pds-select accessibility', () => {
         <option value="ca">Canada</option>
       </pds-select>
     `);
-    // `role-img-alt` is disabled here: the select's dropdown chevron (pds-icon)
-    // renders role="img" without an accessible name. Matches the documented
-    // suppression in the pds-input test — remove once pds-icon exposes an
-    // accessible label.
-    const violations = await runAxe(page, {
-      rules: { 'role-img-alt': { enabled: false } },
-    });
+    const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-select/test/pds-select.e2e.ts
+++ b/libs/core/src/components/pds-select/test/pds-select.e2e.ts
@@ -153,4 +153,16 @@ describe('pds-select accessibility', () => {
     const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
+
+  it('has no axe violations with an error message', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <pds-select component-id="country" label="Country" error-message="Please select a country">
+        <option value="us">United States</option>
+        <option value="ca">Canada</option>
+      </pds-select>
+    `);
+    const violations = await runAxe(page);
+    expect(formatViolations(violations)).toBe('');
+  });
 });

--- a/libs/core/src/components/pds-select/test/pds-select.spec.tsx
+++ b/libs/core/src/components/pds-select/test/pds-select.spec.tsx
@@ -22,7 +22,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -68,7 +68,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
         <option value="1">Option 1</option>
@@ -95,7 +95,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -147,7 +147,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -177,7 +177,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -203,7 +203,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -229,7 +229,7 @@ describe('pds-select', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>
@@ -724,7 +724,7 @@ describe('action slot', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
         <span slot="action">Help</span>
@@ -753,7 +753,7 @@ describe('action slot', () => {
             <div aria-hidden="true" class="hidden">
               <slot></slot>
             </div>
-            <pds-icon class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
+            <pds-icon aria-hidden="true" class="pds-select__select-icon" icon="${enlarge}"></pds-icon>
           </div>
         </mock:shadow-root>
       </pds-select>

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/pds-sortable-item.tsx
@@ -44,7 +44,7 @@ export class PdsSortableItem {
       <Host class="pds-sortable-item" id={this.componentId}>
         {this.showHandle && (
           <div class="pds-sortable-item__handle">
-            <pds-icon icon={handleIcon}></pds-icon>
+            <pds-icon aria-hidden="true" icon={handleIcon}></pds-icon>
           </div>
         )}
         <slot></slot>

--- a/libs/core/src/components/pds-sortable/pds-sortable-item/test/pds-sortable-item.spec.tsx
+++ b/libs/core/src/components/pds-sortable/pds-sortable-item/test/pds-sortable-item.spec.tsx
@@ -39,7 +39,7 @@ describe('pds-sortable-item', () => {
     expect(page.root).toEqualHtml(`
       <pds-sortable-item class="pds-sortable-item" show-handle="true">
         <div class="pds-sortable-item__handle">
-          <pds-icon icon="${handleIcon}"></pds-icon>
+          <pds-icon aria-hidden="true" icon="${handleIcon}"></pds-icon>
         </div>
       </pds-sortable-item>
     `);

--- a/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
+++ b/libs/core/src/components/pds-sortable/test/pds-sortable.e2e.ts
@@ -93,13 +93,7 @@ describe('pds-sortable accessibility', () => {
         <pds-sortable-item>Item 3</pds-sortable-item>
       </pds-sortable>
     `);
-    // `role-img-alt` is disabled here: each item's drag handle (pds-icon)
-    // renders role="img" without an accessible name. Matches the documented
-    // suppression in the pds-input test — remove once pds-icon exposes an
-    // accessible label.
-    const violations = await runAxe(page, {
-      rules: { 'role-img-alt': { enabled: false } },
-    });
+    const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
 });

--- a/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
+++ b/libs/core/src/components/pds-toast/test/pds-toast.e2e.ts
@@ -302,12 +302,7 @@ describe('pds-toast accessibility', () => {
         <span>This is a status message</span>
       </pds-toast>
     `);
-    // `color-contrast` is disabled here: axe flags the message text in the bare
-    // e2e harness, which renders without the full theme/global styles, so
-    // contrast can't be measured reliably (the result is flaky run-to-run).
-    const violations = await runAxe(page, {
-      rules: { 'color-contrast': { enabled: false } },
-    });
+    const violations = await runAxe(page);
     expect(formatViolations(violations)).toBe('');
   });
 });


### PR DESCRIPTION
# Description

Resolves two follow-ups surfaced by the accessibility rollout (#752–#754).

## 1. `role-img-alt` — fix decorative icons (was suppressed)

`pds-icon` (external, `@pine-ds/icons`) renders `role="img"` with no accessible name, so axe's `role-img-alt` fired wherever an icon is used decoratively. Rather than per-test suppressions, this marks the **decorative** usages `aria-hidden="true"` at the call sites:

- `pds-copytext` (copy-button icon — button keeps its value `<span>` as its accessible name)
- `pds-accordion` (chevron) · `pds-select` (dropdown chevron + error icon) · `pds-sortable-item` (drag handle) · `pds-input` (error icon)

Each is decorative reinforcement; the control/text already carries the accessible name (verified no `button-name` regressions). The `role-img-alt` suppressions in pds-input/accordion/select/sortable e2e tests are removed and now enforce.

## 2. `color-contrast` — unreliable in the e2e harness (was suppressed per-test)

Moved `color-contrast` into `DEFAULT_DISABLED_RULES` in `utils/test/axe.ts` with a rationale comment: the bare Stencil E2E harness renders without the theme/global stylesheet and with fonts that may fail to load, so axe measures contrast against incidental colors (flaky run-to-run). Removed the per-test suppressions in pds-filters/pds-toast. **Contrast should be verified in a themed context (Storybook/visual).**

## Not addressed (deferred, by design)

The off-grid motion token follow-up (100/150ms) is a design-token decision and would conflict with `_motion.scss` in #736 — left as documented disables.

**Stacked on #754.** Note: `pds-copytext`'s `role-img-alt` suppression lives in #753 (not in this branch); its `pds-copytext.tsx` icon is fixed here, so that suppression becomes a harmless no-op — drop it when #753 lands (happy to push a one-liner).

New dependencies: none.

Fixes #(no-issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- `stencil test --e2e` for input/accordion/select/sortable/filters/toast — all pass with suppressions removed (267 tests); confirms the `aria-hidden` fix clears `role-img-alt` with no new `button-name` violations.
- `stencil test --spec` for the 5 changed components — all pass (2608 tests) after updating the expected `toEqualHtml` markup to include `aria-hidden`.

- [ ] unit tests
- [x] e2e tests
- [x] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: 3.26.x
- OS: macOS 25.3.0
- Browsers: Puppeteer (Stencil e2e)
- Misc: WCAG 2.0/2.1 A+AA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to decorative ARIA on icons and test expectations, with no functional or API behavior changes to the controls themselves.
> 
> **Overview**
> Decorative **`pds-icon`** instances are now **`aria-hidden="true"`** so assistive tech ignores unnamed `role="img"` chevrons and error glyphs while labels and error text stay the accessible name. This is applied on **`pds-accordion`** (chevron), **`pds-input`** / **`pds-select`** (error icons), **`pds-select`** (dropdown chevron), and **`pds-sortable-item`** (drag handle).
> 
> Component **e2e accessibility tests** no longer disable axe’s **`role-img-alt`** for those cases; **`pds-filters`** and **`pds-toast`** likewise stop passing local **`color-contrast`** overrides (aligned with harness-level contrast handling described in the PR stack). **Spec** snapshots and a **`pds-input`** error-icon assertion were updated, and **`pds-select`** gained an e2e case with an error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058967e6a8107fff1e6b16e058de398afa9502a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->