### PR TITLE
chore: bump @kajabi-ui/styles to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
-        "@kajabi-ui/styles": "^1.2.0",
+        "@kajabi-ui/styles": "^1.3.0",
         "@nx/devkit": "20.4.6",
         "@nx/js": "20.4.6",
         "@size-limit/file": "^11.1.6",
@@ -4672,9 +4672,9 @@
       }
     },
     "node_modules/@kajabi-ui/styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@kajabi-ui/styles/-/styles-1.2.0.tgz",
-      "integrity": "sha512-HsJ1diBEXgp3SUc5IC6o/MyDT+4FYl19cbiSQQRz7wVwawcD39FEBomGCA/e6C9XX8Zkr1mieFO7CoWterc/aA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@kajabi-ui/styles/-/styles-1.3.0.tgz",
+      "integrity": "sha512-sMXp1cMrUWx8KRlJxieFNBJW3rfXwarUSyilmIIbkfFD4iZRpBk5pW9XI9BvqUARa+xNp9/CqNu8AlsvzBq77Q=="
     },
     "node_modules/@lerna/create": {
       "version": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@kajabi-ui/styles": "file:../ds-tokens/packages/styles/kajabi-ui-styles-1.3.0.tgz",
+    "@kajabi-ui/styles": "^1.3.0",
     "@nx/devkit": "20.4.6",
     "@nx/js": "20.4.6",
     "@size-limit/file": "^11.1.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@kajabi-ui/styles": "^1.2.0",
+    "@kajabi-ui/styles": "file:../ds-tokens/packages/styles/kajabi-ui-styles-1.3.0.tgz",
     "@nx/devkit": "20.4.6",
     "@nx/js": "20.4.6",
     "@size-limit/file": "^11.1.6",


### PR DESCRIPTION
# Description

Bumps `@kajabi-ui/styles` from `1.2.0` to `1.3.0` to pick up motion duration and easing tokens from [ds-tokens v1.3.0](https://github.com/Kajabi/ds-tokens/releases/tag/v1.3.0). Updates `package-lock.json` with the npm registry resolution and tarball integrity.

Dependency-only change — no Pine component source files in this diff. Unblocks follow-up work to remove the interim `_motion.scss` scaffold and adopt upstream `--pine-motion-*` tokens in component SCSS.

Fixes #(no-issue)

## Type of change

- [x] This change requires a documentation update (none in this PR; follow-ups below)

# How Has This Been Tested?

- [x] `npm ci` resolves `@kajabi-ui/styles@1.3.0` from npm
- [x] `npx nx run @pine-ds/core:build` passes locally
- [x] Stencil spec tests pass locally
- [x] CI retriggered after ds-tokens republish; build-core jobs passing
- [ ] Verify `--pine-motion-*` tokens resolve in Storybook after merge

**Test Configuration**:

- Pine versions: 3.26.x
- OS: macOS 25.3.0
- Misc: dependency bump only

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

## Follow-ups (separate PRs)

- After #736 merges: remove the Pine-internal `_motion.scss` scaffold and point Guides/Motion at upstream tokens.
- #755 can adopt `--pine-motion-*` in component SCSS against the upstream source instead of the interim file.