### PR TITLE
chore(release): finalize lockfile and commit message before push

### DIFF
--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -237,41 +237,78 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      # `nx release` runs `npm install` internally to refresh the lockfile after
-      # version bumps. In some environments that resolves transitive peer deps
-      # differently than `npm ci` expects, producing a lockfile that release
-      # commits successfully but every downstream `npm ci` then rejects with
-      # "Missing: X from lock file". When that happens, regenerate the lockfile
-      # and push a fix-up commit so feature branches see a green main.
-      - name: Self-heal lockfile if release produced an npm-ci-incompatible state
+      # nx release commits locally but does not push (createRelease: false). We
+      # regenerate the lockfile with the same npm CI uses, amend it into the
+      # release commit, fix the commit message, verify npm ci, then push once.
+      - name: Finalize release commit, push, and create GitHub release
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.KAJABI_CI_GH_TOKEN }}
         run: |
           set -euo pipefail
-          git pull --rebase --autostash
-          rm -rf node_modules
-          if npm ci --ignore-scripts; then
-            echo "Lockfile is npm-ci compatible. No heal needed."
+          git fetch origin main
+          git pull --rebase --autostash origin main
+
+          if git merge-base --is-ancestor HEAD origin/main; then
+            echo "Release did not create a new commit; nothing to finalize."
             exit 0
           fi
-          echo "::warning::Lockfile drifted during release — regenerating."
+
+          VERSION=$(node -p "require('./libs/core/package.json').version")
+          TAG="v${VERSION}"
+          COMMIT_MSG="chore(release): release ${VERSION}"
+
+          rm -rf node_modules
           npm install --ignore-scripts
-          if git diff --quiet -- package-lock.json; then
-            echo "::error::Regenerated lockfile is identical to the broken one; aborting to avoid an infinite heal loop."
-            exit 1
+
+          NEEDS_AMEND=false
+          if ! git diff --quiet -- package-lock.json; then
+            git add package-lock.json
+            NEEDS_AMEND=true
           fi
-          # Verify the regenerated lockfile actually passes npm ci before
-          # pushing — otherwise we could ship a different-but-still-broken
-          # lockfile that keeps feature branches red.
+          if [[ "$(git log -1 --format=%s)" != "$COMMIT_MSG" ]]; then
+            NEEDS_AMEND=true
+          fi
+          if [[ "$NEEDS_AMEND" == "true" ]]; then
+            git commit --amend -m "$COMMIT_MSG"
+          fi
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag -f "$TAG"
+            TAG_FORCE_PUSH=true
+          else
+            git tag "$TAG"
+            TAG_FORCE_PUSH=false
+          fi
+
           rm -rf node_modules
           if ! npm ci --ignore-scripts; then
-            echo "::error::Regenerated lockfile still fails npm ci — aborting heal without pushing."
+            echo "::error::Lockfile still fails npm ci after regeneration."
             exit 1
           fi
-          git add package-lock.json
-          # Use chore: so the next nx release run does not treat the heal as a
-          # bug fix and trigger another patch version bump for plumbing.
-          git commit -m "chore: sync package-lock.json after release"
-          git push
+
+          git push origin HEAD:main
+          if [[ "$TAG_FORCE_PUSH" == "true" ]]; then
+            git push origin "$TAG" --force
+          else
+            git push origin "$TAG"
+          fi
+
+          NOTES_FILE=$(mktemp)
+          trap 'rm -f "$NOTES_FILE"' EXIT
+          awk -v ver="$VERSION" '/^## / { if (found) exit; if ($2 == ver) found=1; next } found { print }' CHANGELOG.md > "$NOTES_FILE"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            if [[ -s "$NOTES_FILE" ]]; then
+              gh release edit "$TAG" --title "$TAG" --notes-file "$NOTES_FILE"
+            else
+              echo "::warning::No changelog section found for ${VERSION}; leaving existing release notes."
+            fi
+          elif [[ -s "$NOTES_FILE" ]]; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES_FILE"
+          else
+            echo "::warning::No changelog section found for ${VERSION}; using generated notes."
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
 
   send-slack-notification:
     runs-on: ubuntu-latest

--- a/nx.json
+++ b/nx.json
@@ -32,7 +32,7 @@
   "release": {
     "changelog": {
       "workspaceChangelog": {
-        "createRelease": "github"
+        "createRelease": false
       }
     },
     "conventionalCommits": {
@@ -93,7 +93,11 @@
     "projects": ["libs/*"],
     "version": {
       "conventionalCommits": true,
-      "preVersionCommand": "npx nx run-many -t build"
+      "preVersionCommand": "npx nx run-many -t build",
+      "generatorOptions": {
+        "installIgnoreScripts": true,
+        "skipLockFileUpdate": true
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Stop `nx release` from pushing a broken `package-lock.json` by setting `skipLockFileUpdate: true` and `createRelease: false` so release commits locally only
- Replace the post-push self-heal step with a finalize step that regenerates the lockfile, amends it into the release commit, sets an explicit commit message, verifies `npm ci`, then pushes once
- Create GitHub releases via `gh` in the workflow using the matching CHANGELOG section

Fixes the release pipeline issues where main briefly failed CI after release (`npm ci` lockfile drift) and where no-op releases produced commits with literal `{version}` in the message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [ ] Merge and trigger the next scheduled/manual release workflow run
- [ ] Confirm finalize step amends lockfile into the release commit (no follow-up `chore: sync package-lock.json` commit)
- [ ] Confirm release commit message is `chore(release): release X.Y.Z` (not `{version}`)
- [ ] Confirm Pine Framework Build passes `npm ci` on the release commit on first push
- [ ] Confirm GitHub release is created with CHANGELOG notes
- [ ] Confirm npm packages publish successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production release pipeline (push timing, tags, GitHub releases); mistakes could block releases or publish inconsistent lockfiles, though `npm ci` is verified before push.
> 
> **Overview**
> **Release flow is reworked** so `nx release` only creates a local commit: GitHub releases from Nx are disabled, and version bump no longer rewrites `package-lock.json` during the release generator.
> 
> The scheduled release workflow **replaces the post-push lockfile self-heal** with a single **finalize** step that regenerates the lockfile, amends it (and the commit message) into the release commit, runs `npm ci` before pushing, pushes `main` and the version tag once, then creates or updates the GitHub release from the matching `CHANGELOG.md` section via `gh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b781fb2f64bb52a6d12cd345775431ed0abbd62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->