### PR TITLE
style: adopt background-overlay token for overlay panel surfaces

### DIFF
--- a/libs/core/src/components/pds-combobox/pds-combobox-dropdown-panel.scss
+++ b/libs/core/src/components/pds-combobox/pds-combobox-dropdown-panel.scss
@@ -1,6 +1,6 @@
 @mixin pds-combobox-dropdown-panel {
   .pds-combobox__listbox {
-    background: var(--pine-color-background-container);
+    background: var(--pine-color-background-overlay);
     border: 0;
     border-radius: var(--pine-dimension-125);
     box-shadow: var(--pine-box-shadow);

--- a/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
+++ b/libs/core/src/components/pds-dropdown-menu/pds-dropdown-menu.scss
@@ -7,7 +7,7 @@
 }
 
 .pds-dropdown-menu--panel {
-  background-color: var(--pine-color-background-container);
+  background-color: var(--pine-color-background-overlay);
   border-radius: var(--pine-dimension-xs);
   left: var(--pine-dimension-none);
   min-width: 170px;

--- a/libs/core/src/components/pds-filters/pds-filter/pds-filter.scss
+++ b/libs/core/src/components/pds-filters/pds-filter/pds-filter.scss
@@ -160,7 +160,7 @@
 
 
 .pds-filter__popover {
-  background-color: var(--pine-color-background-container);
+  background-color: var(--pine-color-background-overlay);
   border: 0;
   border-radius: var(--pine-dimension-100);
   box-shadow: var(--pine-box-shadow-100);

--- a/libs/core/src/components/pds-modal/pds-modal.scss
+++ b/libs/core/src/components/pds-modal/pds-modal.scss
@@ -39,7 +39,7 @@
 }
 
 .pds-modal {
-  background: var(--pine-color-background-container);
+  background: var(--pine-color-background-overlay);
   border-radius: var(--pine-dimension-sm);
   box-shadow: var(--pine-box-shadow-400);
   display: flex;

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -173,7 +173,7 @@
 }
 
 .pds-multiselect__panel {
-  background: var(--pine-color-background-container);
+  background: var(--pine-color-background-overlay);
   border-radius: var(--pine-dimension-125);
   box-shadow: var(--pine-box-shadow);
   box-sizing: border-box;

--- a/libs/core/src/components/pds-popover/pds-popover.tsx
+++ b/libs/core/src/components/pds-popover/pds-popover.tsx
@@ -247,7 +247,7 @@ export class PdsPopover {
     this.portalEl.style.display = 'none';
     this.portalEl.style.opacity = '0';
     this.portalEl.style.visibility = 'hidden';
-    this.portalEl.style.backgroundColor = 'var(--pine-color-background-container)';
+    this.portalEl.style.backgroundColor = 'var(--pine-color-background-overlay)';
     this.portalEl.style.borderRadius = 'var(--pine-dimension-125)';
     this.portalEl.style.boxShadow = 'var(--pine-box-shadow-200)';
     this.portalEl.style.margin = 'var(--pine-dimension-none)';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
-        "@kajabi-ui/styles": "^1.3.0",
+        "@kajabi-ui/styles": "^1.4.0",
         "@nx/devkit": "20.4.6",
         "@nx/js": "20.4.6",
         "@size-limit/file": "^11.1.6",
@@ -4672,9 +4672,9 @@
       }
     },
     "node_modules/@kajabi-ui/styles": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@kajabi-ui/styles/-/styles-1.3.0.tgz",
-      "integrity": "sha512-sMXp1cMrUWx8KRlJxieFNBJW3rfXwarUSyilmIIbkfFD4iZRpBk5pW9XI9BvqUARa+xNp9/CqNu8AlsvzBq77Q=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kajabi-ui/styles/-/styles-1.4.0.tgz",
+      "integrity": "sha512-N9Oc32d2wJRTWmOEyFjTpP8OGeqHBT0mtiM86F7JCjxKN3Kgs5xwIgqPkKkgTfGrNW/AcMiMteZsp9G5yIIgLw=="
     },
     "node_modules/@lerna/create": {
       "version": "8.2.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
-    "@kajabi-ui/styles": "^1.3.0",
+    "@kajabi-ui/styles": "^1.4.0",
     "@nx/devkit": "20.4.6",
     "@nx/js": "20.4.6",
     "@size-limit/file": "^11.1.6",


### PR DESCRIPTION
## Summary

- Bumps `@kajabi-ui/styles` to `^1.4.0` to pick up the new `color.background.overlay` semantic token ([ds-tokens#43](https://github.com/Kajabi/ds-tokens/pull/43))
- Updates floating overlay panel surfaces from `--pine-color-background-container` to `--pine-color-background-overlay` in modal, dropdown menu, combobox listbox, popover, multiselect panel, and filter popover
- In dark mode, overlay panels now use grey-900 instead of black, keeping them visually distinct from page backgrounds

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Test plan

- [x] unit tests — `npx nx run @pine-ds/core:test` passes locally
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually — verify overlay panels in light and dark mode (modal, dropdown, combobox, popover, multiselect, filter)
- [ ] other:

**Test Configuration**:

- Pine versions: branch build against `@kajabi-ui/styles@1.4.0`
- OS: macOS
- Browsers: Chrome
- Screen readers: n/a
- Misc: Form field triggers (combobox input, multiselect trigger) intentionally unchanged — still use `background-container`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual token swap on overlay styling only; no logic, API, or security-sensitive changes.
> 
> **Overview**
> Bumps **`@kajabi-ui/styles`** to **`^1.4.0`** so Pine can use the new **`color.background.overlay`** semantic token.
> 
> **Floating overlay surfaces** (modal dialog, dropdown menu panel, combobox listbox, multiselect dropdown panel, filter popover, and popover portal) now use **`--pine-color-background-overlay`** instead of **`--pine-color-background-container`**. Inline controls such as combobox inputs, multiselect triggers, and filter triggers are **unchanged** and still use the container token.
> 
> In **dark mode**, overlays should read more clearly against page backgrounds (e.g. grey-900 vs black) without changing layout or behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1976b5e423e36dd8b30be07d24746488ef9bf287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->