### PR TITLE
style(status-badge): fix washed-out badge contrast in dark mode

### DIFF
--- a/libs/core/src/stories/_helpers/StatusBadge.css
+++ b/libs/core/src/stories/_helpers/StatusBadge.css
@@ -54,3 +54,31 @@
   --pine-status-badge-fg: var(--pine-color-text-warning);
   --pine-status-badge-dot: var(--pine-color-warning-hover);
 }
+
+/*
+ * Dark mode. The semantic status tints (`*-disabled` backgrounds, `text-*`,
+ * `*-hover`) don't flip between themes, so without these overrides the badge
+ * keeps its light-page pill (e.g. pale green-100) on a dark surface — washed
+ * out and low contrast. Invert each status the way pds-alert does in dark
+ * mode: a dark `*-900` background with light `*-100` text and a bright `*-400`
+ * dot. Storybook sets `data-theme="dark"` on the document, and the badge is
+ * light-DOM, so the attribute selector matches an ancestor.
+ */
+[data-theme='dark'] .pine-status-badge[data-status='stable'] {
+  --pine-status-badge-bg: var(--pine-color-green-900);
+  --pine-status-badge-fg: var(--pine-color-green-100);
+  --pine-status-badge-dot: var(--pine-color-green-400);
+}
+
+[data-theme='dark'] .pine-status-badge[data-status='beta'],
+[data-theme='dark'] .pine-status-badge[data-status='unknown'] {
+  --pine-status-badge-bg: var(--pine-color-yellow-900);
+  --pine-status-badge-fg: var(--pine-color-yellow-100);
+  --pine-status-badge-dot: var(--pine-color-yellow-400);
+}
+
+[data-theme='dark'] .pine-status-badge[data-status='deprecated'] {
+  --pine-status-badge-bg: var(--pine-color-red-900);
+  --pine-status-badge-fg: var(--pine-color-red-100);
+  --pine-status-badge-dot: var(--pine-color-red-400);
+}


### PR DESCRIPTION
# Description

In dark mode the component **status badge** (the `Stable` / `Beta` / `Deprecated` pill at the top of each component's docs page) rendered as a bright, light-mode pill on the dark surface — washed out with poor text contrast.

**Cause:** `StatusBadge.css` colored the badge with semantic status tokens (`--pine-color-success-disabled` background, `--pine-color-text-success` text, `--pine-color-success-hover` dot, and the warning/danger equivalents). Those status *tints* are identical in `:root` and `[data-theme="dark"]` in `@kajabi-ui/styles` (e.g. `--pine-color-success-disabled` resolves to `green-100` in both themes), so the badge kept its light-page styling on a dark background.

**Fix:** Added a `[data-theme="dark"]` block that inverts each status — mirroring how `pds-alert` handles dark mode — using a dark `*-900` background, near-white `*-100` text, and a bright `*-400` dot for `stable`, `beta`/`unknown`, and `deprecated`. Light mode is unchanged.

| Before | After |
|--------|--------|
|<img width="895" height="433" alt="Screenshot 2026-06-05 at 2 54 32 PM" src="https://github.com/user-attachments/assets/c094d208-9ce8-4752-983e-5088bf4a33c6" />|<img width="672" height="410" alt="Screenshot 2026-06-05 at 2 54 17 PM" src="https://github.com/user-attachments/assets/2cefdf4e-cdc1-49af-bcf0-8699a3fd7c2f" />| 

No new dependencies.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually
- [x] other: rendered the real `pine.css` + updated `StatusBadge.css` in headless Chrome with `data-theme="dark"` and confirmed all four statuses (`Stable`, `Beta`, `Deprecated`, `Unknown`) show high-contrast dark pills with legible white text, while light mode is visually unchanged. `stylelint` passes (all colors use `--pine-color-*` tokens).

**Test Configuration**:

- Pine versions: main (latest)
- OS: macOS
- Browsers: Chromium (headless)
- Screen readers: n/a
- Misc: change is docs-only (Storybook `StatusBadge` helper)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only Storybook helper CSS with no runtime component or auth/data impact.
> 
> **Overview**
> Fixes **Storybook component status badges** (`Stable` / `Beta` / `Deprecated` / `Unknown`) looking like light-mode pills on dark docs pages.
> 
> Adds **`[data-theme='dark']` overrides** in `StatusBadge.css` that swap the semantic status tokens (which stay light-tinted in both themes) for inverted palette tokens: dark `*-900` backgrounds, light `*-100` text, and `*-400` dots—aligned with how **`pds-alert`** handles dark mode. **Light mode is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347326cea033d310f98d7dff2f67f5090bcecca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->