### PR TITLE
style(doc-components): scope args-table section background to .args-section

### DIFF
--- a/libs/doc-components/src/components/docArgsTable/docArgsTable.css
+++ b/libs/doc-components/src/components/docArgsTable/docArgsTable.css
@@ -73,7 +73,7 @@
   }
 }
 
-section {
+.args-section {
   background-color: var(--doc-canvas-green);
   border: 1px solid var(--doc-canvas-border-color);
   box-shadow: -1px 0 3px var(--doc-canvas-shadow);


### PR DESCRIPTION
# Linear Ticket

FIXES [DSS-206](https://linear.app/kajabi/issue/DSS-206/storybook-resourcespatterns-page-renders-with-a-green-background)

# Description

Fixes the unexpected **green background** on the Storybook **Resources → Patterns** docs page (and the related "background changes when hovering sidebar nav items" behavior).

**Root cause:** `libs/doc-components/src/components/docArgsTable/docArgsTable.css` contained a global, unscoped element selector:

```css
section {
  background-color: var(--doc-canvas-green); /* #628b83 */
  color: #fff; letter-spacing: 0.35em; ...
}
```

### Screenshots
|  Before   |  After  |
|--------|--------|
|<img width="1070" height="1099" alt="Screenshot 2026-06-05 at 3 24 43 PM" src="https://github.com/user-attachments/assets/eea1d76f-23a4-4d3b-a00f-6e36782f6fc8" />|<img width="1120" height="1170" alt="Screenshot 2026-06-05 at 3 38 11 PM" src="https://github.com/user-attachments/assets/f0383684-3be8-4b95-af78-a1322062dec5" />|

It was only ever meant for the args-table header rows, which `DocArgsTable` renders as `<section className="args-section">` (the PROPERTIES / EVENTS / METHODS labels). As a bare `section` selector, though, it painted **every** `<section>` on any page where the stylesheet was loaded.

The Resources page wraps each pattern in a plain `<section>` (`libs/core/src/stories/_helpers/PatternCatalog.tsx`), and it pulls in `docArgsTable.css` purely as a **barrel side-effect** — `PatternCatalog` imports `{ DocCanvas }` from `@pine-ds/doc-components`, whose barrel `export * from './docArgsTable'` evaluates `docArgsTable.tsx`'s `import './docArgsTable.css'`. So the pattern wrappers turned green.

**Why it looked hover-triggered:** Storybook's preview is a single shared document and injects story CSS lazily during sidebar navigation/prefetch. The moment `docArgsTable.css` landed in that shared `<head>`, it retroactively repainted the already-rendered Resources sections. The defect was the unscoped selector, not the hover.

**Why component args-table pages never showed it:** on those pages the only `<section>` elements were the `.args-section` header rows, which were *supposed* to be green — so the overreaching selector coincided with the intended target and the bug stayed invisible. The Resources page was the first to put an unrelated `<section>` on a page where this stylesheet loads.

**Fix (one line):** scope the rule to the class the element already has — `section` → `.args-section`.

Specificity is preserved, so the args table renders identically: `.args-table section { display: grid }` (0,2,0) still outranks `.args-section` (0,1,0), so the args-table layout is untouched while the green header background is retained. (Scoping to `.args-table section` was deliberately avoided — it would tie specificity and flip the table to `display: flex`.)

No new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] tested manually

Verified in a running Storybook (localhost:6006) by inspecting the preview iframe's CSSOM:

- All 8 `<section>` wrappers on the Resources/Patterns page now compute to `background-color: rgba(0, 0, 0, 0)` (transparent) with `letter-spacing: normal` — **while `docArgsTable.css` is confirmed loaded in that document** (the exact condition that previously triggered green), proving the leak is closed rather than hidden.
- The leaking bare `section` green rule no longer exists in the CSSOM; the green now lives only on the scoped `.args-section` rule.
- Intended styling preserved: component args-table pages (e.g. `pds-button`) retain green PROPERTIES/EVENTS section headers, guaranteed by the scoped selector + specificity above.
- `npx nx run @pine-ds/doc-components:lint` passes; lefthook hooks pass on commit.

**Test Configuration**:

- Pine versions: `@pine-ds/doc-components` (monorepo source, aliased into Storybook)
- OS: macOS
- Browsers: Chrome
- Misc: Storybook dev server, `libs/core` aliases `@pine-ds/doc-components` to source so no rebuild is needed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-selector CSS scoping fix in doc-components styling with no logic or API changes.
> 
> **Overview**
> Fixes unintended green styling on Storybook pages (e.g. **Resources → Patterns**) by scoping the args-table header styles in `docArgsTable.css` from a global `section` selector to **`.args-section`**.
> 
> That stylesheet can load on unrelated docs via `@pine-ds/doc-components` barrel side-effects, so the bare `section` rule was painting every `<section>` on the page. Args-table **PROPERTIES / EVENTS / METHODS** headers still use `<section className="args-section">`, so their green header look is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c982760f1a42476fc269e40aadb45e1ce10db1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->