### PR TITLE
chore: pin @kajabi-ui/styles to ^1.4.0 in published packages

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.0",
-    "@kajabi-ui/styles": "*",
+    "@kajabi-ui/styles": "^1.4.0",
     "@pine-ds/icons": "*",
     "@stencil/core": "4.43.5",
     "@types/dompurify": "^3.0.5",

--- a/libs/react/package.json
+++ b/libs/react/package.json
@@ -37,7 +37,7 @@
     "tsc": "tsc -p ."
   },
   "dependencies": {
-    "@kajabi-ui/styles": "*",
+    "@kajabi-ui/styles": "^1.4.0",
     "@pine-ds/core": "^3.26.4",
     "@pine-ds/icons": "*",
     "tslib": "*"


### PR DESCRIPTION
# Description

The published packages `@pine-ds/core` (`libs/core`) and `@pine-ds/react` (`libs/react`) depend on `@kajabi-ui/styles` with a wildcard `"*"` range. This means any consumer (kajabi-products and other apps) silently pulls *whatever* the latest published token version is, with no upper bound and no ability to pin a known-good token version through Pine. A breaking or regressing token release can reach every consumer with no version gate.

This pins both to `^1.4.0` — the current published version, and the same range the root `package.json` already uses. Caret keeps automatic minor/patch intake while restoring an explicit, pinnable contract.

No code or runtime behavior changes; tokens are consumed at runtime as CSS custom properties either way.

Note: `@pine-ds/icons` is also still wildcard `"*"` in both packages — same argument applies, but left out to keep this PR tightly scoped. Worth a follow-up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] other: dependency-range-only change. CI build + existing spec/e2e suites exercise that Pine still builds and renders against `@kajabi-ui/styles@^1.4.0`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only dependency range change with no code or runtime behavior changes; it reduces unbounded token drift for consumers.
> 
> **Overview**
> Published **`@pine-ds/core`** and **`@pine-ds/react`** no longer declare `@kajabi-ui/styles` as `"*"`. Both now depend on **`^1.4.0`**, matching the root workspace range.
> 
> That gives consumers a bounded, pinnable contract on design tokens while still allowing compatible minor/patch updates. No application or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d40c816a1f5b8cf8f7d763d81ce2b826704b7a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->