### PR TITLE
chore: pin @pine-ds/icons to ^10.0.0 in published packages

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.7.0",
     "@kajabi-ui/styles": "*",
-    "@pine-ds/icons": "*",
+    "@pine-ds/icons": "^10.0.0",
     "@stencil/core": "4.43.5",
     "@types/dompurify": "^3.0.5",
     "dompurify": "^3.2.6",

--- a/libs/react/package.json
+++ b/libs/react/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@kajabi-ui/styles": "*",
     "@pine-ds/core": "^3.26.4",
-    "@pine-ds/icons": "*",
+    "@pine-ds/icons": "^10.0.0",
     "tslib": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Follow-up to #769 (which pinned `@kajabi-ui/styles`). Same issue, same fix, separate PR for clean review.

`@pine-ds/core` (`libs/core`) and `@pine-ds/react` (`libs/react`) depend on `@pine-ds/icons` with a wildcard `"*"` range. Consumers silently pull whatever icon version is latest, with no upper bound and no pinnable contract through Pine — an icon-package release can reach every consumer with no version gate.

Pins both to `^10.0.0` (current published version). Caret keeps automatic minor/patch intake while restoring an explicit range.

No code or runtime behavior changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] other: dependency-range-only change; CI build + existing suites exercise that Pine builds against `@pine-ds/icons@^10.0.0`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency manifest-only change with no runtime or logic edits; risk is limited to install resolution staying within ^10.x for icons.
> 
> **Overview**
> Pins **`@pine-ds/icons`** from wildcard **`"*"`** to **`^10.0.0`** in **`@pine-ds/core`** and **`@pine-ds/react`** so consumers get an explicit semver contract instead of silently resolving the latest icons release.
> 
> No application or component code changes; only **`libs/core/package.json`** and **`libs/react/package.json`** dependency ranges are updated, mirroring the earlier **`@kajabi-ui/styles`** pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08dfef2255fde218ebe8f24efaeb51cb7b5c3afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->