### PR TITLE
docs: add versioning and deprecation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,10 @@ git rebase main
 
 The branch can now be pushed. When creating your pull request, please fill out the template with as much info as necessary, including before and after screenshots. Please tag `Kajabi/dss-devs` to notify the Design System team. Our standards require at least two accepted reviews before merging.
 
+## Versioning & Deprecation
+
+Pine's component API is a public contract. Before removing, renaming, or changing the default of a prop, event, method, slot, or documented `--pds-*` custom property, read [VERSIONING.md](./VERSIONING.md) — it defines what counts as a breaking change and how to deprecate (mark `@deprecated`, keep it working, remove only in a major with a migration note).
+
 ## Architecture Decisions
 
 Significant, long-lived decisions are recorded as [Architecture Decision Records](./docs/adr/README.md) under `docs/adr/`. Read the index before proposing changes that reshape architecture, lock in conventions, or trade off something material — and add a new ADR in the same PR if your change qualifies.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,105 @@
+# Versioning & deprecation policy
+
+Pine's published packages (`@pine-ds/core`, `@pine-ds/react`) are consumed by
+kajabi-products and other apps that upgrade on their own schedule. The component
+API is a **public contract**. This document defines what counts as a breaking
+change, how we deprecate, and how releases are cut.
+
+We follow [Semantic Versioning](https://semver.org/). For the token side of the
+system, see the matching policy in the [`ds-tokens`](https://github.com/Kajabi/ds-tokens) repo.
+
+## What is the public API?
+
+The contract a consumer can rely on:
+
+- **Component tags** (`pds-*`) and their existence.
+- **Props, events, methods, and named slots** on each component.
+- **Exported TypeScript types** (event detail interfaces, prop unions, etc.).
+- **Public CSS custom properties** — the `--pds-*` host variables a component
+  documents for theming/overrides.
+- **The React wrappers** in `@pine-ds/react` (generated from core, so they track
+  the same surface).
+
+Not part of the contract: `_internal/` sub-components, `src/utils/` helpers,
+generated files, and anything not exported or documented.
+
+## What each version level means
+
+### MAJOR — breaking, requires a migration note
+- **Removing** a component, prop, event, method, or named slot.
+- **Renaming** any of the above (remove + add — deprecate first; see below).
+- **Changing a default** in a way that changes rendered behavior.
+- **Changing or removing a documented `--pds-*` custom property** consumers style against.
+- **Dropping a framework target** or changing package entry points/exports.
+
+### MINOR — additive, backward compatible
+- **Adding** a component, prop, event, method, or slot.
+- Adding a new documented custom property or variant.
+
+### PATCH — fixes & internals
+- Bug fixes that don't change the API surface.
+- Internal refactors, SCSS/visual fixes that don't alter documented behavior.
+- Docs, tests, tooling.
+
+When in doubt, size up. Shipping a breaking change as a minor is far more
+expensive for consumers than an over-cautious major.
+
+## Deprecation — prefer it over removal
+
+This codifies the convention Pine already follows (see live examples below).
+Don't remove or rename a public API in place. Instead:
+
+1. **Mark it deprecated in JSDoc** on the `@Prop` / `@Event` / `@Method`, pointing
+   to the replacement:
+   ```ts
+   /**
+    * Determines whether the chip should be displayed in a larger size.
+    * @deprecated Use `size` prop instead. Set `size="lg"` for the large variant.
+    */
+   @Prop() large = false;
+   ```
+2. **Keep it functional** — a deprecated prop must still work for the whole
+   deprecation window so consumers can upgrade without breaking.
+3. **Rebuild** (`npx nx run @pine-ds/core:build`) so the generated `readme.md` and
+   types pick up the `@deprecated` tag. Stencil renders it as a
+   **[DEPRECATED]** marker in the component's docs automatically — don't hand-edit
+   generated files.
+4. **Remove only in a subsequent major**, with a migration note.
+
+Live examples of this pattern in the codebase:
+
+| Component | Deprecated | Replacement |
+| --- | --- | --- |
+| `pds-chip` | `large` prop | `size="lg"` |
+| `pds-button` | `icon` prop | `start` slot |
+| `pds-link` | `external` prop | `target` prop |
+
+## Migration notes
+
+Every breaking change ships with a migration note (in the PR description, carried
+into `CHANGELOG.md`) containing what was removed/renamed, the replacement, and a
+before/after snippet:
+
+```
+### Breaking
+- Removed deprecated `large` prop from `pds-chip`.
+  Migrate: replace `<pds-chip large>` with `<pds-chip size="lg">`.
+```
+
+## How releases are cut
+
+- **Trigger:** maintainers run the release workflow manually
+  (`workflow_dispatch`) — releases are intentional, not automatic on merge.
+- **Version:** Nx Release computes the bump from the Conventional Commits since the
+  last release (`feat` → minor, `fix` → patch, `feat!`/`BREAKING CHANGE:` →
+  major). Writing the right commit type is part of getting the version right.
+- **Publish:** to npm with provenance (`NPM_CONFIG_PROVENANCE: true`); the version
+  commit and tag are pushed by CI.
+- **Changelog:** `CHANGELOG.md` is generated from commit history; migration notes
+  for breaking changes should be reflected there.
+
+## Consumer guidance
+
+- Pin real ranges (`^3.x`), not `*`, so a release lands on your schedule.
+- Read the changelog before a minor/major bump; watch for **[DEPRECATED]** markers
+  in component docs and migrate ahead of the eventual major.


### PR DESCRIPTION
# Description

From the engineering-health audit: Pine scored well on most dimensions but had no written **versioning or deprecation policy**. The component API (`@pine-ds/core` / `@pine-ds/react`) is a public contract consumed by kajabi-products and other apps, yet there was no documented answer to "what counts as a breaking change?" or "how do I deprecate a prop?".

Notably, **Pine already deprecates props** via JSDoc `@deprecated` (live in `pds-chip` `large`, `pds-button` `icon`, `pds-link` `external`) — the practice exists but was never written down. This codifies the existing convention rather than inventing a new one.

## What this adds

- **`VERSIONING.md`** — defines the public API surface (tags, props/events/methods/slots, exported types, documented `--pds-*` custom properties, the generated React wrappers), the SemVer rules for each (MAJOR/MINOR/PATCH), the deprecation workflow (mark `@deprecated` → keep functional → rebuild so the generated `readme.md` shows **[DEPRECATED]** → remove only in a major), a migration-note format, and how releases are cut (Nx Release, Conventional Commits, provenance).
- **`CONTRIBUTING.md`** — adds a short "Versioning & Deprecation" section pointing at it, beside the existing Architecture Decisions section.

Mirrors the structure of the `ds-tokens` `VERSIONING.md` for cross-repo consistency.

## Type of change

- [x] This change requires a documentation update (docs-only)

# How Has This Been Tested?

- [x] other: docs-only. Verified the `@deprecated` examples cited are real and that Stencil surfaces them as **[DEPRECATED]** in generated `readme.md` (confirmed in `pds-chip/readme.md`).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, build, or package behavior changes.
> 
> **Overview**
> Adds a written **versioning and deprecation policy** for Pine’s public component API, plus a contributor pointer so API changes follow it before merge.
> 
> **`VERSIONING.md`** defines what counts as the public contract (`pds-*` tags, props/events/methods/slots, exported types, documented `--pds-*` vars, `@pine-ds/react`), SemVer rules for MAJOR/MINOR/PATCH, the deprecation flow (JSDoc `@deprecated` → keep working → rebuild for generated **[DEPRECATED]** docs → remove only in a major with a migration note), migration-note format, release cutting (manual workflow, Nx Release + Conventional Commits, npm provenance), and consumer upgrade guidance. It explicitly codifies patterns already used in components like `pds-chip`, `pds-button`, and `pds-link`.
> 
> **`CONTRIBUTING.md`** gains a **Versioning & Deprecation** section linking to that doc, placed next to Architecture Decisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f320069c162f175141f668d09a5563250e0b0b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->