### PR TITLE
fix(pds-text): warn on invalid size prop values

### DIFF
--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -14,6 +14,12 @@ export class PdsText {
   @Element() el: HTMLPdsTextElement;
   private contentEl: HTMLElement;
   private truncationCleanup: (() => void) | null = null;
+  // Runtime-readable copy of the `size` union (TS types are erased at runtime).
+  // Kept next to the @Prop below so the two stay in sync.
+  private static readonly VALID_SIZES = [
+    '2xl', 'xl', 'lg', 'md', 'sm', 'xs', '2xs',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  ];
   /**
    * Sets the text alignment.
    */
@@ -56,6 +62,19 @@ export class PdsText {
     | 'h4'
     | 'h5'
     | 'h6';
+
+  @Watch('size')
+  validateSize(newValue?: string) {
+    if (
+      newValue !== undefined &&
+      newValue.trim() !== '' &&
+      !PdsText.VALID_SIZES.includes(newValue)
+    ) {
+      console.warn(
+        `pds-text: invalid size "${newValue}". Valid values are: ${PdsText.VALID_SIZES.join(', ')}.`,
+      );
+    }
+  }
 
   /**
    * Sets the font weight.
@@ -102,6 +121,7 @@ export class PdsText {
   }
 
   componentDidLoad() {
+    this.validateSize(this.size);
     if (this.truncate) {
       this.initTruncationTooltip();
     }

--- a/libs/core/src/components/pds-text/pds-text.tsx
+++ b/libs/core/src/components/pds-text/pds-text.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, Element, Watch } from '@stencil/core';
 import { setColor } from '../../utils/utils';
 import { setupTruncationTooltip } from '../../utils/truncation-tooltip';
+import { TEXT_SIZES, TextSizeType } from '../../utils/types';
 
 /**
  * @part content - The text content container
@@ -14,12 +15,6 @@ export class PdsText {
   @Element() el: HTMLPdsTextElement;
   private contentEl: HTMLElement;
   private truncationCleanup: (() => void) | null = null;
-  // Runtime-readable copy of the `size` union (TS types are erased at runtime).
-  // Kept next to the @Prop below so the two stay in sync.
-  private static readonly VALID_SIZES = [
-    '2xl', 'xl', 'lg', 'md', 'sm', 'xs', '2xs',
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  ];
   /**
    * Sets the text alignment.
    */
@@ -48,33 +43,7 @@ export class PdsText {
   /**
    * Sets the font size.
    */
-  @Prop() size?:
-    | '2xl'
-    | 'xl'
-    | 'lg'
-    | 'md'
-    | 'sm'
-    | 'xs'
-    | '2xs'
-    | 'h1'
-    | 'h2'
-    | 'h3'
-    | 'h4'
-    | 'h5'
-    | 'h6';
-
-  @Watch('size')
-  validateSize(newValue?: string) {
-    if (
-      newValue !== undefined &&
-      newValue.trim() !== '' &&
-      !PdsText.VALID_SIZES.includes(newValue)
-    ) {
-      console.warn(
-        `pds-text: invalid size "${newValue}". Valid values are: ${PdsText.VALID_SIZES.join(', ')}.`,
-      );
-    }
-  }
+  @Prop() size?: TextSizeType;
 
   /**
    * Sets the font weight.
@@ -120,8 +89,30 @@ export class PdsText {
     }
   }
 
-  componentDidLoad() {
+  @Watch('size')
+  validateSize(newValue?: string) {
+    // Skip when the prop is omitted or explicitly cleared (an empty string is a
+    // common "unset" sentinel). Any other unsupported value — including a
+    // whitespace-only string — is a developer mistake worth warning about.
+    if (newValue === undefined || newValue === '') {
+      return;
+    }
+
+    if (!(TEXT_SIZES as readonly string[]).includes(newValue)) {
+      const display = newValue.length > 80 ? `${newValue.slice(0, 80)}…` : newValue;
+      console.warn(
+        `pds-text: invalid size "${display}". Valid values are: ${TEXT_SIZES.join(', ')}.`,
+      );
+    }
+  }
+
+  componentWillLoad() {
+    // Validate the initial value before the first render so the warning precedes
+    // any attempt to apply an unknown size class. @Watch covers later changes.
     this.validateSize(this.size);
+  }
+
+  componentDidLoad() {
     if (this.truncate) {
       this.initTruncationTooltip();
     }

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -276,5 +276,35 @@ describe('pds-text', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid size "body-md"'));
     });
+
+    it('does not warn for an empty size value', async () => {
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="">Hi</pds-text>`,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns for a whitespace-only size value', async () => {
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="   ">Hi</pds-text>`,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid size'));
+    });
+
+    it('truncates an excessively long invalid size value in the warning', async () => {
+      const longValue = 'x'.repeat(200);
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="${longValue}">Hi</pds-text>`,
+      });
+
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('…');
+      expect(message).not.toContain('x'.repeat(81));
+    });
   });
 });

--- a/libs/core/src/components/pds-text/test/pds-text.spec.tsx
+++ b/libs/core/src/components/pds-text/test/pds-text.spec.tsx
@@ -225,4 +225,56 @@ describe('pds-text', () => {
     const contentEl = page.root!.shadowRoot!.querySelector('[part="content"]') as HTMLElement;
     expect(contentEl.getAttribute('tabindex')).toBeNull();
   });
+
+  describe('size validation', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns when size is not a supported value', async () => {
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="body-sm">Hi</pds-text>`,
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid size "body-sm"'));
+    });
+
+    it('does not warn for a supported size value', async () => {
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="lg">Hi</pds-text>`,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when size is not set', async () => {
+      await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text>Hi</pds-text>`,
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('warns when size is updated to an invalid value', async () => {
+      const page = await newSpecPage({
+        components: [PdsText],
+        html: `<pds-text size="lg">Hi</pds-text>`,
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      page.rootInstance.size = 'body-md';
+      await page.waitForChanges();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid size "body-md"'));
+    });
+  });
 });

--- a/libs/core/src/utils/types.ts
+++ b/libs/core/src/utils/types.ts
@@ -83,3 +83,24 @@ export type ChipVariantType =
   'text'
   | 'tag'
   | 'dropdown';
+
+// Single source of truth for `pds-text` `size` values. The `as const` tuple is
+// readable at runtime (for validation) and `TextSizeType` is derived from it,
+// so the supported list and the prop type cannot drift apart.
+export const TEXT_SIZES = [
+  '2xl',
+  'xl',
+  'lg',
+  'md',
+  'sm',
+  'xs',
+  '2xs',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+] as const;
+
+export type TextSizeType = (typeof TEXT_SIZES)[number];


### PR DESCRIPTION
# Description

`pds-text` accepts a fixed set of `size` values (`2xl xl lg md sm xs 2xs h1 h2 h3 h4 h5 h6`). When an unsupported value is passed (e.g. `body-sm`, `body-md`), the component generates a non-existent class (`pds-text--size-body-sm`) that has no matching SCSS, so the value **silently does nothing** — it neither errors nor falls back visibly. This let invalid values propagate undetected across a consuming app for months.

This adds dev-time runtime validation: if `size` is set to a value outside the supported set, the component logs a `console.warn` naming the bad value and listing the valid ones. The element still renders (warning, not a throw), so production behavior is unchanged.

This complements compile-time TS typing — it catches cases where `pds-text` is used as a raw custom element or fed a `string`-typed variable, where the type union can't be enforced.

Mirrors the existing runtime-validation pattern already used in `pds-radio-group` (`console.warn('pds-...: ...')`).

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added spec coverage in `pds-text.spec.tsx`:
- warns when `size` is an unsupported value
- does not warn for a supported value
- does not warn when `size` is unset
- warns when `size` is updated to an invalid value at runtime (via `@Watch`)

`pds-text` spec: 19/19 pass. Full `@pine-ds/core` suite green (2619 tests). `@pine-ds/core:build` succeeds with no `readme.md` / `components.d.ts` drift (internal change, no public API/JSDoc change). Lint: 0 errors.

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [x] tested manually
- [ ] other:

**Test Configuration**:

- Pine versions: main (`@pine-ds/core`)
- OS: macOS
- Browsers: n/a (spec-level)
- Screen readers: n/a
- Misc: dev-time `console.warn`, no production behavior change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only warnings and a type refactor; no change to production render behavior or public API surface beyond shared types.
> 
> **Overview**
> **`pds-text`** now **warns at dev time** when `size` is set to a value outside the supported set, instead of silently applying a useless CSS class.
> 
> Supported sizes are centralized in **`TEXT_SIZES`** / **`TextSizeType`** in `types.ts`, and the component’s `size` prop uses that type. Validation runs on initial load and when `size` changes (`@Watch`); invalid values log a **`console.warn`** with the bad value (truncated if very long) and the list of valid options. **`undefined`**, empty string, and supported values stay silent; whitespace-only strings still warn. Rendering is unchanged—warnings only, no throws.
> 
> Spec coverage was added for initial invalid/valid/unset sizes, runtime updates, empty vs whitespace-only values, and long-value truncation in the message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327a50d24567a9770e8f177c11c4757fa34a77a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->