### PR TITLE
chore: fix global CODEOWNERS pattern and route to current maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Global owners
+# NOTE: `*` matches all files. A bare `-` here previously matched only a file
+# literally named "-", so no code-owner review was actually enforced on general
+# files. Maintained by the two remaining DSS maintainers after the team wound down.
 
-- @Kajabi/dss-devs
+* @QuintonJason @pixelflips
 /.github/ @kajabi/production-engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # Global owners
 # NOTE: `*` matches all files. A bare `-` here previously matched only a file
 # literally named "-", so no code-owner review was actually enforced on general
-# files. Maintained by the two remaining DSS maintainers after the team wound down.
+# files. Routed to the @Kajabi/dss-devs team (still active, admin on this repo).
 
-* @QuintonJason @pixelflips
+* @Kajabi/dss-devs
 /.github/ @kajabi/production-engineering


### PR DESCRIPTION
# Description

Two things, both maintenance for the incoming-contributor phase now that the DSS team has wound down:

1. **Fixes a latent bug.** The global-owners line was `- @Kajabi/dss-devs`. In CODEOWNERS, patterns are gitignore-style — `*` matches all files, but a bare `-` matches only a file literally named `-`. GitHub doesn't flag it (it's syntactically valid), but it means **no code-owner review has actually been required on general files** — only `/.github/` (owned by PE) had a working rule. Changed to `*`.

2. **Routes to the real maintainers.** `@Kajabi/dss-devs` is a dissolved team (2 remaining members). Points ownership at the two people actually maintaining Pine now — @QuintonJason and @pixelflips — so the review gate survives the team being deleted.

The `/.github/ @kajabi/production-engineering` rule is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] other: verified via `GET /repos/Kajabi/pine/codeowners/errors` (no syntax errors) and confirmed `@QuintonJason`/`@pixelflips` are the two `dss-devs` members with write access.

# Checklist:

- [x] I have performed a self-review of my code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repository governance only; no application code or runtime behavior changes.
> 
> **Overview**
> **Fixes global code-owner coverage** so GitHub actually requires review on normal paths. The global rule was `- @Kajabi/dss-devs`; in CODEOWNERS that pattern only matches a file named `-`, not the whole tree, so only `/.github/` (production-engineering) had been enforcing owners.
> 
> Replaces it with `* @Kajabi/dss-devs` and adds a short comment documenting the mistake. The `/.github/ @kajabi/production-engineering` line is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f495f6c13cac8abe5056af9bcace688a2e0f10d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->