### PR TITLE
Add margin-block-end to pds-textarea label wrapper

### DIFF
--- a/libs/core/src/components/pds-textarea/pds-textarea.scss
+++ b/libs/core/src/components/pds-textarea/pds-textarea.scss
@@ -40,6 +40,7 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
+  margin-block-end: var(--pine-dimension-2xs);
 }
 
 .pds-textarea__action {


### PR DESCRIPTION
## Summary
- Adds `margin-block-end: var(--pine-dimension-2xs)` to `.pds-textarea__label-wrapper`
- Matches the spacing used by `.pds-input__label-wrapper` for visual consistency across input types

## Test plan
- [ ] Verify `pds-textarea` with label renders with correct bottom margin on label wrapper
- [ ] Compare spacing between `pds-textarea` and `pds-input` labels — should now be consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic SCSS only; no logic, data, or API impact.
> 
> **Overview**
> Adds **`margin-block-end: var(--pine-dimension-2xs)`** on **`.pds-textarea__label-wrapper`** so labeled textareas get the same gap between the label row and the field as **`pds-input`**.
> 
> This is a one-line styling tweak in `pds-textarea.scss`; no markup or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee56267e15350021fb96bf641b22f7698630af35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->