### PR TITLE
style: remove positive letter spacing from Inter headings

### DIFF
--- a/libs/core/src/global/styles/_letter-spacing.scss
+++ b/libs/core/src/global/styles/_letter-spacing.scss
@@ -1,0 +1,27 @@
+////
+/// Letter spacing token overrides (Pine-internal until upstream consolidation)
+///
+/// Removes the small positive tracking that `@kajabi-ui/styles` applies to
+/// Inter headings, which reads as too spread out. Body copy is normalized to
+/// `0`, and `h1`/`h2` adopt a tight tracking matching Tailwind's
+/// `tracking-tight` (`-0.025em`); the remaining heading roles sit at `0`.
+///
+/// Namespace contract: these CSS custom properties use the canonical
+/// `--pine-letter-spacing*` namespace owned by `@kajabi-ui/styles`. Pine
+/// redefines the values here (this file is `@use`d after the upstream import
+/// in `app.scss`, so these win) without renaming the tokens. When upstream
+/// publishes matching values, remove this file in the same PR that bumps the
+/// `@kajabi-ui/styles` version. Component SCSS does not change.
+///
+/// @group pine
+////
+
+:root {
+  --pine-letter-spacing: 0; // body/default (cleans up the invalid upstream value)
+  --pine-letter-spacing-heading-1: -0.025em; // Tailwind tracking-tight
+  --pine-letter-spacing-heading-2: -0.025em; // Tailwind tracking-tight
+  --pine-letter-spacing-heading-3: 0;
+  --pine-letter-spacing-heading-4: 0;
+  --pine-letter-spacing-heading-5: 0;
+  --pine-letter-spacing-heading-6: 0;
+}

--- a/libs/core/src/global/styles/app.scss
+++ b/libs/core/src/global/styles/app.scss
@@ -1,4 +1,5 @@
 @use '~@kajabi-ui/styles/dist/pine/pine';
+@use 'letter-spacing';
 @use 'fonts';
 @use 'motion';
 @use '../../components/pds-combobox/pds-combobox-dropdown-panel.scss' as *;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Description

Inter headings and body copy currently inherit small positive letter spacing from the upstream `@kajabi-ui/styles` heading tokens (`--pine-letter-spacing-heading-1…6`, ranging `.26px`→`.16px`), which reads as too spread out. Most notably the large headings are missing the tight tracking they should have.

This adds a local token override — following the existing `_motion.scss` pattern — that normalizes the values without renaming any tokens:

- `--pine-letter-spacing` (body/default) → `0` (also cleans up the invalid upstream `.16px * -1` value, which browsers already ignore)
- `--pine-letter-spacing-heading-1` / `-2` → `-0.025em` (matches Tailwind's `tracking-tight`)
- `--pine-letter-spacing-heading-3` … `-6` → `0`

The new file `libs/core/src/global/styles/_letter-spacing.scss` is `@use`d in `app.scss` immediately after the upstream import so its `:root` definitions win. Consuming components need no changes — they inherit the updated values. `pds-filter`'s direct use of the raw core token `--pine-letter-spacing-114` is intentionally left as-is.

No new dependencies.

> [!NOTE]
> **This is a deliberately narrow, incremental fix.** It stops the bleeding on Inter's positive tracking by overriding token *values* in place, without restructuring the token API. See "Follow-up" below for the more holistic work.

## Follow-up (root-cause / holistic)

This PR intentionally does not tackle the following, which should be handled in a dedicated follow-up:

- **Restructure the scale to a named Tailwind-style API** (`--pine-letter-spacing-tighter / tight / normal / wide / wider / widest`) instead of the role-based `--pine-letter-spacing-heading-*` tokens, and repoint all consumers. This is the "at the root" cleanup and is a larger, purely-structural change (~16 SCSS files + Storybook chrome).
- **Fix upstream** in `@kajabi-ui/styles` so the override file can be deleted (the base `--pine-letter-spacing` value there is invalid CSS, and headings ship positive tracking). This override is designed to be removed in the same PR that bumps to a corrected `@kajabi-ui/styles`.
- **Reconcile the docs tables**: `<DocTokenTable category="letter-spacing" />` reads the upstream JSON, so it still shows the old upstream values.
- **Remove the now-dead `, normal` fallback** in `libs/core/src/utils/truncation-tooltip.ts` (it guarded the previously-invalid upstream value).

## Before / after

Real Pine typography (Inter, correct weights/sizes) with the current upstream letter spacing (left) vs. this PR's values (right). The visible win is the tighter h1/h2; h3–h6 and body are effectively unchanged because the upstream positive tracking there was already sub-pixel/no-op.

[Letter spacing before/after comparison](https://cursor.com/agents/bc-019f7b3a-b088-772f-91a0-dc38fbf97c69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fletter-spacing-before-after.png)

Zoomed in on a heading — the end-of-line markers expose the width delta (grey = before, purple = after tracking-tight):

[Zoomed h1 before/after tracking-tight](https://cursor.com/agents/bc-019f7b3a-b088-772f-91a0-dc38fbf97c69/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fletter-spacing-h1-zoom.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [ ] tested manually

Verified via the core build/lint/test targets (`@pine-ds/core:build`, `:lint`, `:test` — 2906 tests passing). Confirmed the override wins in the compiled `pine-core.css` (our `:root` block emits after the upstream one). CSS custom-property overrides live in the global stylesheet and are not represented in Stencil spec snapshots, so existing component tests are unaffected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Design has QA'ed and approved this PR

**Review:** The Pine gauntlet (design + existence reviewers) was run on this branch — APPROVED, no blockers or should-fix items; three CONSIDER notes (two folded into the file's comments, one is the `truncation-tooltip.ts` cleanup listed under Follow-up).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7b3a-b088-772f-91a0-dc38fbf97c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7b3a-b088-772f-91a0-dc38fbf97c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

