### PR TITLE
feat(pds-tabs): add divider and stretch (fill-height) props

### DIFF
--- a/libs/core/src/components.d.ts
+++ b/libs/core/src/components.d.ts
@@ -2194,6 +2194,10 @@ export namespace Components {
           * @default false
          */
         "selected": boolean;
+        /**
+          * @default false
+         */
+        "stretch": boolean;
         "variant": string;
     }
     interface PdsTabs {
@@ -2206,6 +2210,16 @@ export namespace Components {
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
+        /**
+          * Adds a divider rule beneath the tab list.
+          * @defaultValue false
+         */
+        "divider"?: boolean;
+        /**
+          * Stretches the component so the active tab panel fills the remaining height. Requires the component to have a constrained height (e.g. a flex parent).
+          * @defaultValue false
+         */
+        "stretch"?: boolean;
         /**
           * Sets the aria-label attached to the tablist element
          */
@@ -5488,6 +5502,10 @@ declare namespace LocalJSX {
           * @default false
          */
         "selected"?: boolean;
+        /**
+          * @default false
+         */
+        "stretch"?: boolean;
         "variant"?: string;
     }
     interface PdsTabs {
@@ -5500,6 +5518,16 @@ declare namespace LocalJSX {
           * A unique identifier used for the underlying component `id` attribute.
          */
         "componentId": string;
+        /**
+          * Adds a divider rule beneath the tab list.
+          * @defaultValue false
+         */
+        "divider"?: boolean;
+        /**
+          * Stretches the component so the active tab panel fills the remaining height. Requires the component to have a constrained height (e.g. a flex parent).
+          * @defaultValue false
+         */
+        "stretch"?: boolean;
         /**
           * Sets the aria-label attached to the tablist element
          */
@@ -6054,6 +6082,14 @@ declare namespace LocalJSX {
         "variant": 'inline' | 'plain';
         "fontSize": 'sm' | 'md' | 'lg';
         "href": string;
+        "turbo": string;
+        "turboFrame": string;
+        "turboAction": 'advance' | 'replace';
+        "turboMethod": 'get' | 'post' | 'put' | 'patch' | 'delete';
+        "turboConfirm": string;
+        "turboStream": string;
+        "turboPrefetch": string;
+        "turboPreload": string;
     }
     interface PdsLoaderAttributes {
         "isLoading": boolean;
@@ -6256,11 +6292,14 @@ declare namespace LocalJSX {
         "parentComponentId": string;
         "variant": string;
         "selected": boolean;
+        "stretch": boolean;
     }
     interface PdsTabsAttributes {
         "tablistLabel": string;
         "componentId": string;
         "variant": 'primary' | 'availability' | 'filter' | 'pill';
+        "divider": boolean;
+        "stretch": boolean;
         "activeTabName": string;
         "activeTabIndex": number;
     }

--- a/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
+++ b/libs/core/src/components/pds-tabs/docs/pds-tabs.mdx
@@ -233,6 +233,84 @@ Individual tabs can be disabled using the `disabled` prop. Disabled tabs cannot 
   </pds-tabs>
 </DocCanvas>
 
+### Divider
+
+The `divider` prop adds a full-width rule beneath the tab list, separating the tabs from their panel. Useful when tabs sit directly above dense content and need a visual seam.
+
+<DocCanvas mdxSource={{
+  react: `
+<PdsTabs activeTabName="Dollop" variant="primary" componentId="divider-example" tablistLabel="Foo" divider>
+  <PdsTab name="Sturdy">Sturdy</PdsTab>
+  <PdsTab name="Dollop">Dollop</PdsTab>
+  <PdsTab name="Waffle">Waffle</PdsTab>
+  <PdsTabpanel name="Sturdy">Content Sturdy</PdsTabpanel>
+  <PdsTabpanel name="Dollop">Content Dollop</PdsTabpanel>
+  <PdsTabpanel name="Waffle">Content Waffle</PdsTabpanel>
+</PdsTabs>
+`,
+  webComponent: `
+<pds-tabs active-tab-name="Dollop" variant="primary" component-id="divider-example" tablist-label="Foo" divider>
+  <pds-tab name="Sturdy">Sturdy</pds-tab>
+  <pds-tab name="Dollop">Dollop</pds-tab>
+  <pds-tab name="Waffle">Waffle</pds-tab>
+  <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+  <pds-tabpanel name="Dollop">Content Dollop</pds-tabpanel>
+  <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+</pds-tabs>
+`
+}}>
+  <pds-tabs active-tab-name="Dollop" variant="primary" component-id="divider-example" tablist-label="Foo" divider>
+    <pds-tab name="Sturdy">Sturdy</pds-tab>
+    <pds-tab name="Dollop">Dollop</pds-tab>
+    <pds-tab name="Waffle">Waffle</pds-tab>
+    <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+    <pds-tabpanel name="Dollop">Content Dollop</pds-tabpanel>
+    <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+  </pds-tabs>
+</DocCanvas>
+
+### Stretch
+
+The `stretch` prop makes the component fill its container's height and lets the active panel take the remaining space below the tab list — for tab sets inside a height-bounded region (a rail, a modal body, a split-pane column) where the panel should scroll on its own rather than the page. Give the parent a fixed height for the effect to show.
+
+<DocCanvas mdxSource={{
+  react: `
+<div style={{ height: '240px', border: '1px solid var(--pine-color-border-subtle)' }}>
+  <PdsTabs activeTabName="Dollop" variant="primary" componentId="stretch-example" tablistLabel="Foo" stretch>
+    <PdsTab name="Sturdy">Sturdy</PdsTab>
+    <PdsTab name="Dollop">Dollop</PdsTab>
+    <PdsTab name="Waffle">Waffle</PdsTab>
+    <PdsTabpanel name="Sturdy">Content Sturdy</PdsTabpanel>
+    <PdsTabpanel name="Dollop">Content Dollop</PdsTabpanel>
+    <PdsTabpanel name="Waffle">Content Waffle</PdsTabpanel>
+  </PdsTabs>
+</div>
+`,
+  webComponent: `
+<div style="height: 240px; border: 1px solid var(--pine-color-border-subtle);">
+  <pds-tabs active-tab-name="Dollop" variant="primary" component-id="stretch-example" tablist-label="Foo" stretch>
+    <pds-tab name="Sturdy">Sturdy</pds-tab>
+    <pds-tab name="Dollop">Dollop</pds-tab>
+    <pds-tab name="Waffle">Waffle</pds-tab>
+    <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+    <pds-tabpanel name="Dollop">Content Dollop</pds-tabpanel>
+    <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+  </pds-tabs>
+</div>
+`
+}}>
+  <div style={{height: '240px', border: '1px solid var(--pine-color-border-subtle)'}}>
+    <pds-tabs active-tab-name="Dollop" variant="primary" component-id="stretch-example" tablist-label="Foo" stretch>
+      <pds-tab name="Sturdy">Sturdy</pds-tab>
+      <pds-tab name="Dollop">Dollop</pds-tab>
+      <pds-tab name="Waffle">Waffle</pds-tab>
+      <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+      <pds-tabpanel name="Dollop">Content Dollop</pds-tabpanel>
+      <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+    </pds-tabs>
+  </div>
+</DocCanvas>
+
 ## Additional Resources
 
 [W3C: Tabs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/)

--- a/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.scss
@@ -2,6 +2,17 @@
   display: block;
 }
 
+// When the parent `pds-tabs` has `stretch`, the active panel fills the height
+// the tabs column hands it (the host is a flex item of that column).
+:host(.pds-tabpanel--stretch-active) {
+  flex: 1 1 auto;
+  min-block-size: 0;
+}
+
+:host(.pds-tabpanel--stretch-active) .pds-tabpanel.is-active {
+  block-size: 100%;
+}
+
 .pds-tabpanel {
   display: none;
   margin-top: var(--tabs-dimension-panel-margin-top);

--- a/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabpanel/pds-tabpanel.tsx
@@ -31,9 +31,18 @@ export class PdsTabpanel {
   /** @internal */
   @Prop({mutable: true}) selected = false;          // eslint-disable-line @stencil-community/strict-mutable
 
+  /**
+   * Keeps track of the parent `stretch` state so the active panel can fill height, this property is passed by parent component
+   */
+  /** @internal */
+  @Prop() stretch = false;
+
   render() {
     return (
-      <Host slot="tabpanels">
+      <Host
+        slot="tabpanels"
+        class={this.stretch && this.selected ? "pds-tabpanel--stretch-active" : undefined}
+      >
         <div
           role="tabpanel"
           id={this.parentComponentId + "__" + this.name + '-panel'}

--- a/libs/core/src/components/pds-tabs/pds-tabpanel/test/pds-tabpanel.spec.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabpanel/test/pds-tabpanel.spec.tsx
@@ -42,4 +42,22 @@ describe('pds-tabpanel', () => {
       </pds-tabpanel>
     `);
   });
+
+  it('adds the stretch-active class when stretch and selected are both set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTabpanel],
+      html: `<pds-tabpanel stretch="true" selected="true" parent-component-id="foo" name="two">Content</pds-tabpanel>`,
+    });
+    await page.waitForChanges();
+    expect(page.root.classList.contains('pds-tabpanel--stretch-active')).toBe(true);
+  });
+
+  it('does not add the stretch-active class when the panel is not selected', async () => {
+    const page = await newSpecPage({
+      components: [PdsTabpanel],
+      html: `<pds-tabpanel stretch="true" parent-component-id="foo" name="two">Content</pds-tabpanel>`,
+    });
+    await page.waitForChanges();
+    expect(page.root.classList.contains('pds-tabpanel--stretch-active')).toBe(false);
+  });
 });

--- a/libs/core/src/components/pds-tabs/pds-tabs.scss
+++ b/libs/core/src/components/pds-tabs/pds-tabs.scss
@@ -17,6 +17,24 @@
   gap: var(--pine-dimension-md);
 }
 
+// Optional divider rule beneath the tab list.
+:host(.pds-tabs--divider) .pds-tabs__tablist {
+  border-block-end: var(--pine-border-width-thin) solid var(--pine-color-border-subtle);
+}
+
+// Stretch: make the component a flex column so the active tab panel fills the
+// remaining height (the tab list stays fixed at the top). The active
+// `pds-tabpanel` opts into `flex: 1` via `.pds-tabpanel--stretch-active`.
+:host(.pds-tabs--stretch) {
+  block-size: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+:host(.pds-tabs--stretch) .pds-tabs__tablist {
+  flex: 0 0 auto;
+}
+
 :host(.pds-tabs--availability) .pds-tabs__tablist {
   gap: var(--pine-dimension-xs);
 }

--- a/libs/core/src/components/pds-tabs/pds-tabs.tsx
+++ b/libs/core/src/components/pds-tabs/pds-tabs.tsx
@@ -32,6 +32,19 @@ export class PdsTabs {
   @Prop() variant!: 'primary' | 'availability' | 'filter' | 'pill';
 
   /**
+   * Adds a divider rule beneath the tab list.
+   * @defaultValue false
+   */
+  @Prop() divider?: boolean = false;
+
+  /**
+   * Stretches the component so the active tab panel fills the remaining height.
+   * Requires the component to have a constrained height (e.g. a flex parent).
+   * @defaultValue false
+   */
+  @Prop() stretch?: boolean = false;
+
+  /**
    * Sets the starting active tab name and maintains the name as the component re-renders
    */
   @Prop({mutable: true}) activeTabName!: string;
@@ -122,6 +135,7 @@ export class PdsTabs {
 
     this.tabPanels.forEach((child) => {
       this.propGeneration(child);
+      child.stretch = this.stretch;
     });
   }
 
@@ -130,6 +144,12 @@ export class PdsTabs {
     if (this.variant && this.variant != 'primary') {
       const variantClassName = `pds-tabs--${this.variant}`;
       className += ' ' + variantClassName;
+    }
+    if (this.divider) {
+      className += ' pds-tabs--divider';
+    }
+    if (this.stretch) {
+      className += ' pds-tabs--stretch';
     }
 
     return className;

--- a/libs/core/src/components/pds-tabs/readme.md
+++ b/libs/core/src/components/pds-tabs/readme.md
@@ -7,12 +7,14 @@
 
 ## Properties
 
-| Property                     | Attribute         | Description                                                                          | Type                                                | Default     |
-| ---------------------------- | ----------------- | ------------------------------------------------------------------------------------ | --------------------------------------------------- | ----------- |
-| `activeTabName` _(required)_ | `active-tab-name` | Sets the starting active tab name and maintains the name as the component re-renders | `string`                                            | `undefined` |
-| `componentId` _(required)_   | `component-id`    | A unique identifier used for the underlying component `id` attribute.                | `string`                                            | `undefined` |
-| `tablistLabel` _(required)_  | `tablist-label`   | Sets the aria-label attached to the tablist element                                  | `string`                                            | `undefined` |
-| `variant` _(required)_       | `variant`         | Sets tabs variant styles as outlined in Figma documentation                          | `"availability" \| "filter" \| "pill" \| "primary"` | `undefined` |
+| Property                     | Attribute         | Description                                                                                                                                           | Type                                                | Default     |
+| ---------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- | ----------- |
+| `activeTabName` _(required)_ | `active-tab-name` | Sets the starting active tab name and maintains the name as the component re-renders                                                                  | `string`                                            | `undefined` |
+| `componentId` _(required)_   | `component-id`    | A unique identifier used for the underlying component `id` attribute.                                                                                 | `string`                                            | `undefined` |
+| `divider`                    | `divider`         | Adds a divider rule beneath the tab list.                                                                                                             | `boolean`                                           | `false`     |
+| `stretch`                    | `stretch`         | Stretches the component so the active tab panel fills the remaining height. Requires the component to have a constrained height (e.g. a flex parent). | `boolean`                                           | `false`     |
+| `tablistLabel` _(required)_  | `tablist-label`   | Sets the aria-label attached to the tablist element                                                                                                   | `string`                                            | `undefined` |
+| `variant` _(required)_       | `variant`         | Sets tabs variant styles as outlined in Figma documentation                                                                                           | `"availability" \| "filter" \| "pill" \| "primary"` | `undefined` |
 
 
 ## Slots

--- a/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
+++ b/libs/core/src/components/pds-tabs/stories/pds-tabs.stories.js
@@ -61,3 +61,29 @@ Availability.args = {
   variant: 'availability',
   tablistLabel: "Foo",
 }
+
+export const Divider = () => html`
+<pds-tabs active-tab-name="Dollop" component-id="divider" tablist-label="Foo" variant="primary" divider>
+  <pds-tab name="Sturdy">Sturdy</pds-tab>
+  <pds-tab name="Dollop">Dollop</pds-tab>
+  <pds-tab name="Waffle">Waffle</pds-tab>
+  <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+  <pds-tabpanel name="Dollop">Content Dollop</pds-tabpanel>
+  <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+</pds-tabs>
+`;
+
+export const Stretch = () => html`
+<div style="block-size: 240px; border: var(--pine-border-width-thin) solid var(--pine-color-border-subtle); display: flex;">
+  <pds-tabs active-tab-name="Dollop" component-id="stretch" tablist-label="Foo" variant="primary" divider stretch>
+    <pds-tab name="Sturdy">Sturdy</pds-tab>
+    <pds-tab name="Dollop">Dollop</pds-tab>
+    <pds-tab name="Waffle">Waffle</pds-tab>
+    <pds-tabpanel name="Sturdy">Content Sturdy</pds-tabpanel>
+    <pds-tabpanel name="Dollop">
+      <div style="align-items: end; background-color: var(--pine-color-background-muted); block-size: 100%; display: flex;">Composer pinned to the bottom</div>
+    </pds-tabpanel>
+    <pds-tabpanel name="Waffle">Content Waffle</pds-tabpanel>
+  </pds-tabs>
+</div>
+`;

--- a/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
+++ b/libs/core/src/components/pds-tabs/test/pds-tabs.spec.tsx
@@ -283,4 +283,20 @@ it('renders variant prop', async () => {
     expect(page.body.querySelector('pds-tab[name="one"] > button')).toHaveClass('is-active');
     expect(page.body.querySelector('pds-tab[name="two"] > button')).not.toHaveClass('is-active');
   });
+
+  it('adds the divider class when the divider prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTabs],
+      html: `<pds-tabs component-id="test" divider="true"></pds-tabs>`,
+    });
+    expect(page.root.classList.contains('pds-tabs--divider')).toBe(true);
+  });
+
+  it('adds the stretch class when the stretch prop is set', async () => {
+    const page = await newSpecPage({
+      components: [PdsTabs],
+      html: `<pds-tabs component-id="test" stretch="true"></pds-tabs>`,
+    });
+    expect(page.root.classList.contains('pds-tabs--stretch')).toBe(true);
+  });
 });


### PR DESCRIPTION
# Description

Adds two opt-in props to `pds-tabs` that consumers currently can't get without reaching into the shadow DOM via `::part(tab-list)` / forcing panel heights:

- **`divider`** (boolean) — draws a rule beneath the tab list (`border-block-end` on `.pds-tabs__tablist`), the standard underlined-tabs look. Addresses **[DSS-219](https://linear.app/kajabi/issue/DSS-219)**.
- **`stretch`** (boolean) — makes the component a flex column so the **active tab panel fills the remaining height** (tab list stays fixed at top). Addresses **[DSS-220](https://linear.app/kajabi/issue/DSS-220)** (High). Implemented by passing `stretch` down to `pds-tabpanel` (same mechanism as `variant`/`selected`); the active panel opts into `flex: 1` via a `pds-tabpanel--stretch-active` host class and fills via `block-size: 100%`. No `::slotted`/attribute-reflection churn, so existing snapshots are untouched.

Both are **additive and off by default** — zero visual change for existing consumers.

**Motivation / context:** surfaced by the Clubs app-frame spike ([kajabi-products#55087](https://github.com/Kajabi/kajabi-products/pull/55087)), where the group Chat-tab composer couldn't pin to the panel bottom (the fill-height trap) and the tab strip needed an underline — both hand-worked via `::part()` overrides.

## Scope note — DSS-221 (tab-label padding) intentionally NOT included
The third tabs gap ([DSS-221](https://linear.app/kajabi/issue/DSS-221), tokenise tab-label padding) is **carved out on purpose**: the current default underline padding is a raw `11px` and the spike actually wanted a different padding *model* (padded buttons vs. today's `gap`-spaced tab list). Either change shifts **every tab in every consuming app**, so it needs design sign-off and belongs in its own design-gated PR rather than riding along here. No new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (auto-generated `readme.md` regenerated via build)

# How Has This Been Tested?

- [x] unit tests
- [ ] e2e tests
- [ ] accessibility tests
- [ ] tested manually
- [ ] other: Storybook stories added (`Divider`, `Stretch`); visual/design QA still to come

Added spec coverage: `pds-tabs` gets the `pds-tabs--divider`/`pds-tabs--stretch` classes when the props are set; `pds-tabpanel` gets `pds-tabpanel--stretch-active` only when `stretch` **and** `selected`. Full core suite green locally (`nx run @pine-ds/core:test --skip-nx-cache` — 90 suites / 2920 tests). Build regenerates `readme.md` + `components.d.ts`; lint passes (0 errors).

**Follow-up before ready-for-review:** design QA of the divider colour/weight and the stretch behaviour in a real constrained-height layout.

**Test Configuration**:
- Pine versions: `@pine-ds/core@3.27.0` (this branch)
- Draft — not yet browser/AT-verified.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI props default to false with targeted layout CSS and unit tests; no changes to tab selection or ARIA behavior when props are unset.
> 
> **Overview**
> Adds two opt-in, default-off props on **`pds-tabs`**: **`divider`** draws a subtle rule under the tab list, and **`stretch`** turns the host into a flex column so the active **`pds-tabpanel`** can consume remaining height inside a bounded parent (replacing common `::part` / manual height hacks).
> 
> **`stretch`** is propagated to child panels; only the selected panel gets **`pds-tabpanel--stretch-active`** and the matching flex/height styles. **`components.d.ts`**, readme, MDX examples, Storybook stories, and unit specs cover the new API and class behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae11b5252ed87ef9e6e982c5b18ef20f8ff4834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->