### PR TITLE
docs(pds-button): document ::part(button) for compact/inverse icon buttons

### DIFF
--- a/libs/core/src/components/pds-button/docs/pds-button.mdx
+++ b/libs/core/src/components/pds-button/docs/pds-button.mdx
@@ -376,6 +376,72 @@ Sizes also apply to icon-only buttons, adjusting the button dimensions according
   <pds-button variant="primary" icon-only="true" size="micro"><pds-icon slot="start" aria-hidden="true" name="favorite" size="var(--pine-dimension-150)"></pds-icon>Micro</pds-button>
 </DocCanvas>
 
+### Compact / custom-surface icon buttons
+
+When a placement needs an icon button the size and variant props don't express — for
+example a chat composer's **send** affordance: a compact fixed square with an inverse
+surface — target the exposed `button` shadow part rather than reaching into internals.
+`::part(button)` is public API, so this is a supported customization.
+
+The example pairs the override with `variant="unstyled"`. That's a recommendation, not a
+requirement: `unstyled` is a state-neutral base (transparent background across default/
+hover/disabled, no padding, border, or min-width), so the `::part(button)` rules fully own
+the appearance instead of layering over — and fighting the hover/focus surface of — another
+variant. Any variant works, but a non-`unstyled` one will still apply its own interaction-
+state colors underneath.
+
+> ***Note:*** Reach for this only when the built-in `variant` and `size` props can't
+> get you there. Keep the accessible label (the visually-hidden slot text) so the
+> control is still announced.
+
+<DocCanvas
+  mdxSource={{
+    react: `
+    <style>{\`
+      .compact-inverse-icon-button::part(button) {
+        width: var(--pine-dimension-400);
+        height: var(--pine-dimension-400);
+        min-width: 0;
+        padding: 0;
+        border-radius: var(--pine-border-radius-md);
+        background: var(--pine-color-background-inverse-inset);
+        color: var(--pine-color-text-primary);
+      }
+    \`}</style>
+
+    <PdsButton className="compact-inverse-icon-button" variant="unstyled" iconOnly="true" icon="arrow-up">Send message</PdsButton>
+    `,
+    webComponent: `
+    <style>
+      .compact-inverse-icon-button::part(button) {
+        width: var(--pine-dimension-400);
+        height: var(--pine-dimension-400);
+        min-width: 0;
+        padding: 0;
+        border-radius: var(--pine-border-radius-md);
+        background: var(--pine-color-background-inverse-inset);
+        color: var(--pine-color-text-primary);
+      }
+    </style>
+
+    <pds-button class="compact-inverse-icon-button" variant="unstyled" icon-only="true" icon="arrow-up">Send message</pds-button>
+    `
+}}>
+  <style>{`
+    .compact-inverse-icon-button::part(button) {
+      width: var(--pine-dimension-400);
+      height: var(--pine-dimension-400);
+      min-width: 0;
+      padding: 0;
+      border-radius: var(--pine-border-radius-md);
+      background: var(--pine-color-background-inverse-inset);
+      color: var(--pine-color-text-primary);
+    }
+  `}</style>
+
+  <pds-button class="compact-inverse-icon-button" variant="unstyled" icon-only="true" icon="arrow-up">Send message</pds-button>
+</DocCanvas>
+
 ### Button Link
 
 The button link variant allows a `pds-button` to function as a link. By providing an `href` attribute, the button will render as an anchor (`<a>`) element while maintaining the visual appearance of a button. This is useful for creating call-to-action buttons that navigate to external resources or different parts of your application.

--- a/libs/core/src/components/pds-button/pds-button.tsx
+++ b/libs/core/src/components/pds-button/pds-button.tsx
@@ -4,7 +4,7 @@ import { hasShadowDom } from '../../utils/utils';
 import { caretDown, addCircle } from '@pine-ds/icons/icons';
 
 /**
- * @part button - Exposes the button element for styling.
+ * @part button - Exposes the underlying button (or anchor) element for styling, including custom size, shape, or surface on icon-only placements (e.g. a compact square or inverse icon button).
  * @part button-content - Exposes the button content for styling.
  * @part button-text - Exposes the button text for styling.
  * @part caret - Exposes the caret icon component for styling. Appears only on the disclosure variant.

--- a/libs/core/src/components/pds-button/readme.md
+++ b/libs/core/src/components/pds-button/readme.md
@@ -43,14 +43,14 @@
 
 ## Shadow Parts
 
-| Part               | Description                                                                           |
-| ------------------ | ------------------------------------------------------------------------------------- |
-| `"button"`         | Exposes the button element for styling.                                               |
-| `"button-content"` | Exposes the button content for styling.                                               |
-| `"button-text"`    | Exposes the button text for styling.                                                  |
-| `"caret"`          | Exposes the caret icon component for styling. Appears only on the disclosure variant. |
-| `"icon"`           | Exposes the icon component for styling.                                               |
-| `"loader-svg"`     | Exposes the loader SVG element for color customization. Appears only when loading.    |
+| Part               | Description                                                                                                                                                                     |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"button"`         | Exposes the underlying button (or anchor) element for styling, including custom size, shape, or surface on icon-only placements (e.g. a compact square or inverse icon button). |
+| `"button-content"` | Exposes the button content for styling.                                                                                                                                         |
+| `"button-text"`    | Exposes the button text for styling.                                                                                                                                            |
+| `"caret"`          | Exposes the caret icon component for styling. Appears only on the disclosure variant.                                                                                           |
+| `"icon"`           | Exposes the icon component for styling.                                                                                                                                         |
+| `"loader-svg"`     | Exposes the loader SVG element for color customization. Appears only when loading.                                                                                              |
 
 
 ## Dependencies

--- a/libs/core/src/components/pds-button/stories/pds-button.stories.js
+++ b/libs/core/src/components/pds-button/stories/pds-button.stories.js
@@ -251,3 +251,28 @@ Sizes.args = {
   type: 'button',
   variant: 'primary'
 }
+
+// Demonstrates the supported `::part(button)` hook: a compact fixed-size,
+// inverse-surface icon button (e.g. a chat composer send affordance) that the
+// stock size/variant props don't express.
+export const CompactIconButtonViaPart = {
+  render: () => html`
+    <style>
+      .compact-inverse-icon-button::part(button) {
+        width: var(--pine-dimension-400);
+        height: var(--pine-dimension-400);
+        min-width: 0;
+        padding: 0;
+        border-radius: var(--pine-border-radius-md);
+        background: var(--pine-color-background-inverse-inset);
+        color: var(--pine-color-text-primary);
+      }
+    </style>
+    <pds-button class="compact-inverse-icon-button" variant="unstyled" icon-only icon="arrow-up">
+      Send message
+    </pds-button>
+  `,
+  parameters: {
+    controls: { exclude: ['icon'] },
+  },
+};


### PR DESCRIPTION
# Description

Documents `::part(button)` as the supported hook for icon buttons whose size/shape/surface the stock `variant` and `size` props can't express — e.g. a compact fixed **32×32 square** icon button with an **inverse surface** (a chat composer's *send* affordance).

The `button` part is already exposed on both the `<button>` and `<a>` render paths and already listed in the Shadow Parts table, so no component behavior changes here. This PR makes the pattern explicit and supported so consumers stop copying a blind, undocumented `::part(button)` override:

- Enriches the `@part button` JSDoc so the generated Shadow Parts table describes it as the hook for custom size/shape/surface on icon-only placements.
- Adds a **Storybook story** (`CompactIconButtonViaPart`) and an **MDX "Compact / custom-surface icon buttons"** section demonstrating the token-based recipe (`--pine-dimension-400`, `--pine-border-radius-md`, `--pine-color-background-inverse-inset`, `--pine-color-text-primary`).

Addresses the "document `::part(button)` as public API" option in DSS-225. The additive-API options (an `inverse` variant / compact size prop) are intentionally **not** included here — this is the low-risk, no-new-API path.

Surfaced by the Clubs app-frame spike (kajabi-products PR #55087).

## Type of change

- [x] This change requires a documentation update
- [x] Documentation-only (no runtime/behavior change)

# How Has This Been Tested?

- [x] tested manually — built core (`nx run @pine-ds/core:build`); Shadow Parts table regenerates with the new description; story renders the compact inverse send button.
- Existing `pds-button` specs unaffected (no source/behavior change).

**Test Configuration**:

- Pine versions: main @ 4f6f765d
- Misc: `@stencil/core` 4.38.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, docs-only
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated readme only; no button behavior or styling logic changes.
> 
> **Overview**
> Documents **`::part(button)`** as the supported way to style icon-only buttons when **`variant`** and **`size`** are not enough (e.g. a compact inverse “send” control).
> 
> The **`@part button`** JSDoc and generated Shadow Parts table now call out custom size, shape, and surface on the underlying button or anchor. **MDX** adds a “Compact / custom-surface icon buttons” section with a Pine-token recipe and guidance to prefer **`variant="unstyled"`** so part styles are not fighting variant hover/focus. **Storybook** adds **`CompactIconButtonViaPart`** with the same example.
> 
> No component runtime or API changes beyond doc text regeneration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a8579c1b3554f5f0fc90e46d682fd78e17e57c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->