### PR TITLE
feat(pds-avatar): expose an initials shadow part

### DIFF
--- a/libs/core/src/components/pds-avatar/pds-avatar.tsx
+++ b/libs/core/src/components/pds-avatar/pds-avatar.tsx
@@ -5,6 +5,7 @@ import { checkCircleFilled, userFilled } from '@pine-ds/icons/icons';
  * @part asset-wrapper
  * @part button
  * @part image - The main image element that represents the avatar component.
+ * @part initials - The text element that renders the avatar's initials, for restyling their color.
 */
 @Component({
   tag: 'pds-avatar',
@@ -179,7 +180,7 @@ export class PdsAvatar {
 
     if (this.initials) {
       return (
-        <svg class="pds-avatar__initials" viewBox="0 0 32 32">
+        <svg class="pds-avatar__initials" part="initials" viewBox="0 0 32 32">
           <text x="16" y="20">{this.initials}</text>
         </svg>
       );

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -338,4 +338,16 @@ describe('pds-avatar', () => {
     expect(dot.hasAttribute('role')).toBe(false);
   });
 
+  it('exposes an "initials" shadow part so consumers can restyle the initials', async () => {
+    const page = await newSpecPage({
+      components: [PdsAvatar],
+      html: `<pds-avatar initials="QJ"></pds-avatar>`,
+    });
+
+    const initials = page.root.shadowRoot.querySelector('[part="initials"]');
+    expect(initials).not.toBeNull();
+    expect(initials.tagName.toLowerCase()).toBe('svg');
+    expect(initials.textContent).toContain('QJ');
+  });
+
 });

--- a/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
+++ b/libs/core/src/components/pds-avatar/test/pds-avatar.spec.tsx
@@ -194,7 +194,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar pds-avatar--has-initials" initials="KJ" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <svg class="pds-avatar__initials" viewBox="0 0 32 32">
+            <svg class="pds-avatar__initials" part="initials" viewBox="0 0 32 32">
               <text x="16" y="20">KJ</text>
             </svg>
           </div>
@@ -228,7 +228,7 @@ describe('pds-avatar', () => {
       <pds-avatar class="pds-avatar pds-avatar--has-initials" initials="KJ" badge="true" size="lg" variant="customer">
         <mock:shadow-root>
           <div part="asset-wrapper" style="height: 56px; width: 56px;">
-            <svg class="pds-avatar__initials" viewBox="0 0 32 32">
+            <svg class="pds-avatar__initials" part="initials" viewBox="0 0 32 32">
               <text x="16" y="20">KJ</text>
             </svg>
             <pds-icon class="pds-avatar__badge" color="var(--pine-color-purple-600)" icon="${checkCircleFilled}" size="33.53%"></pds-icon>


### PR DESCRIPTION
# Description

Exposes an **`initials` shadow part** on `pds-avatar` so consumers can restyle the initials (e.g. color) via `::part(initials)` instead of hijacking the internal `--pine-color-brand` custom property — which is the only lever available today.

```css
/* before: the only way to recolor initials */
pds-avatar { --pine-color-brand: var(--pine-color-text-readonly); }

/* after */
pds-avatar::part(initials) { fill: var(--pine-color-text-readonly); }
```

Surfaced (again) building the Kajabi Clubs members roster, where per-entity/readonly initials needed a color the component doesn't expose. Implements **DSS-228**; sibling of the initials/background color gap (DSS-216).

No behavior change and no default restyle — the initials still default to `--pine-color-brand`; this only adds the `part` hook. `components.d.ts` is unaffected (shadow parts aren't part of the type surface); the readme's Shadow Parts table regenerates in CI.

Fixes DSS-228

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (readme Shadow Parts — regenerated by CI)

# How Has This Been Tested?

- [x] unit tests

Added a spec asserting `pds-avatar[initials]` renders an element with `part="initials"` (mirrors the existing `part="status"` test). Not built/run locally to avoid regenerating `components.d.ts` with a non-canonical toolchain — CI runs the canonical build + suite.

**Test Configuration**:

- Pine versions: 3.29.0 (branch off `main`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (JSDoc `@part`; readme regenerates in CI)
- [x] I have added tests that prove my feature works
- [ ] New and existing tests pass locally with my changes (deferred to CI — see above)
- [ ] Design has QA'ed and approved this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive styling hook only; no changes to rendering logic, defaults, or security-sensitive paths.
> 
> **Overview**
> Adds an **`initials` shadow part** on `pds-avatar` so apps can restyle initials text (e.g. `fill`) via `::part(initials)` instead of overriding `--pine-color-brand`.
> 
> The initials SVG gets `part="initials"` and JSDoc documents the part; unit snapshots and a new spec assert the part is present. **No default visual or behavioral change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85083cba562550e773708a0a9a6e93e391188a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->