### PR TITLE
style(pds-multiselect): match error and helper message weight to sibling form fields

### DIFF
--- a/libs/core/src/components/pds-multiselect/pds-multiselect.scss
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.scss
@@ -324,7 +324,7 @@
 
 .pds-multiselect__helper {
   color: var(--pine-color-text-message);
-  font: var(--pine-typography-body-sm);
+  font: var(--pine-typography-body-sm-medium);
   margin-block-start: var(--pine-dimension-2xs);
   margin-inline-start: var(--pine-dimension-none);
 }
@@ -333,7 +333,7 @@
   align-items: flex-start;
   color: var(--pine-color-text-message-danger);
   display: flex;
-  font: var(--pine-typography-body-sm);
+  font: var(--pine-typography-body-sm-medium);
   gap: var(--pine-dimension-2xs);
   margin-block-start: var(--pine-dimension-2xs);
   margin-inline-start: var(--pine-dimension-none);


### PR DESCRIPTION
# Description

`pds-multiselect` rendered its error and helper messages one font weight lighter than every other Pine form control. Put a multiselect in a form beside a `pds-input` or `pds-select` and its error read as subtly less urgent than its neighbours.

Both `.pds-multiselect__error` and `.pds-multiselect__helper` used `--pine-typography-body-sm` (weight 400). Every sibling that renders these messages uses `--pine-typography-body-sm-medium` (weight 500):

| Component | error / helper `font` |
| -- | -- |
| `pds-input` | `body-sm-medium` |
| `pds-select` | `body-sm-medium` |
| `pds-textarea` | `body-sm-medium` |
| `pds-checkbox` | `body-sm-medium` |
| `pds-switch` | `body-sm-medium` |
| `pds-multiselect` | **`body-sm`** ← the outlier |

This aligns the multiselect with the other five. The two tokens differ in exactly one slot:

```
--pine-typography-body-sm-medium: var(--pine-font-weight-medium)  var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
--pine-typography-body-sm:        var(--pine-font-weight-regular) var(--pine-font-size-body-sm)/var(--pine-line-height-body) var(--pine-font-family-inter);
```

Size, line-height and family are identical, so this is a weight-only change with no layout impact.

The reporting ticket asked about `__error` and flagged `__helper` as worth checking in the same pass — it had diverged too, so both are fixed here.

Fixes DSS-236

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] other: token-value verification

Reported with live `getComputedStyle` measurements across five controls in one form (Kajabi Super Admin dispatch targeting panel): four `pds-input`/`pds-select` errors computed weight **500**, the `pds-multiselect` error computed **400**. Size (12px) and colour (`rgb(220, 38, 38)`) already agreed across all five — only weight differed.

Verified locally:

- `npx stylelint libs/core/src/components/pds-multiselect/pds-multiselect.scss` — clean.
- `npx nx run @pine-ds/core:test` — **91 suites / 2984 tests pass**.
- Confirmed the target token resolves in `@kajabi-ui/styles/dist/pine/pine.css` and differs from the old one only in the `font-weight` slot.

No new tests added: the existing `pds-multiselect.spec.tsx` cases for `.pds-multiselect__error` and `.pds-multiselect__helper` assert element presence and text content, and Stencil's `newSpecPage` renders into mock-doc without applying stylesheets — computed font weight is not observable at the spec layer. This is the kind of change visual regression coverage catches rather than unit tests.

**Test Configuration**:

- Pine versions: reported against `@pine-ds/core@3.29.0`; fixed on `main` at `fe4a93da`
- OS: macOS
- Browsers: Chrome (original measurement)
- Screen readers: n/a
- Misc: SCSS-only change; no generated files, no public API change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

---

### Note for reviewers, not changed here

`pds-radio`'s `.pds-radio__message` uses `--pine-typography-body` — a different *size*, not just weight, and its message sits inline in a flex card rather than below the control. That looked like a deliberate structural difference rather than the same bug, so it is left alone. Worth a separate look if it is not intentional.
<!-- ux-change-guard -->

---

## UX/Product Change Summary

> Auto-generated by **ux-change-guard**. Flags code changes that may affect user experience or product behavior.

### Detected Changes

| Category | Severity | Change Description | File(s) |
|----------|----------|-------------------|---------|
| Visual Styling | Low | Helper text and error message typography in `pds-multiselect` switched from `--pine-typography-body-sm` to `--pine-typography-body-sm-medium`, rendering both messages at a heavier font weight for every consumer of the component. Since the token bundles font-size/line-height alongside weight, any difference in those values would also shift message height and could alter vertical spacing beneath the field. | `pds-multiselect.scss:327`, `pds-multiselect.scss:336` |

<details>
<summary>📋 Full file paths (click to expand and copy)</summary>

- `libs/core/src/components/pds-multiselect/pds-multiselect.scss:327`
- `libs/core/src/components/pds-multiselect/pds-multiselect.scss:336`

</details>

### Risk Assessment

Low risk — a purely presentational weight change intended to align `pds-multiselect` messages with sibling form fields, affecting all downstream consumers without opt-out. Verify that `--pine-typography-body-sm-medium` differs only in weight (not size or line-height) from `--pine-typography-body-sm`, and confirm the rendered result matches `pds-input` / `pds-select` helper and error text.

### Action Items

- [ ] @pixelflips — Confirm these UX/product changes are intentional
- [ ] @pixelflips — Verify with Product/Leadership before merging
