### PR TITLE
fix(pds-radio): show a not-allowed cursor on disabled card overlays

### DIFF
--- a/libs/core/src/components/pds-radio/pds-radio.scss
+++ b/libs/core/src/components/pds-radio/pds-radio.scss
@@ -68,6 +68,12 @@
     label {
       color: var(--pine-color-text-label-disabled);
       cursor: not-allowed;
+
+      // The overlay owns the hit test at z-index 1, and its own cursor
+      // declaration beats the value inherited from this rule.
+      &::after {
+        cursor: not-allowed;
+      }
     }
   }
 
@@ -297,6 +303,12 @@ label:has(input:disabled) {
     label {
       color: var(--pine-color-text-label-disabled);
       cursor: not-allowed;
+
+      // The overlay owns the hit test at z-index 1, and its own cursor
+      // declaration beats the value inherited from this rule.
+      &::after {
+        cursor: not-allowed;
+      }
     }
 
     .pds-radio__message {

--- a/libs/core/src/components/pds-radio/test/pds-radio.e2e.ts
+++ b/libs/core/src/components/pds-radio/test/pds-radio.e2e.ts
@@ -107,6 +107,48 @@ describe('pds-radio', () => {
     expect(eventSpy).toHaveReceivedEvent();
   });
 
+  it('shows a not-allowed cursor on the bordered card overlay when disabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pds-radio component-id="default" label="Label text" has-border />');
+
+    const overlayCursor = () =>
+      page.evaluate(() => {
+        const label = document.querySelector('pds-radio label');
+        return label ? getComputedStyle(label, '::after').cursor : '';
+      });
+
+    expect(await overlayCursor()).toBe('pointer');
+
+    const component = await page.find('pds-radio');
+    component.setProperty('disabled', true);
+    await page.waitForChanges();
+
+    expect(await overlayCursor()).toBe('not-allowed');
+  });
+
+  it('shows a not-allowed cursor on the image card overlay when disabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<pds-radio component-id="default" label="Label text"><span slot="image"></span></pds-radio>'
+    );
+
+    const component = await page.find('pds-radio');
+    expect(component).toHaveClass('has-image');
+
+    const overlayCursor = () =>
+      page.evaluate(() => {
+        const label = document.querySelector('pds-radio label');
+        return label ? getComputedStyle(label, '::after').cursor : '';
+      });
+
+    expect(await overlayCursor()).toBe('pointer');
+
+    component.setProperty('disabled', true);
+    await page.waitForChanges();
+
+    expect(await overlayCursor()).toBe('not-allowed');
+  });
+
   it('combines has-border with other state classes', async () => {
     const page = await newE2EPage();
     await page.setContent('<pds-radio component-id="default" label="Label text" has-border invalid disabled />');


### PR DESCRIPTION
# Description

A **disabled** `pds-radio` card showed `cursor: pointer` on hover, so it looked clickable while doing nothing on click.

The host, the label and the image container all correctly got `cursor: not-allowed`, but the full-bleed `label::after` overlay that makes the whole card clickable did not. `cursor` inherits, but an explicit declaration on the pseudo-element beats the inherited value from `label` — and because the overlay is absolutely positioned at `z-index: 1` across 100% × 100% of the card, it is what the pointer is actually over for essentially the entire card. So it won the hit test and its `pointer` stuck.

This adds `cursor: not-allowed` to the overlay in the disabled state.

## Both card variants were affected, not just `has-image`

The ticket reported this against `has-image` and described the non-image variant as behaving correctly because it "has no `::after` overlay." That turned out not to hold — **`:host(.has-border)` has its own identical overlay and the identical gap**:

| Variant | overlay `cursor: pointer` | disabled block covers `label` | disabled block covers `label::after` |
| -- | -- | -- | -- |
| `:host(.has-border)` | `pds-radio.scss:52` | yes | **no** |
| `:host(.has-image)` | `pds-radio.scss:240` | yes | **no** |

A plain `pds-radio` (neither variant) renders no overlay and was genuinely unaffected.

Both are fixed here. Fixing only `has-image` would have left the ticket's own stated expectation — "matching the non-image variant" — resting on a baseline that was itself broken.

Fixes DSS-239

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] e2e tests
- [x] unit tests (existing suite, no regressions)

Added two e2e regression tests in `pds-radio.e2e.ts`, one per variant. Each asserts the overlay's computed cursor via `getComputedStyle(label, '::after').cursor`, checking `pointer` while enabled and `not-allowed` after `disabled` is set — the enabled assertion is a positive control so the test cannot pass vacuously on a missed selector.

**Verified the tests actually detect the bug.** With the SCSS change stashed and only the tests applied, both fail with exactly the reported symptom:

```
● pds-radio › shows a not-allowed cursor on the bordered card overlay when disabled
  Expected: "not-allowed"
  Received: "pointer"

● pds-radio › shows a not-allowed cursor on the image card overlay when disabled
  Expected: "not-allowed"
  Received: "pointer"

Test Suites: 1 failed, 90 passed, 91 total
Tests:       2 failed, 2984 passed, 2986 total
```

With the fix restored, the full suite is green:

```
Test Suites: 91 passed, 91 total
Tests:       2986 passed, 2986 total
```

Also clean: `npx stylelint …/pds-radio.scss` and `npx eslint …/pds-radio.e2e.ts`.

**Heads up for reviewers:** e2e specs are not currently run by any CI job — `build.yml` runs `build-core`, `test-lint`, `test-specs` and `size-check` only. These tests pass locally via `nx run @pine-ds/core:test` (which runs `stencil test --spec --e2e`), but they will not gate this PR. Flagging so the green checks aren't read as having exercised them. A computed-style assertion is not expressible in a `newSpecPage` spec, since mock-doc does not apply stylesheets, so e2e was the only layer that could cover this.

**Test Configuration**:

- Pine versions: reported against `@pine-ds/core@3.29.0`; fixed on `main` at `fe4a93da`
- OS: macOS
- Browsers: Chromium via Puppeteer (Stencil e2e)
- Screen readers: n/a — `disabled` was already announced correctly via the inner `<input disabled>`; this was cosmetic only
- Misc: SCSS + e2e only. No generated files, no public API change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

---

### Unrelated drift noticed while working, deliberately not included

Running the test target rebuilds the library, which regenerates `libs/core/src/components.d.ts` and `libs/core/src/components/pds-avatar/readme.md`. On current `main` both come back **changed**, meaning main's committed generated artifacts are stale relative to their source — the avatar readme is missing the `initials` shadow part that #795 (current HEAD) added to the `.tsx`, and `components.d.ts` is missing regenerated `pds-tab` / `pds-tabs` JSDoc and avatar status attrs.

Reverted here to keep this PR to the two files it is about. Worth a separate housekeeping PR to re-sync them, and possibly a CI check that fails when generated output is dirty after a build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CSS and e2e coverage only; no behavior, API, or accessibility semantics change beyond cursor display on disabled card overlays.
> 
> **Overview**
> Disabled **bordered** and **image** card `pds-radio` variants still showed a **pointer** cursor because the full-bleed `label::after` click overlay keeps its own `cursor: pointer` and wins the hit test over inherited `not-allowed` on the label.
> 
> The fix sets **`cursor: not-allowed`** on that pseudo-element inside each variant’s disabled styling (`:has(input:disabled)` for bordered cards, `.is-disabled` for image cards), with a short comment explaining why inheritance isn’t enough.
> 
> Two **e2e** regressions assert `getComputedStyle(label, '::after').cursor` is `pointer` when enabled and `not-allowed` after `disabled` is set—one test per card variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99462f4901d454c7bed83f42ff3630281e54611d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->