### PR TITLE
fix(form): describe the error message when a field is invalid without a helper message

### DIFF
--- a/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
+++ b/libs/core/src/components/pds-checkbox/pds-checkbox.tsx
@@ -182,7 +182,7 @@ export class PdsCheckbox {
         <label htmlFor={this.componentId}>
           <input
             type="checkbox"
-            aria-describedby={assignDescription(this.componentId, this.invalid, this.errorMessage || this.helperMessage)}
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage, this.errorMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
             id={this.componentId}
             indeterminate={this.indeterminate}

--- a/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
+++ b/libs/core/src/components/pds-checkbox/test/pds-checkbox.spec.tsx
@@ -223,4 +223,17 @@ describe('pds-checkbox', () => {
 
     expect(eventSpy).not.toHaveBeenCalled();
   });
+  it('describes the helper message when invalid with no error message', async () => {
+    const page = await newSpecPage({
+      components: [PdsCheckbox],
+      html: `<pds-checkbox component-id="cb" invalid helper-message="Pick one"></pds-checkbox>`,
+    });
+
+    const shadow = page.root.shadowRoot;
+    const describedBy = shadow.querySelector('input').getAttribute('aria-describedby');
+
+    expect(describedBy).toBe('cb__helper-message');
+    expect(shadow.querySelector(`#${describedBy}`).textContent).toContain('Pick one');
+  });
+
 });

--- a/libs/core/src/components/pds-input/pds-input.tsx
+++ b/libs/core/src/components/pds-input/pds-input.tsx
@@ -561,7 +561,7 @@ export class PdsInput {
             <input
               ref={(input) => (this.nativeInput = input)}
               class="pds-input__field"
-              aria-describedby={assignDescription(componentId, invalid, helperMessage)}
+              aria-describedby={assignDescription(componentId, invalid, helperMessage, errorMessage)}
               aria-invalid={invalid ? "true" : undefined}
               autocomplete={this.autocomplete}
               disabled={disabled}

--- a/libs/core/src/components/pds-input/test/pds-input.spec.tsx
+++ b/libs/core/src/components/pds-input/test/pds-input.spec.tsx
@@ -1048,4 +1048,17 @@ describe('pds-input', () => {
       expect(wrapper?.classList.contains('is-disabled')).toBe(true);
     });
   });
+  it('describes the error message when invalid with no helper message', async () => {
+    const page = await newSpecPage({
+      components: [PdsInput],
+      html: `<pds-input component-id="field-1" invalid error-message="Required"></pds-input>`,
+    });
+
+    const shadow = page.root.shadowRoot;
+    const describedBy = shadow.querySelector('input').getAttribute('aria-describedby');
+
+    expect(describedBy).toBe('field-1__error-message');
+    expect(shadow.querySelector(`#${describedBy}`).textContent).toContain('Required');
+  });
+
 });

--- a/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
+++ b/libs/core/src/components/pds-multiselect/pds-multiselect.tsx
@@ -1526,7 +1526,8 @@ export class PdsMultiselect {
                   aria-describedby={assignDescription(
                     this.componentId,
                     this.invalid || !!this.errorMessage,
-                    this.errorMessage || this.helperMessage
+                    this.helperMessage,
+                    this.errorMessage
                   )}
                   aria-invalid={this.invalid || !!this.errorMessage ? 'true' : undefined}
                   onKeyDown={this.handleTriggerKeyDown}
@@ -1554,7 +1555,8 @@ export class PdsMultiselect {
                 aria-describedby={assignDescription(
                   this.componentId,
                   this.invalid || !!this.errorMessage,
-                  this.errorMessage || this.helperMessage
+                  this.helperMessage,
+                  this.errorMessage
                 )}
                 aria-invalid={this.invalid || !!this.errorMessage ? 'true' : undefined}
                 onClick={this.handleTriggerClick}

--- a/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
+++ b/libs/core/src/components/pds-multiselect/test/pds-multiselect.spec.tsx
@@ -2128,4 +2128,17 @@ describe('pds-multiselect', () => {
     });
   });
 
+  it('describes the error message when invalid with no helper message', async () => {
+    const page = await newSpecPage({
+      components: [PdsMultiselect],
+      html: `<pds-multiselect component-id="test" invalid error-message="Required"></pds-multiselect>`,
+    });
+
+    const shadow = page.root.shadowRoot;
+    const describedBy = shadow.querySelector('[aria-describedby]').getAttribute('aria-describedby');
+
+    expect(describedBy).toBe('test__error-message');
+    expect(shadow.querySelector(`#${describedBy}`).textContent).toContain('Required');
+  });
+
 });

--- a/libs/core/src/components/pds-radio/pds-radio.tsx
+++ b/libs/core/src/components/pds-radio/pds-radio.tsx
@@ -147,7 +147,7 @@ export class PdsRadio {
     const renderLabelAndMessages = () => [
       <label htmlFor={this.componentId} key={`${this.componentId}-label`}>
         <input
-          aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+          aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage, this.errorMessage)}
           aria-invalid={this.invalid ? "true" : undefined}
           type="radio"
           id={this.componentId}

--- a/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
+++ b/libs/core/src/components/pds-radio/test/pds-radio.spec.tsx
@@ -125,7 +125,7 @@ describe('pds-radio', () => {
     expect(page.root).toEqualHtml(`
       <pds-radio class="is-invalid" component-id="default" error-message="This is a short error message." invalid="true" label="Label text">
         <label for="default">
-          <input aria-invalid="true" id="default" type="radio">
+          <input aria-describedby="default__error-message" aria-invalid="true" id="default" type="radio">
           <span>Label text</span>
         </label>
         <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">

--- a/libs/core/src/components/pds-switch/pds-switch.tsx
+++ b/libs/core/src/components/pds-switch/pds-switch.tsx
@@ -157,7 +157,7 @@ export class PdsSwitch {
       <Host class={this.switchClassNames()} aria-disabled={this.disabled ? 'true' : null}>
         <label htmlFor={this.componentId}>
           <input
-            aria-describedby={assignDescription(this.componentId, this.invalid, this.errorMessage || this.helperMessage)}
+            aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage, this.errorMessage)}
             aria-invalid={this.invalid ? "true" : undefined}
             checked={this.checked}
             class="pds-switch__input"

--- a/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
+++ b/libs/core/src/components/pds-switch/test/pds-switch.spec.tsx
@@ -244,4 +244,17 @@ describe('pds-switch', () => {
     expect(eventSpy).not.toHaveBeenCalled();
   });
 
+  it('describes the helper message when invalid with no error message', async () => {
+    const page = await newSpecPage({
+      components: [PdsSwitch],
+      html: `<pds-switch component-id="sw" invalid helper-message="Pick one"></pds-switch>`,
+    });
+
+    const shadow = page.root.shadowRoot;
+    const describedBy = shadow.querySelector('input').getAttribute('aria-describedby');
+
+    expect(describedBy).toBe('sw__helper-message');
+    expect(shadow.querySelector(`#${describedBy}`).textContent).toContain('Pick one');
+  });
+
 });

--- a/libs/core/src/components/pds-textarea/pds-textarea.tsx
+++ b/libs/core/src/components/pds-textarea/pds-textarea.tsx
@@ -519,7 +519,7 @@ export class PdsTextarea {
           <div class="pds-textarea__field-wrapper">
             <textarea
               ref={(el) => this.nativeTextarea = el }
-              aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage)}
+              aria-describedby={assignDescription(this.componentId, this.invalid, this.helperMessage, this.errorMessage)}
               aria-invalid={this.invalid ? "true" : undefined}
               autocomplete={this.autocomplete}
               class={this.textareaClassNames()}

--- a/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
+++ b/libs/core/src/components/pds-textarea/test/pds-textarea.spec.tsx
@@ -52,7 +52,7 @@ describe('pds-textarea', () => {
         <mock:shadow-root>
           <div class="pds-textarea">
             <div class="pds-textarea__field-wrapper">
-              <textarea aria-invalid="true" class="pds-textarea__field is-invalid" id="pds-textarea-error" name="pds-textarea-error"></textarea>
+              <textarea aria-describedby="pds-textarea-error__error-message" aria-invalid="true" class="pds-textarea__field is-invalid" id="pds-textarea-error" name="pds-textarea-error"></textarea>
             </div>
             <p aria-live="assertive" class="pds-textarea__error-message" id="pds-textarea-error__error-message">
               <pds-icon icon="${danger}" size="small"></pds-icon>

--- a/libs/core/src/utils/form.ts
+++ b/libs/core/src/utils/form.ts
@@ -7,15 +7,23 @@ export const messageId = (id: string, messageType: string) => {
 
 /**
  * Assign aria-description id to relate messages with form element
+ *
+ * Returns the error message id when invalid, otherwise the helper message id.
+ * Pass only messages the component renders — a described id must exist in the DOM.
  */
-export const assignDescription = (id: string, invalid: boolean, helperMessage: string) => {
-  if (!helperMessage) return
+export const assignDescription = (
+  id: string,
+  invalid: boolean,
+  helperMessage?: string,
+  errorMessage?: string
+) => {
+  const hasErrorMessage = Boolean(errorMessage);
+  const hasHelperMessage = Boolean(helperMessage);
 
-  let relatedId = messageId(id, 'helper')
+  if (invalid && hasErrorMessage) return messageId(id, 'error');
+  if (hasHelperMessage) return messageId(id, 'helper');
 
-  if (invalid) relatedId = messageId(id, 'error');
-
-  return relatedId;
+  return undefined;
 };
 
 /**

--- a/libs/core/src/utils/test/form.spec.ts
+++ b/libs/core/src/utils/test/form.spec.ts
@@ -1,8 +1,36 @@
-import { isRequired, exposeTypeProperty } from '../form';
+import { assignDescription, isRequired, exposeTypeProperty } from '../form';
 
 interface ElementWithType extends Element {
   type: string;
 }
+
+describe('assignDescription', () => {
+  it('describes nothing when there are no messages', () => {
+    expect(assignDescription('field', false)).toBeUndefined();
+    expect(assignDescription('field', true)).toBeUndefined();
+  });
+
+  it('describes the helper message when valid', () => {
+    expect(assignDescription('field', false, 'Helper')).toBe('field__helper-message');
+    expect(assignDescription('field', false, 'Helper', 'Error')).toBe('field__helper-message');
+  });
+
+  it('does not describe an error message while valid', () => {
+    expect(assignDescription('field', false, undefined, 'Error')).toBeUndefined();
+  });
+
+  it('describes the error message when invalid, with no helper message present', () => {
+    expect(assignDescription('field', true, undefined, 'Error')).toBe('field__error-message');
+  });
+
+  it('prefers the error message over the helper message when invalid', () => {
+    expect(assignDescription('field', true, 'Helper', 'Error')).toBe('field__error-message');
+  });
+
+  it('falls back to the helper message when invalid with no error message', () => {
+    expect(assignDescription('field', true, 'Helper')).toBe('field__helper-message');
+  });
+});
 
 describe('isRequired', () => {
   it('returns empty string when no target or component defined', () => {


### PR DESCRIPTION
# Description

`assignDescription` in `libs/core/src/utils/form.ts` returned early whenever there was no helper message, so a field with an error and **no** `helper-message` got `aria-invalid="true"` and no `aria-describedby` at all — it announced "invalid" with no reason given. Adding an unrelated `helper-message` was the only way to turn the error association on, which is a surprising coupling.

```js
export const assignDescription = (id, invalid, helperMessage) => {
  if (!helperMessage) return;   // ← no helper, no description, even when invalid
  let relatedId = messageId(id, 'helper');
  if (invalid) relatedId = messageId(id, 'error');
  return relatedId;
};
```

This is groundwork for DSS-234 (`pds-select` error not announced) and DSS-235 (`pds-combobox` has no error/helper props), both of which need a correct `assignDescription` to build on. Splitting it out so the six-component behavior change gets reviewed on its own rather than riding along inside a single-component fix.

## A second, latent bug

Three components had already worked around the early return by passing `errorMessage || helperMessage` as the helper argument. That introduced a **dangling reference**: with `invalid` true, a helper message and no error message, the old code returned the *error* id — pointing `aria-describedby` at an element the component never rendered. `pds-switch` and `pds-checkbox` only render their error element when `errorMessage` is set, so the id resolved to nothing.

A dangling `aria-describedby` is worse than a missing one: the screen reader announces nothing and the author gets no signal the wiring is broken.

The call sites had drifted into three different shapes, which is the real tell that this logic belonged in the util rather than at each call site:

| Components | 3rd argument | `invalid` argument |
| -- | -- | -- |
| `pds-radio`, `pds-input`, `pds-textarea` | `helperMessage` | `invalid` |
| `pds-switch`, `pds-checkbox` | `errorMessage \|\| helperMessage` | `invalid` |
| `pds-multiselect` | `errorMessage \|\| helperMessage` | `invalid \|\| !!errorMessage` |

## The change

The two messages are now separate parameters, and the util owns the priority rule:

```ts
export const assignDescription = (
  id: string,
  invalid: boolean,
  helperMessage?: string,
  errorMessage?: string
) => {
  const hasErrorMessage = Boolean(errorMessage);
  const hasHelperMessage = Boolean(helperMessage);

  if (invalid && hasErrorMessage) return messageId(id, 'error');
  if (hasHelperMessage) return messageId(id, 'helper');

  return undefined;
};
```

All seven call sites across six components are updated. `pds-multiselect` keeps its own `invalid || !!errorMessage` first argument, so its behavior is unchanged.

Resulting behavior, with the two changed rows marked:

| `invalid` | helper | error | before | after |
| -- | -- | -- | -- | -- |
| false | — | — | none | none |
| false | set | — | helper | helper |
| false | — | set | none | none |
| false | set | set | helper | helper |
| true | — | — | none | none |
| true | set | — | **error (dangling)** | **helper** |
| true | — | set | **none** | **error** |
| true | set | set | error | error |

`assignDescription` is internal: it is not re-exported from `libs/core/src/index.ts`, and the package `exports` map only exposes `.`, `./components/*` and `./loader`, so no consumer can import it through a declared subpath. The signature only widened (`helperMessage` required → optional, plus a new optional parameter), so this is non-breaking either way. No props, events or generated files change.

Relates to DSS-234, DSS-235

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] accessibility tests (aria association assertions)

Added 6 unit tests covering the full matrix in `utils/test/form.spec.ts` — `assignDescription` had **no** coverage before this — plus 4 component tests. Each component test asserts both the id and that the id **resolves to a rendered element**, so a dangling reference fails the test rather than passing it.

Two existing snapshots also needed updating, and they are the clearest evidence the fix lands: `pds-radio` and `pds-textarea` had encoded the buggy output, and now show the association appearing next to the error element that was already being rendered.

```
- <input aria-invalid="true" id="default" type="radio">
+ <input aria-describedby="default__error-message" aria-invalid="true" id="default" type="radio">
  ...
  <div aria-live="assertive" class="pds-radio__message pds-radio__message--error" id="default__error-message">
```

**Verified the tests actually detect the bugs.** With all source reverted to `main` and only the tests applied, 7 tests across 6 suites fail:

| Test | Received without the fix | Bug class |
| -- | -- | -- |
| `pds-input` | `null` | missing association |
| util: invalid + error, no helper | `undefined` | missing association |
| `pds-radio` snapshot | no `aria-describedby` | missing association |
| `pds-textarea` snapshot | no `aria-describedby` | missing association |
| `pds-switch` | `sw__error-message` | dangling reference |
| `pds-checkbox` | `cb__error-message` | dangling reference |
| util: invalid + helper, no error | `field__error-message` | dangling reference |

`pds-multiselect`'s new test **passed** without the fix, which is the expected control — it already had the complete workaround at its call site.

With the fix applied, the full suite is green:

```
Test Suites: 91 passed, 91 total
Tests:       2994 passed, 2994 total
```

`form.ts` also goes from 1 eslint warning to **0** — the pre-existing `strict-boolean-conditions` warning was on the `if (!helperMessage)` line this change removes. No new warnings anywhere.

**Test Configuration**:

- Pine versions: `main` at `fe4a93da`
- OS: macOS
- Browsers: n/a (spec layer)
- Screen readers: not re-verified manually — the original report confirmed the symptom in VoiceOver/NVDA against `@pine-ds/core@3.29.0`; this PR verifies the DOM association that drives it
- Misc: no generated files, no public API change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

---

### Reviewer notes

**Deliberately not changed:** an error message present while `invalid` is false is still not described. Most of these components render their error element on `errorMessage` alone, so there is an argument for describing it regardless of `invalid` — but that is a wider behavior change than this fix, and `pds-multiselect` already opts into it via its own `invalid || !!errorMessage` argument. Worth deciding separately whether the other five should follow.

**Also noticed, not included:** on current `main` a build leaves `libs/core/src/components.d.ts` and `libs/core/src/components/pds-avatar/readme.md` dirty — main's committed generated artifacts are stale relative to source (the avatar readme is missing the `initials` shadow part that #795 added to the `.tsx`). Reverted here to keep this PR scoped. Same note as on #798; wants its own housekeeping PR.
<!-- ux-change-guard -->

---

## UX/Product Change Summary

> Auto-generated by **ux-change-guard**. Flags code changes that may affect user experience or product behavior.

### Detected Changes

| Category | Severity | Change Description | File(s) |
|----------|----------|-------------------|---------|
| Error Handling | Medium | Invalid fields that supply only an `error-message` (no helper message) now render `aria-describedby` pointing at the error text, where previously the attribute was omitted entirely — screen reader users hear the validation error on focus instead of only the field label. The rendered-output change is proven by the updated snapshot assertions for radio (`aria-describedby="default__error-message"`) and textarea (`aria-describedby="pds-textarea-error__error-message"`). | `pds-input.tsx:564`, `pds-textarea.tsx:522`, `pds-radio.tsx:150` |
| Error Handling | Medium | Invalid fields that supply only a `helper-message` now describe the rendered helper text instead of emitting an `aria-describedby` that referenced a non-existent error element, so assistive tech announces the guidance rather than silently resolving to nothing. New spec assertions confirm `cb__helper-message` / `sw__helper-message` resolve to elements containing "Pick one". | `pds-checkbox.tsx:185`, `pds-switch.tsx:160`, `pds-multiselect.tsx:1526` |

<details>
<summary>📋 Full file paths (click to expand and copy)</summary>

- `libs/core/src/components/pds-input/pds-input.tsx:564`
- `libs/core/src/components/pds-textarea/pds-textarea.tsx:522`
- `libs/core/src/components/pds-radio/pds-radio.tsx:150`
- `libs/core/src/components/pds-checkbox/pds-checkbox.tsx:185`
- `libs/core/src/components/pds-switch/pds-switch.tsx:160`
- `libs/core/src/components/pds-multiselect/pds-multiselect.tsx:1526`
- `libs/core/src/components/pds-multiselect/pds-multiselect.tsx:1555`
- `libs/core/src/utils/form.ts:15`

</details>

### Risk Assessment

Low-risk accessibility correction — the only user-perceptible change is which message screen readers announce for invalid form fields, and every affected component now points at an element that actually exists in the DOM. Verify with a screen reader that fields rendering *both* helper and error text still announce the error (not the helper) when invalid, and confirm no other callers of `assignDescription` outside this diff rely on the old three-positional-argument signature, since the third argument's meaning changed from "message to describe" to "helper message".

### Action Items

- [ ] @pixelflips — Confirm these UX/product changes are intentional
- [ ] @pixelflips — Verify with Product/Leadership before merging
