### PR TITLE
fix(pds-select): announce the error message to assistive technology

### DIFF
--- a/libs/core/src/components/pds-select/pds-select.tsx
+++ b/libs/core/src/components/pds-select/pds-select.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
-import { isSpecTest, messageId, exposeTypeProperty } from '../../utils/form';
+import { assignDescription, isSpecTest, messageId, exposeTypeProperty } from '../../utils/form';
 import { danger, enlarge } from '@pine-ds/icons/icons';
 
 /**
@@ -264,6 +264,12 @@ export class PdsSelect {
     );
   }
 
+  // The field also renders as invalid whenever an error message is present, via
+  // `select:has(~ .pds-select__message .pds-select__error-message)` in the styles.
+  private isInvalid(): boolean {
+    return Boolean(this.invalid) || Boolean(this.errorMessage);
+  }
+
   private classNames() {
     const classNames = [];
 
@@ -372,6 +378,8 @@ export class PdsSelect {
             </div>
           )}
           <select
+            aria-describedby={assignDescription(this.componentId, this.isInvalid(), this.helperMessage, this.errorMessage)}
+            aria-invalid={this.isInvalid() ? 'true' : undefined}
             aria-label={this.hideLabel ? this.label : undefined}
             autocomplete={this.autocomplete || undefined}
             class="pds-select__field"

--- a/libs/core/src/components/pds-select/test/pds-select.spec.tsx
+++ b/libs/core/src/components/pds-select/test/pds-select.spec.tsx
@@ -171,7 +171,7 @@ describe('pds-select', () => {
                 <span></span>
               </label>
             </div>
-            <select class="pds-select__field" id="field-1" part="select">
+            <select aria-invalid="true" class="pds-select__field" id="field-1" part="select">
               <slot></slot>
             </select>
             <div aria-hidden="true" class="hidden">
@@ -901,5 +901,65 @@ describe('highlight', () => {
 
     // Disabled state should apply (CSS selector excludes disabled)
     expect(root?.classList.contains('is-disabled')).toBe(true);
+  });
+});
+
+describe('aria associations', () => {
+  const renderSelect = async (attrs: string) => {
+    const page = await newSpecPage({
+      components: [PdsSelect],
+      html: `<pds-select component-id="field-1" ${attrs}></pds-select>`,
+    });
+
+    const shadow = page.root.shadowRoot;
+    const select = shadow.querySelector('select');
+
+    return {
+      describedBy: select.getAttribute('aria-describedby'),
+      invalid: select.getAttribute('aria-invalid'),
+      describedText: (id: string) => shadow.querySelector(`#${id}`)?.textContent,
+    };
+  };
+
+  it('describes the error message when invalid', async () => {
+    const { describedBy, invalid, describedText } = await renderSelect(
+      'invalid="true" error-message="Please select a country"'
+    );
+
+    expect(describedBy).toBe('field-1__error-message');
+    expect(invalid).toBe('true');
+    expect(describedText(describedBy)).toContain('Please select a country');
+  });
+
+  it('describes the error message when only error-message is set', async () => {
+    const { describedBy, invalid, describedText } = await renderSelect(
+      'error-message="Please select a country"'
+    );
+
+    expect(describedBy).toBe('field-1__error-message');
+    expect(invalid).toBe('true');
+    expect(describedText(describedBy)).toContain('Please select a country');
+  });
+
+  it('prefers the error message over the helper message', async () => {
+    const { describedBy } = await renderSelect(
+      'invalid="true" helper-message="Pick one" error-message="Required"'
+    );
+
+    expect(describedBy).toBe('field-1__error-message');
+  });
+
+  it('describes the helper message when valid', async () => {
+    const { describedBy, invalid, describedText } = await renderSelect('helper-message="Pick one"');
+
+    expect(describedBy).toBe('field-1__helper-message');
+    expect(invalid).toBeNull();
+    expect(describedText(describedBy)).toContain('Pick one');
+  });
+
+  it('describes nothing when there are no messages', async () => {
+    const { describedBy } = await renderSelect('label="Country"');
+
+    expect(describedBy).toBeNull();
   });
 });


### PR DESCRIPTION
# Description

> **Stacked on #799.** Base branch is `fix/form-error-description`, so this diff shows only the `pds-select` changes. Merge #799 first; this will retarget to `main` automatically.

`pds-select` rendered `error-message` into its shadow root but wired **no ARIA association at all** — no `aria-describedby`, no `aria-invalid`. A sighted user saw the red invalid state and the message; a screen reader user got neither the message nor any indication the field was invalid.

The inner `<select>` received `aria-label`, `autocomplete`, `disabled`, `id`, `multiple`, `name`, `part` and `required` — and nothing describing the error. The message elements already carried the right ids (`messageId(componentId, 'error' | 'helper')`); only the association was missing.

Fixes DSS-234

## `aria-invalid` follows the error message, not just the `invalid` prop

`pds-select` has **two independent** triggers for its danger treatment:

```scss
// pds-select.scss:92 — inside the field rule
&:has(~ .pds-select__message .pds-select__error-message) {
  background-color: var(--pine-select-color-background-danger);
  border-color: var(--pine-color-border-danger);
}

// pds-select.scss:112
:host(.is-invalid) select { /* same danger treatment */ }
```

The first fires on the mere presence of the error element, so **a consumer who sets only `error-message` already gets a red field with no `invalid` prop**. If `aria-invalid` keyed off `invalid` alone, a sighted user would see an invalid field while a screen reader announced a valid one.

So the condition is `invalid || !!errorMessage`, extracted to a small private method since it feeds both attributes:

```ts
// The field also renders as invalid whenever an error message is present, via
// `select:has(~ .pds-select__message .pds-select__error-message)` in the styles.
private isInvalid(): boolean {
  return Boolean(this.invalid) || Boolean(this.errorMessage);
}
```

This is also exactly the expression `pds-multiselect` already uses, so the fix is consistent with the sibling the ticket points at rather than inventing a third convention.

The `is-invalid` **class** is deliberately left keyed to the `invalid` prop only — changing that would alter which of the two style paths applies and is a visual change this PR has no reason to make.

Resulting behavior on the inner `<select>`:

| `invalid` | helper | error | `aria-invalid` | `aria-describedby` |
| -- | -- | -- | -- | -- |
| — | — | — | absent | absent |
| — | set | — | absent | helper id |
| — | — | set | `"true"` | error id |
| true | — | set | `"true"` | error id |
| true | set | set | `"true"` | error id |
| true | — | — | `"true"` | absent |

The last row is intentional: `aria-invalid` is accurate, and there is no message element to point at, so no `aria-describedby` is emitted rather than a dangling reference.

No props, events, methods or generated files change — `pds-select/readme.md` and `components.d.ts` are both untouched, confirmed by rebuilding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] unit tests
- [x] accessibility tests (aria association assertions)

Added an `aria associations` describe block with 5 tests. Each asserts the attribute value **and** that `aria-describedby` resolves to a rendered element containing the expected text, so a dangling reference fails rather than passes.

**Verified the tests actually detect the bug.** With `pds-select.tsx` reverted and only the tests applied, 5 tests fail — every one receiving `null`, which is precisely the symptom the ticket reported from the browser (`aria-describedby: null`, `aria-invalid: null`):

```
● aria associations › describes the error message when invalid
    Expected: "field-1__error-message"    Received: null
● aria associations › describes the error message when only error-message is set
    Expected: "field-1__error-message"    Received: null
● aria associations › prefers the error message over the helper message
    Expected: "field-1__error-message"    Received: null
● aria associations › describes the helper message when valid
    Expected: "field-1__helper-message"   Received: null
● pds-select › renders with invalid class when prop set

Tests: 5 failed, 2994 passed, 2999 total
```

`describes nothing when there are no messages` correctly passes either way — the intended control.

One existing snapshot needed updating: `renders with invalid class when prop set` now shows `aria-invalid="true"` on the `<select>`, with no `aria-describedby` since that case sets no messages.

With the fix applied:

```
Test Suites: 91 passed, 91 total
Tests:       2999 passed, 2999 total
```

`pds-select.tsx` eslint warning count is unchanged from `main` (5, all pre-existing `strict-boolean-conditions`); the `Boolean()` coercion in `isInvalid()` avoids adding any.

**Test Configuration**:

- Pine versions: reported against `@pine-ds/core@3.29.0`; fixed on top of #799
- OS: macOS
- Browsers: n/a (spec layer)
- Screen readers: not re-verified manually — the original report confirmed the symptom in VoiceOver/NVDA and via `shadowRoot.querySelector('select')` in a real form; this PR verifies the DOM association that drives it
- Misc: no generated files, no public API change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Design has QA'ed and approved this PR

---

### Reviewer notes

**Host ARIA still isn't inherited.** The ticket also noted that `pds-select` is `shadow: true` and never calls `inheritAriaAttributes`, so a consumer putting `aria-describedby` on the host element gets nothing. That is now much less pressing — the component wires its own messages correctly — but it still means a consumer cannot add their *own* extra description. Adding attribute inheritance changes how the component handles host attributes generally and would affect more than the error case, so it is left out here. Worth its own ticket if the team wants it.

**Error present but `invalid` false** is now announced as invalid on `pds-select`, matching its own styling and `pds-multiselect`. The other five form components still describe an error only when `invalid` is explicitly set — the divergence I flagged on #799. Resolving that consistently across all of them is still worth a separate decision.
<!-- ux-change-guard -->

---

## UX/Product Change Summary

> Auto-generated by **ux-change-guard**. Flags code changes that may affect user experience or product behavior.

### Detected Changes

| Category | Severity | Change Description | File(s) |
|----------|----------|-------------------|---------|
| Error Handling | Medium | The native `<select>` now carries `aria-describedby` pointing at the rendered error message (or the helper message when valid), so screen reader users hear the validation error announced when the field receives focus instead of getting no explanation for the failure. Error message takes precedence over helper message, meaning helper text is no longer announced once a field is in an error state. | `pds-select.tsx:381` |
| UI State Changes | Medium | `aria-invalid="true"` is now emitted whenever `errorMessage` is set, even if the `invalid` prop was never passed, so consumers that supply only an error message will see the field reported as invalid to assistive technology where it previously was not. This aligns the accessibility state with the existing visual error styling but changes the announced state for existing usages. | `pds-select.tsx:382`, `pds-select.tsx:268` |

<details>
<summary>📋 Full file paths (click to expand and copy)</summary>

- `libs/core/src/components/pds-select/pds-select.tsx:381`
- `libs/core/src/components/pds-select/pds-select.tsx:382`
- `libs/core/src/components/pds-select/pds-select.tsx:268`

</details>

### Risk Assessment

Low overall risk — the change adds accessibility semantics that match the already-rendered visual error state, with no change to visual output or component API. Verify that consumers rendering their own external error text alongside `errorMessage` do not now get a duplicate or conflicting announcement, and that snapshot tests in downstream apps consuming `pds-select` are updated for the new `aria-invalid` attribute.

### Action Items

- [ ] @pixelflips — Confirm these UX/product changes are intentional
- [ ] @pixelflips — Verify with Product/Leadership before merging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only DOM attributes on the inner select; no API or visual styling changes, though apps with strict HTML snapshots may need updates for the new `aria-invalid` attribute.
> 
> **Overview**
> **`pds-select`** now associates its inner `<select>` with helper and error text for assistive technology, matching the pattern used by other form controls (via shared `assignDescription`).
> 
> The native select gets **`aria-describedby`** pointing at the rendered helper or error message id (errors win when both exist), and **`aria-invalid="true"`** when the field should be treated as invalid. Invalid state is **`invalid` OR `error-message`**, via a new `isInvalid()` helper, so screen readers align with the existing visual error styling when only `error-message` is set—not only when `invalid` is passed. The host **`is-invalid`** class is unchanged and still follows the `invalid` prop alone.
> 
> Unit coverage adds an **`aria associations`** block and updates the invalid-prop snapshot to expect `aria-invalid` on the select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd0161d310cee0183df029ec47495f26fddde75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->